### PR TITLE
use correct cmake var CMAKE_INSTALL_PREFIX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,6 @@ python3 setup.py build develop
 pushd pytorch_translate/cpp
 # If you need to specify a compiler other than the default one cmake is picking
 # up, you can use the -DCMAKE_C_COMPILER and -DCMAKE_CXX_COMPILER flags.
-cmake -DCMAKE_PREFIX_PATH="${CONDA_PATH}/usr/local" -DCMAKE_INSTALL_PATH="${CONDA_PATH}" .
+cmake -DCMAKE_PREFIX_PATH="${CONDA_PATH}/usr/local" -DCMAKE_INSTALL_PREFIX="${CONDA_PATH}" .
 make
 popd


### PR DESCRIPTION
Tested locally. This is not breaking anything now because we're not relying elsewhere on library components that are built here, but it's better for it to be correct (CMAKE_INSTALL_PATH is not a real cmake variable and is ignored).