### PR TITLE
Fix loading dictionaries

### DIFF
--- a/pytorch_translate/dictionary.py
+++ b/pytorch_translate/dictionary.py
@@ -126,8 +126,7 @@ class Dictionary(dictionary.Dictionary):
         is_char_vocab: bool = False,
     ) -> "Dictionary":  # https://www.python.org/dev/peps/pep-0484/#forward-references
         if os.path.isfile(vocab_file):
-            d = cls()
-            d.load(vocab_file)
+            d = cls.load(vocab_file)
             print(
                 f"Re-using existing vocab file {vocab_file}. Specified "
                 f"max vocab size of {max_vocab_size} may not be enforced."


### PR DESCRIPTION
Summary: Loading existing dictionaries was broken, resulting in 100% UNKs when resuming training.

Reviewed By: yukatherin

Differential Revision: D8154677

fbshipit-source-id: 0c2658c92db1487e0f70c3308dbba80ee4b8185d