### PR TITLE
Add pytorch/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 
 # Dot files
 .python3
+
+# Produced by install script
+pytorch/


### PR DESCRIPTION
It gets cloned when running the `install.sh` script.