### PR TITLE
ScriptModule Beam Search

### DIFF
--- a/fbtranslate/onnx_full_export.py
+++ b/fbtranslate/onnx_full_export.py
@@ -72,7 +72,7 @@ def main():
         unk_penalty=args.unk_penalty,
     )
 
-    src_dict = encoder_ensemble.models[0].src_dict
+    src_dict = beam_search.models[0].src_dict
     token_list = [src_dict.unk()] * 4 + [src_dict.eos()]
     src_tokens = torch.LongTensor(
         np.array(token_list, dtype='int64').reshape(-1, 1),
@@ -81,8 +81,8 @@ def main():
         np.array([len(token_list)], dtype='int32'),
     )
 
-    decoder_step_ensemble.save_to_db(
-        args.decoder_output_file,
+    beam_search.save_to_db(
+        args.output_file,
     )
 
 


### PR DESCRIPTION
This PR contains the implementation for beam search in the jitscript syntax. The unit test is confirmed working on Pytorch master as of tonight.

I've also added `onnx_full_export.py`, which should export a model with the beam search from checkpoints, but I haven't been able to test this since we need to update Pytorch+Caffe2 in fbcode so I can hit the absolute paths in the checkpoint files.

Note also that this PR mirrors D7594637 from fbcode into OSS.