### PR TITLE
Make ManagedCheckpoints work in generate.py

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -25,6 +25,7 @@ from pytorch_translate import dictionary as pytorch_translate_dictionary
 from pytorch_translate import generate
 from pytorch_translate import preprocess
 from pytorch_translate import rnn  # noqa
+from pytorch_translate import utils
 from pytorch_translate.research.word_prediction import word_prediction_criterion  # noqa
 from pytorch_translate.research.word_prediction import word_prediction_model  # noqa
 
@@ -373,7 +374,10 @@ def train(args, extra_state, trainer, dataset):
             extra_state["batch_offset"] = i + 1
 
             (
-                _, val_ppl, val_bleu, stop_training_mid_epoch
+                _,
+                val_ppl,
+                val_bleu,
+                stop_training_mid_epoch,
             ) = validate_save_and_evaluate_bleu(
                 args=args,
                 trainer=trainer,
@@ -406,7 +410,10 @@ def train(args, extra_state, trainer, dataset):
         # batch_offset being None denotes the end of an epoch.
         extra_state["batch_offset"] = None
         (
-            val_loss, val_ppl, val_bleu, stop_training_end_of_epoch
+            val_loss,
+            val_ppl,
+            val_bleu,
+            stop_training_end_of_epoch,
         ) = validate_save_and_evaluate_bleu(
             args=args,
             trainer=trainer,
@@ -576,69 +583,6 @@ def save_checkpoint_maybe_continuous(filename, trainer, extra_state):
     extra_state.pop("param_totals")
 
 
-# The purpose of this class is to keep track of the list of checkpoints
-# currently alive and automatically delete those that are no more required
-# and that we do not want to keep around.
-# In a nutshell, this class remembers the last max_num_checkpoints
-# and delete (auto_clear == True) the oldest checkpoint each time a new one
-# is added past this number.
-class ManagedCheckpoints:
-
-    # - max_num_checkpoints: Maximum number of checkpoints we need at one point.
-    # - auto_clear: Control whether or not checkpoints should get deleted when
-    #   they are not in the last max_num_checkpoints appended to the
-    #   self anymore.
-    def __init__(self, max_num_checkpoints, auto_clear):
-        self.auto_clear = auto_clear
-        assert max_num_checkpoints > 0, "Empty listing is not supported"
-        self.kept_checkpoints = collections.deque(maxlen=max_num_checkpoints)
-
-    def append(self, checkpoint_filename):
-        # If we append a filename that we already manage, we would need
-        # to remove it from its current position otherwise it may get deleted
-        # by the time we reach the use for this append.
-        # E.g., Let us assume we have a max of 2 checkpoint.
-        # We insert last_checkpoint, use it, then insert last_checkpoint,
-        # use it, then insert it again. The first file gets delete, but it
-        # is actually the same as the current one, so we actually delete
-        # the current one. Then we try to use it and we will get an error
-        # for file not found.
-        # Although this is pretty easy to support this case, given we only
-        # append the same file names with no_epoch_checkpoints, we decided
-        # not to slow every other uses case for that.
-        # Instead we rely on the fact that when this happens, we actually
-        # don't automatically delete files (auto_clear == False).
-        assert (
-            not self.auto_clear or not self.kept_checkpoints.count(checkpoint_filename)
-        ), "Not yet implemented"
-        if (
-            self.auto_clear
-            and len(self.kept_checkpoints) == self.kept_checkpoints.maxlen
-        ):
-            # We reach the max number of checkpoints we keep around.
-            # Delete the oldest one.
-            os.remove(self.kept_checkpoints.popleft())
-        # Save the new checkpoint.
-        self.kept_checkpoints.append(checkpoint_filename)
-
-    def get_last_n(self, num_elements):
-        assert 0 < num_elements <= self.kept_checkpoints.maxlen, (
-            f"Requested number of elements {num_elements} "
-            f"must be between 0 and maxlen {self.kept_checkpoints.maxlen}, "
-            f"exclusive"
-        )
-        # If we ask for more elements than what we currently have, return all
-        # of them.
-        # Reason why we don't assert unlike for maxlen is because maxlen points
-        # out a design issue (the reserved size is too small), whereas the case
-        # where we ask more elements than what is currently in the list happens
-        # when we print the average of X checkpoints for BLEU, but we haven't
-        # yet computed that many checkpoints. We could also assert in this case
-        # and fix the caller, but handling it here was just fine!
-        start = max(len(self.kept_checkpoints) - num_elements, 0)
-        return collections.deque(itertools.islice(self.kept_checkpoints, start, None))
-
-
 def save_checkpoint(trainer, args, extra_state):
     epoch = extra_state["epoch"]
     batch_offset = extra_state["batch_offset"]
@@ -648,7 +592,7 @@ def save_checkpoint(trainer, args, extra_state):
         print(
             f"Preparing to save checkpoints for epoch {epoch}, "
             f"offset {batch_offset}. ",
-            flush=True
+            flush=True,
         )
 
     if "last_checkpoints" not in extra_state:
@@ -656,7 +600,7 @@ def save_checkpoint(trainer, args, extra_state):
             raise argparse.ArgumentTypeError(
                 "--generate-bleu-eval-avg-checkpoints must be >= 1."
             )
-        extra_state["last_checkpoints"] = ManagedCheckpoints(
+        extra_state["last_checkpoints"] = utils.ManagedCheckpoints(
             max(args.generate_bleu_eval_avg_checkpoints, args.max_checkpoints_kept),
             # Don't auto_clear checkpoints for no_epoch_checkpoints, because
             # we are only going to reuse the same file.
@@ -797,7 +741,7 @@ def _save_averaged_checkpoint(args, extra_state):
     if not hasattr(_save_averaged_checkpoint, "last_avg_checkpoints"):
         if args.max_checkpoints_kept == 0:
             raise argparse.ArgumentTypeError("--max-checkpoints-kept must be != 0.")
-        _save_averaged_checkpoint.last_avg_checkpoints = ManagedCheckpoints(
+        _save_averaged_checkpoint.last_avg_checkpoints = utils.ManagedCheckpoints(
             max(args.max_checkpoints_kept, 1), auto_clear=args.max_checkpoints_kept > 0
         )
 
@@ -862,7 +806,9 @@ def evaluate_bleu(args, dataset, extra_state):
         or val_bleu > extra_state["evaluate_bleu"]["best"]
     ):
         extra_state["evaluate_bleu"] = {
-            "best": val_bleu, "best_epoch": epoch, "num_since_best": 0
+            "best": val_bleu,
+            "best_epoch": epoch,
+            "num_since_best": 0,
         }
         best_filename = os.path.join(args.save_dir, "averaged_checkpoint_best.pt")
         shutil.copy2(filename, best_filename)
@@ -973,7 +919,7 @@ def main(args):
 
     # Set distributed training parameters for a single node.
     args.distributed_world_size = torch.cuda.device_count()
-    args.distributed_init_method = (f"tcp://localhost:{random.randint(10000, 20000)}")
+    args.distributed_init_method = f"tcp://localhost:{random.randint(10000, 20000)}"
 
     if args.distributed_world_size == 1:
         return single_process_main(args)

--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
+import collections
+import itertools
+import os
 
 
 # Helper type for argparse to enable flippable boolean flags. For example,
@@ -18,3 +21,66 @@ def bool_flag(value):
         raise argparse.ArgumentTypeError(
             f"Expected boolean string such as 'true'/'false' instead of {value}."
         )
+
+
+# The purpose of this class is to keep track of the list of checkpoints
+# currently alive and automatically delete those that are no more required
+# and that we do not want to keep around.
+# In a nutshell, this class remembers the last max_num_checkpoints
+# and delete (auto_clear == True) the oldest checkpoint each time a new one
+# is added past this number.
+class ManagedCheckpoints:
+
+    # - max_num_checkpoints: Maximum number of checkpoints we need at one point.
+    # - auto_clear: Control whether or not checkpoints should get deleted when
+    #   they are not in the last max_num_checkpoints appended to the
+    #   self anymore.
+    def __init__(self, max_num_checkpoints, auto_clear):
+        self.auto_clear = auto_clear
+        assert max_num_checkpoints > 0, "Empty listing is not supported"
+        self.kept_checkpoints = collections.deque(maxlen=max_num_checkpoints)
+
+    def append(self, checkpoint_filename):
+        # If we append a filename that we already manage, we would need
+        # to remove it from its current position otherwise it may get deleted
+        # by the time we reach the use for this append.
+        # E.g., Let us assume we have a max of 2 checkpoint.
+        # We insert last_checkpoint, use it, then insert last_checkpoint,
+        # use it, then insert it again. The first file gets delete, but it
+        # is actually the same as the current one, so we actually delete
+        # the current one. Then we try to use it and we will get an error
+        # for file not found.
+        # Although this is pretty easy to support this case, given we only
+        # append the same file names with no_epoch_checkpoints, we decided
+        # not to slow every other uses case for that.
+        # Instead we rely on the fact that when this happens, we actually
+        # don't automatically delete files (auto_clear == False).
+        assert not self.auto_clear or not self.kept_checkpoints.count(
+            checkpoint_filename
+        ), "Not yet implemented"
+        if (
+            self.auto_clear
+            and len(self.kept_checkpoints) == self.kept_checkpoints.maxlen
+        ):
+            # We reach the max number of checkpoints we keep around.
+            # Delete the oldest one.
+            os.remove(self.kept_checkpoints.popleft())
+        # Save the new checkpoint.
+        self.kept_checkpoints.append(checkpoint_filename)
+
+    def get_last_n(self, num_elements):
+        assert 0 < num_elements <= self.kept_checkpoints.maxlen, (
+            f"Requested number of elements {num_elements} "
+            f"must be between 0 and maxlen {self.kept_checkpoints.maxlen}, "
+            f"exclusive"
+        )
+        # If we ask for more elements than what we currently have, return all
+        # of them.
+        # Reason why we don't assert unlike for maxlen is because maxlen points
+        # out a design issue (the reserved size is too small), whereas the case
+        # where we ask more elements than what is currently in the list happens
+        # when we print the average of X checkpoints for BLEU, but we haven't
+        # yet computed that many checkpoints. We could also assert in this case
+        # and fix the caller, but handling it here was just fine!
+        start = max(len(self.kept_checkpoints) - num_elements, 0)
+        return collections.deque(itertools.islice(self.kept_checkpoints, start, None))


### PR DESCRIPTION
Summary: Refactor out ManagedCheckpoints to allow us to pickle it correctly for generate.py to use

Reviewed By: fstahlberg

Differential Revision: D8106030

fbshipit-source-id: ecd2942ad9eec2d0a84152cb01ab3179adca1182