### PR TITLE
Apply target lexicon in vocab reduction when finding top words

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -1035,6 +1035,7 @@ def main(args):
         dialect=args.target_lang,
         save_dir=args.save_dir,
         max_vocab_size=args.target_max_vocab_size,
+        tokens_with_penalty=args.penalized_target_tokens_file,
     )
 
     # Set distributed training parameters for a single node.


### PR DESCRIPTION
Summary:
Add --target-lexicon flag
Revert https://github.com/pytorch/translate/pull/56
Top words are built regardless of alignment, and the point of the target lexicon was actually to apply it to this.

Reviewed By: dpacgopinath

Differential Revision: D7998734

fbshipit-source-id: 17373bc145f06157c9d51f2d8e1383c65eca59b8