### PR TITLE
squash .data

### DIFF
--- a/pytorch_translate/char_encoder.py
+++ b/pytorch_translate/char_encoder.py
@@ -162,7 +162,7 @@ class CharEmbModel(nn.Module):
         # else: apply conv-pool-highway directly on sentence batch, generate
         # segment embeddings per sentence
         if self.preserve_word:
-            src_char_tokens = self._prepare_char_batch(src_tokens.data, left_padded)
+            src_char_tokens = self._prepare_char_batch(src_tokens, left_padded)
         else:
             src_char_tokens = src_tokens
 

--- a/pytorch_translate/char_source_model.py
+++ b/pytorch_translate/char_source_model.py
@@ -228,11 +228,11 @@ class CharRNNEncoder(FairseqEncoder):
         final_hiddens, final_cells = [], []
         for i, rnn_layer in enumerate(self.layers):
             if self.bidirectional and i == 0:
-                h0 = x.data.new(2, bsz, self.hidden_dim // 2).zero_()
-                c0 = x.data.new(2, bsz, self.hidden_dim // 2).zero_()
+                h0 = x.new(2, bsz, self.hidden_dim // 2).zero_()
+                c0 = x.new(2, bsz, self.hidden_dim // 2).zero_()
             else:
-                h0 = x.data.new(1, bsz, self.hidden_dim).zero_()
-                c0 = x.data.new(1, bsz, self.hidden_dim).zero_()
+                h0 = x.new(1, bsz, self.hidden_dim).zero_()
+                c0 = x.new(1, bsz, self.hidden_dim).zero_()
 
             # apply LSTM along entire sequence
             current_output, (h_last, c_last) = rnn_layer(packed_input, (h0, c0))

--- a/pytorch_translate/research/test/test_multihead_attention.py
+++ b/pytorch_translate/research/test/test_multihead_attention.py
@@ -104,7 +104,7 @@ class MultiheadAttentionTest(unittest.TestCase):
                 value=V_tensor,
                 unseen_mask=unseen_mask,
                 src_lengths=src_lengths_tensor,
-            )[0].data.numpy()
+            )[0].numpy()
 
             reference = self._scaled_dot_attn_ref(
                 Q=Q,
@@ -194,9 +194,9 @@ class MultiheadAttentionTest(unittest.TestCase):
         X_fc_b = 0
         for name, param in module.named_parameters():
             if X_name + '_fc.weight' in name:
-                X_fc_w = param.data.numpy()
+                X_fc_w = param.numpy()
             elif X_name + '_fc.bias' in name:
-                X_fc_b = param.data.numpy()
+                X_fc_b = param.numpy()
         return np.matmul(X, np.transpose(X_fc_w)) + X_fc_b
 
     def _multihead_attn_test_helper(self, unseen_mask, use_src_lengths):

--- a/pytorch_translate/research/word_prediction/word_prediction_criterion.py
+++ b/pytorch_translate/research/word_prediction/word_prediction_criterion.py
@@ -55,8 +55,8 @@ class WordPredictionCriterion(FairseqCriterion):
             sample_size = sample['ntokens']
 
         logging_output = {
-            'loss': translation_loss.data,
-            'word_prediction_loss': word_prediction_loss.data,
+            'loss': translation_loss,
+            'word_prediction_loss': word_prediction_loss,
             'ntokens': sample['ntokens'],
             'sample_size': sample_size,
         }

--- a/pytorch_translate/test/test_onnx.py
+++ b/pytorch_translate/test/test_onnx.py
@@ -61,7 +61,7 @@ class TestONNX(unittest.TestCase):
 
         for i in range(len(pytorch_encoder_outputs)):
             caffe2_out_value = caffe2_encoder_outputs[i]
-            pytorch_out_value = pytorch_encoder_outputs[i].data.numpy()
+            pytorch_out_value = pytorch_encoder_outputs[i].detach().numpy()
             np.testing.assert_allclose(
                 caffe2_out_value,
                 pytorch_out_value,
@@ -129,7 +129,7 @@ class TestONNX(unittest.TestCase):
 
         for i in range(len(pytorch_encoder_outputs)):
             caffe2_out_value = caffe2_encoder_outputs[i]
-            pytorch_out_value = pytorch_encoder_outputs[i].data.numpy()
+            pytorch_out_value = pytorch_encoder_outputs[i].detach().numpy()
             np.testing.assert_allclose(
                 caffe2_out_value,
                 pytorch_out_value,
@@ -196,7 +196,7 @@ class TestONNX(unittest.TestCase):
 
         for i in range(len(pytorch_decoder_outputs)):
             caffe2_out_value = caffe2_decoder_outputs[i]
-            pytorch_out_value = pytorch_decoder_outputs[i].data.numpy()
+            pytorch_out_value = pytorch_decoder_outputs[i].detach().numpy()
             np.testing.assert_allclose(
                 caffe2_out_value,
                 pytorch_out_value,
@@ -314,7 +314,7 @@ class TestONNX(unittest.TestCase):
 
         for i in range(len(pytorch_next_step_outputs)):
             caffe2_out_value = caffe2_next_step_outputs[i]
-            pytorch_out_value = pytorch_next_step_outputs[i].data.numpy()
+            pytorch_out_value = pytorch_next_step_outputs[i].detach().numpy()
             np.testing.assert_allclose(
                 caffe2_out_value,
                 pytorch_out_value,

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -281,7 +281,7 @@ def setup_training(args):
     print(f"| model {args.arch}, criterion {criterion.__class__.__name__}")
     print(
         f"| num. model params: \
-        {sum(p.data.numel() for p in model.parameters())}"
+        {sum(p.numel() for p in model.parameters())}"
     )
 
     # Build trainer


### PR DESCRIPTION
Summary:
Quick simplification of the code base removing `.data` annotations on tensors. This is generally unnecessary since the merging of tensors and variables.

Exceptions are when calling an in-place operation on a leaf variable (here meaning parameter, i.e., tensor which is not computed and requires grad), such as:

  param.data.uniform_(-0.1, 0.1)

And when calling `.numpy()` on a tensor which requires grad

Differential Revision: D8208506
