### PR TITLE
beam search without repeated encoder computation

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -144,11 +144,9 @@ class SequenceGenerator(torch.nn.Module):
             else:
                 incremental_states[model] = None
 
-            # compute the encoder output for each beam
-            encoder_out = model.encoder(
-                src_tokens.repeat(1, beam_size).view(-1, srclen),
-                src_lengths.repeat(beam_size),
-            )
+            # expand outputs for each example beam_size times
+            encoder_out = model.encoder(src_tokens, src_lengths)
+            encoder_out = model.encoder.expand_encoder_output(encoder_out, beam_size)
             encoder_outs.append(encoder_out)
 
         # initialize buffers


### PR DESCRIPTION
Summary: PyTorch beam search (in beam_decode.py) currently replicates the same computation beam_size times, contributing to global warming. Instead let's just do the computation once and resuse the results. (The difference is quite small for current default configuration, but becomes more important as encoder becomes a less negligible portion of computation.)

Differential Revision: D8078775

fbshipit-source-id: dc3f4506b71ce246161ad65aac803c129461f859