### PR TITLE
onnx export with minidb; update dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,39 @@
 ```bash
 pushd ~
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    chmod +x miniconda.sh
-    ./miniconda.sh -b -p ~/miniconda
-    rm miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b -p ~/miniconda
+rm miniconda.sh
 popd
 ```
 
-### Install PyTorch
+### Install PyTorch and Caffe2
 ```bash
-. ~/miniconda/bin/activate
-conda uninstall -y pytorch pytorch-nightly
-conda install -y pytorch-nightly -c pytorch
+
+# Install basic PyTorch dependencies
+conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
+
+# Add LAPACK support for the GPU
+conda install -c pytorch magma-cuda80 # or magma-cuda90 if CUDA 9
+
+pushd ~
+git clone --recursive https://github.com/pytorch/pytorch
+cd pytorch
+
+# PyTorch build from source
+python setup.py install
+
+# Caffe2 build from source (with ATen)
+CMAKE_ARGS=-DUSE_ATEN=ON python setup_caffe2.py install
+popd
+```
+
+### Install ONNX
+```bash
+pushd ~
+git clone --recursive https://github.com/onnx/onnx.git
+pip install ./onnx
+popd
 ```
 
 ### Install FBTranslate

--- a/fbtranslate/ensemble_export.py
+++ b/fbtranslate/ensemble_export.py
@@ -183,7 +183,7 @@ def save_caffe2_rep_to_db(
             num_workers=num_workers,
         )
         predictor_exporter.save_to_db(
-            db_type='log_file_db',
+            db_type='minidb',
             db_destination=output_path,
             predictor_export_meta=predictor_export_meta,
         )

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,27 @@ rm miniconda.sh
 popd
 
 . ~/miniconda/bin/activate
-conda uninstall -y pytorch pytorch-nightly
-conda install -y pytorch-nightly -c pytorch
 
-. ~/miniconda/bin/activate
+export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" # [anaconda root directory]
+
+# Install basic PyTorch dependencies
+conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
+
+# Add LAPACK support for the GPU
+conda install -c pytorch magma-cuda80 # or magma-cuda90 if CUDA 9
+
+git clone --recursive https://github.com/pytorch/pytorch
+cd pytorch
+
+# PyTorch build from source
+python setup.py install
+
+# Caffe2 build from source (with ATen)
+CMAKE_ARGS=-DUSE_ATEN=ON python setup_caffe2.py install
+
+# Install ONNX
+git clone https://github.com/onnx/onnx.git
+pip install onnx
+
 yes | pip uninstall fbtranslate
 python3 setup.py build develop


### PR DESCRIPTION
Changing the storage format for exported Caffe2 networks to minidb, for compatibility with decoder code being developed concurrently by @theweiho. Based on local testing, changing the method of installing dependencies PyTorch, Caffe2, and ONNX.