### PR TITLE
Lexicon indices handling in vocab reduction

### DIFF
--- a/pytorch_translate/vocab_reduction.py
+++ b/pytorch_translate/vocab_reduction.py
@@ -154,6 +154,12 @@ def get_translation_candidates(
                 prob = float(prob)
                 source_index = src_dict.index(source_word)
                 target_index = dst_dict.index(target_word)
+                if (
+                    source_index not in src_dict.lexicon_indices and
+                    target_index in dst_dict.lexicon_indices
+                ):
+                    continue
+
                 if source_index is not None and target_index is not None:
                     if source_index != current_source_index:
                         # We've finished processing the possible translation


### PR DESCRIPTION
Summary: Makes use of dictionary.py lexicon_indices. If you don't want to trigger this behavior, don't pass in tokens_with_penalty during dictionary init

Reviewed By: jhcross

Differential Revision: D7979990

fbshipit-source-id: e6affec544228813622f21f054bb7abeb96ba4b2