### PR TITLE
Update README to use PyTorch+Caffe2 conda package

### DIFF
--- a/pytorch_translate/examples/export_iwslt14.sh
+++ b/pytorch_translate/examples/export_iwslt14.sh
@@ -10,12 +10,12 @@ tar -xvzf data.tar.gz
 rm -f data.tar.gz model.tar.gz
 python3 pytorch_translate/onnx_component_export.py \
     --checkpoint model/averaged_checkpoint_best_0.pt \
-    --encoder_output_file encoder.pb \
-    --decoder_output_file decoder.pb \
-    --src_dict model/dictionary-de.txt \
-    --dst_dict model/dictionary-en.txt \
-    --beam_size 6 \
-    --word_penalty 0.25 \
-    --unk_penalty -0.5 \
-    --batched_beam && \
+    --encoder-output-file encoder.pb \
+    --decoder-output-file decoder.pb \
+    --source-vocab-file model/dictionary-de.txt \
+    --target-vocab-file model/dictionary-en.txt \
+    --beam-size 6 \
+    --word-penalty 0.25 \
+    --unk-penalty -0.5 \
+    --batched-beam && \
   echo "Finished exporting encoder as ./encoder.pb and decoder as ./decoder.pb"

--- a/pytorch_translate/examples/train_iwslt14.sh
+++ b/pytorch_translate/examples/train_iwslt14.sh
@@ -58,6 +58,6 @@ CUDA_VISIBLE_DEVICES=0 python3 pytorch_translate/train.py \
    --eval-target-text-file data/valid.tok.bpe.en \
    --source-max-vocab-size 14000 \
    --target-max-vocab-size 14000 \
-   --log-interval 5000 \
+   --log-interval 10 \
    --seed "${RANDOM}" \
    2>&1 | tee -a checkpoints/log

--- a/pytorch_translate/onnx_component_export.py
+++ b/pytorch_translate/onnx_component_export.py
@@ -17,7 +17,7 @@ def get_parser_with_args():
         description=("Export PyTorch-trained FBTranslate models to Caffe2 components")
     )
     parser.add_argument(
-        "--checkpoint",
+        "--path", "--checkpoint",
         action="append",
         nargs="+",
         help="PyTorch checkpoint file (at least one required)",


### PR DESCRIPTION
Summary:
Simplify installation instructions by using the combined PyTorch+Caffe2 conda package (can probably replace https://github.com/pytorch/translate/pull/43)

Also fix some examples after internal sync

Differential Revision: D7939466

fbshipit-source-id: f3f1012e652787929b30cdbf74d513e741971f8d