### PR TITLE
build char vocab

### DIFF
--- a/pytorch_translate/dictionary.py
+++ b/pytorch_translate/dictionary.py
@@ -7,8 +7,32 @@ from fairseq import dictionary, tokenizer
 from pytorch_translate import vocab_constants
 
 
+TAGS = [
+    "@PLAIN",
+    "@FBENTITY",
+    "@DIGITS",
+    "@EMOTICON",
+    "@USERNAME",
+    "@URL",
+    "@MULTIPUNCT",
+    "@PERSON",
+    "@NOTRANSLATE",
+]
+
+
 def default_dictionary_path(save_dir: str, dialect: str) -> str:
     return os.path.join(save_dir, f"dictionary-{dialect}.txt")
+
+
+def char_tokenize(line):
+    words = tokenizer.tokenize_line(line)
+    chars = []
+    for word in words:
+        if word in TAGS:
+            chars.append(word)
+        else:
+            chars.extend(c for c in word)
+    return chars
 
 
 class Dictionary(dictionary.Dictionary):
@@ -57,10 +81,13 @@ class Dictionary(dictionary.Dictionary):
         vocab_file: str,
         max_vocab_size: int,
         tokens_with_penalty: Optional[str] = None,
+        is_char_vocab: bool = False,
     ) -> "Dictionary":  # https://www.python.org/dev/peps/pep-0484/#forward-references
         d = cls()
+
+        tokenize = char_tokenize if is_char_vocab else tokenizer.tokenize_line
         tokenizer.Tokenizer.add_file_to_dictionary(
-            filename=corpus_file, dict=d, tokenize=tokenizer.tokenize_line
+            filename=corpus_file, dict=d, tokenize=tokenize
         )
 
         # Set indices to receive penalty
@@ -96,6 +123,7 @@ class Dictionary(dictionary.Dictionary):
         vocab_file: str,
         max_vocab_size: int,
         tokens_with_penalty: Optional[str] = None,
+        is_char_vocab: bool = False,
     ) -> "Dictionary":  # https://www.python.org/dev/peps/pep-0484/#forward-references
         if os.path.isfile(vocab_file):
             d = cls()
@@ -115,6 +143,7 @@ class Dictionary(dictionary.Dictionary):
             vocab_file=vocab_file,
             max_vocab_size=max_vocab_size,
             tokens_with_penalty=tokens_with_penalty,
+            is_char_vocab=is_char_vocab,
         )
 
 

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -16,7 +16,7 @@ def add_args(parser):
         "--source-vocab-file",
         default="",
         metavar="FILE",
-        help="Path to text file representing the fairseq Dictionary to use. "
+        help="Path to text file representing the dictionary of tokens to use. "
         "If the file does not exist, the dict is auto-generated from source "
         "training data and saved as that file.",
     )
@@ -28,6 +28,19 @@ def add_args(parser):
         help="If a new vocab file needs to be generated, restrict it to the "
         "top N most common words. If we re-use an existing vocab file, this "
         "flag will have no effect. A value of < 0 means no max size.",
+    )
+    group.add_argument(
+        "--char-source-vocab-file",
+        default="",
+        metavar="FILE",
+        help="Same as --source-vocab-file except using characters.",
+    )
+    group.add_argument(
+        "--char-source-max-vocab-size",
+        default=-1,
+        type=int,
+        metavar="N",
+        help="Same as --source-max-vocab-size except using characters.",
     )
     group.add_argument(
         "--target-vocab-file",
@@ -214,6 +227,15 @@ def preprocess_corpora(args):
         max_vocab_size=args.source_max_vocab_size,
         tokens_with_penalty=None,
     )
+    if args.char_source_vocab_file:
+        # TODO: assign results and pass to new and improved binarize_text_file
+        pytorch_translate_dictionary.Dictionary.build_vocab_file_if_nonexistent(
+            corpus_file=args.train_source_text_file,
+            vocab_file=args.char_source_vocab_file,
+            max_vocab_size=args.char_source_max_vocab_size,
+            tokens_with_penalty=None,
+            is_char_vocab=True,
+        )
     if args.train_source_text_file:
         args.train_source_binary_prefix = binarize_text_file(
             text_file=args.train_source_text_file,


### PR DESCRIPTION
Summary: Add option to preprocess.py to build a separate character vocab from a text file corpus. First step of introducing data loading which will provide both word- and character-level numberized inputs for source sentences.

Differential Revision: D8130404

fbshipit-source-id: f8bd0b36d648c4b47fbc3c9dfc0aabb3c06e41fd