### PR TITLE
Changed _generate to fail quickly when receiving an invalid beam size

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -134,7 +134,9 @@ class SequenceGenerator(torch.nn.Module):
 
         # the max beam size is the dictionary size - 1, since we never select pad
         beam_size = beam_size if beam_size is not None else self.beam_size
-        beam_size = min(beam_size, self.vocab_size - 1)
+        assert beam_size < self.vocab_size, (
+            "Beam size must be smaller than target vocabulary"
+        )
 
         encoder_outs = []
         incremental_states = {}


### PR DESCRIPTION
Summary: The existing implementation caps the beam size at the vocabulary size and will likely cause the program to stall and fail silently. Changed to an assert to immediately notify the user and fail fast if an invalid beam size is entered.

Reviewed By: liezl200

Differential Revision: D8150727

fbshipit-source-id: 7e5a050b1132cbaad554cff375452e73fee9ceb4