### PR TITLE
@staticmethod expand_encoder_output()

### DIFF
--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -243,7 +243,8 @@ class RNNModel(FairseqModel):
             )
         return targets
 
-    def expand_encoder_output(self, encoder_out, n):
+    @staticmethod
+    def expand_encoder_output(encoder_out, n):
         """
         Expand all outputs to replicate each instance from batch in place n
         times (as for beam search)


### PR DESCRIPTION
Summary: Make expand_encoder_output() a static method so that it requires less copypasta to reuse for other (non-subclass) models.

Differential Revision: D8107582

fbshipit-source-id: be962637366e8c430783e1d6f5516a629333e3a2