### PR TITLE
use numpy .npz format to binarize datasets

### DIFF
--- a/pytorch_translate/data.py
+++ b/pytorch_translate/data.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import numpy as np
 import os
+import torch
 
-from fairseq import data, indexed_dataset
+from fairseq import data, indexed_dataset, tokenizer
 from typing import NamedTuple, Optional
 
 from pytorch_translate import dictionary as pytorch_translate_dictionary
@@ -17,6 +19,70 @@ class CorpusConfig(NamedTuple):
 class ParallelCorpusConfig(NamedTuple):
     source: CorpusConfig
     target: CorpusConfig
+
+
+class InMemoryNumpyDataset(indexed_dataset.IndexedDataset):
+    """analogous to fairseq.indexed_dataset.IndexedInMemoryDataset"""
+
+    def __init__(self):
+        """Initialize empty dataset"""
+        self.buffer = None
+        self.offsets = None
+        self.sizes = None
+
+    def __getitem__(self, i):
+        assert i < self.__len__(), f"index {i} out of range!"
+        a = self.buffer[self.offsets[i] : self.offsets[i + 1]]
+        return torch.from_numpy(a)
+
+    def __len__(self):
+        # offsets includes 0 and end indices for each example
+        return self.offsets.size - 1
+
+    def __del__(self):
+        pass
+
+    def save(self, path):
+        assert self.buffer is not None
+        assert self.offsets is not None
+        np.savez(path, buffer=self.buffer, offsets=self.offsets)
+
+    def load(self, path):
+        npz = np.load(path)
+        self.buffer = npz["buffer"]
+        self.offsets = npz["offsets"]
+        self.sizes = self.offsets[1:] - self.offsets[:-1]
+
+    def parse(self, path, dict, reverse_order=False, append_eos=False):
+        array_list = []
+        offsets = [0]
+        sizes = []
+        with open(path, "r") as f:
+            for line in f:
+                words = tokenizer.tokenize_line(line)
+                if reverse_order:
+                    words.reverse()
+                inds = [dict.index(w) for w in words]
+                if append_eos:
+                    inds.append(dict.eos_index)
+
+                array_list.append(np.array(inds, dtype=np.int32))
+                offsets.append(offsets[-1] + len(inds))
+                sizes.append(len(inds))
+
+        # +1 for Lua compatibility
+        self.buffer = np.concatenate(array_list) + 1
+        self.offsets = np.array(offsets, dtype=np.int32)
+        self.sizes = np.array(sizes, dtype=np.int32)
+        del array_list
+        del offsets
+        del sizes
+
+    @staticmethod
+    def create_from_file(path):
+        result = InMemoryNumpyDataset()
+        result.load(path)
+        return result
 
 
 def make_language_pair_dataset_from_text(
@@ -71,21 +137,14 @@ def load_binarized_dataset(
     )
 
     for split, corpus in [(train_split, train_corpus), (eval_split, eval_corpus)]:
-        if (
-            not indexed_dataset.IndexedInMemoryDataset.exists(corpus.source.data_file)
-            or not indexed_dataset.IndexedInMemoryDataset.exists(
-                corpus.target.data_file
-            )
-        ):
-            raise ValueError(
-                f"One or both of source file: {corpus.source.data_file} and "
-                f"target file: {corpus.target.data_file} for split {split} "
-                f"was not found."
-            )
+        if not os.path.exists(corpus.source.data_file):
+            raise ValueError(f"{corpus.source.data_file} for {split} not found!")
+        if not os.path.exists(corpus.target.data_file):
+            raise ValueError(f"{corpus.target.data_file} for {split} not found!")
 
         dataset.splits[split] = data.LanguagePairDataset(
-            src=indexed_dataset.IndexedInMemoryDataset(corpus.source.data_file),
-            dst=indexed_dataset.IndexedInMemoryDataset(corpus.target.data_file),
+            src=InMemoryNumpyDataset.create_from_file(corpus.source.data_file),
+            dst=InMemoryNumpyDataset.create_from_file(corpus.target.data_file),
             pad_idx=source_dict.pad(),
             eos_idx=source_dict.eos(),
         )

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -231,18 +231,18 @@ def setup_training(args):
 
     train_corpus = pytorch_translate_data.ParallelCorpusConfig(
         source=pytorch_translate_data.CorpusConfig(
-            dialect=args.source_lang, data_file=args.train_source_binary_prefix
+            dialect=args.source_lang, data_file=args.train_source_binary_path
         ),
         target=pytorch_translate_data.CorpusConfig(
-            dialect=args.target_lang, data_file=args.train_target_binary_prefix
+            dialect=args.target_lang, data_file=args.train_target_binary_path
         ),
     )
     eval_corpus = pytorch_translate_data.ParallelCorpusConfig(
         source=pytorch_translate_data.CorpusConfig(
-            dialect=args.source_lang, data_file=args.eval_source_binary_prefix
+            dialect=args.source_lang, data_file=args.eval_source_binary_path
         ),
         target=pytorch_translate_data.CorpusConfig(
-            dialect=args.target_lang, data_file=args.eval_target_binary_prefix
+            dialect=args.target_lang, data_file=args.eval_target_binary_path
         ),
     )
 


### PR DESCRIPTION
Summary: Simplification allowing us to save binarized datasets in a single file rather than having separate files for indices and offsets. This is preparatory to having combined token/character datasets, which would otherwise require four files per dataset.

Differential Revision: D8132665

fbshipit-source-id: 203b8f9cd1c556663947d535f67c7a533f40c6c8