### PR TITLE
Remove unused save_dir param from load_raw_text_dataset

### DIFF
--- a/fbtranslate/data.py
+++ b/fbtranslate/data.py
@@ -57,7 +57,6 @@ def load_raw_text_dataset(
     eval_corpus: ParallelCorpusConfig,
     train_split: str,
     eval_split: str,
-    save_dir: str,
     args: argparse.Namespace,
     penalized_target_tokens_file=None,
 ) -> data.LanguageDatasets:

--- a/fbtranslate/train.py
+++ b/fbtranslate/train.py
@@ -307,7 +307,6 @@ def setup_training(args):
         eval_corpus=eval_corpus,
         train_split=args.train_subset,
         eval_split=args.valid_subset,
-        save_dir=args.save_dir,
         args=args,
         penalized_target_tokens_file=args.penalized_target_tokens_file,
     )


### PR DESCRIPTION
We used to use save_dir to infer file paths for vocab files, which was how fairseq used save_dir. We don't support that anymore because we chose to require vocab files to be explicitly specified with the full path name.