### PR TITLE
black formatting for Python tests

### DIFF
--- a/pytorch_translate/test/test_average_checkpoints.py
+++ b/pytorch_translate/test/test_average_checkpoints.py
@@ -14,33 +14,33 @@ class AverageCheckpointsTest(unittest.TestCase):
     def test_average_checkpoints(self):
         params_0 = collections.OrderedDict(
             [
-                ('a', torch.DoubleTensor([100.0])),
-                ('b', torch.FloatTensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])),
-                ('c', torch.IntTensor([7, 8, 9])),
+                ("a", torch.DoubleTensor([100.0])),
+                ("b", torch.FloatTensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])),
+                ("c", torch.IntTensor([7, 8, 9])),
             ]
         )
         params_1 = collections.OrderedDict(
             [
-                ('a', torch.DoubleTensor([1.0])),
-                ('b', torch.FloatTensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])),
-                ('c', torch.IntTensor([2, 2, 2])),
+                ("a", torch.DoubleTensor([1.0])),
+                ("b", torch.FloatTensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])),
+                ("c", torch.IntTensor([2, 2, 2])),
             ]
         )
         params_avg = collections.OrderedDict(
             [
-                ('a', torch.DoubleTensor([50.5])),
-                ('b', torch.FloatTensor([[1.0, 1.5, 2.0], [2.5, 3.0, 3.5]])),
+                ("a", torch.DoubleTensor([50.5])),
+                ("b", torch.FloatTensor([[1.0, 1.5, 2.0], [2.5, 3.0, 3.5]])),
                 # We expect truncation for integer division
-                ('c', torch.IntTensor([4, 5, 5])),
+                ("c", torch.IntTensor([4, 5, 5])),
             ]
         )
 
         fd_0, path_0 = tempfile.mkstemp()
         fd_1, path_1 = tempfile.mkstemp()
-        torch.save(collections.OrderedDict([('model', params_0)]), path_0)
-        torch.save(collections.OrderedDict([('model', params_1)]), path_1)
+        torch.save(collections.OrderedDict([("model", params_0)]), path_0)
+        torch.save(collections.OrderedDict([("model", params_1)]), path_1)
 
-        output = average_checkpoints([path_0, path_1])['model']
+        output = average_checkpoints([path_0, path_1])["model"]
 
         os.close(fd_0)
         os.remove(path_0)
@@ -48,16 +48,17 @@ class AverageCheckpointsTest(unittest.TestCase):
         os.remove(path_1)
 
         for (k_expected, v_expected), (k_out, v_out) in zip(
-                params_avg.items(), output.items()):
+            params_avg.items(), output.items()
+        ):
             self.assertEquals(
                 k_expected,
                 k_out,
-                f'Key mismatch - expected {k_expected} but found {k_out}. '
-                '(Expected list of keys: {params_avg.keys()} '
-                'vs actual list of keys: {output.keys()})'
+                f"Key mismatch - expected {k_expected} but found {k_out}. "
+                "(Expected list of keys: {params_avg.keys()} "
+                "vs actual list of keys: {output.keys()})",
             )
             np.testing.assert_allclose(
                 v_expected.numpy(),
                 v_out.numpy(),
-                err_msg=f'Tensor value mismatch for key {k_expected}'
+                err_msg=f"Tensor value mismatch for key {k_expected}",
             )

--- a/pytorch_translate/test/test_beam_decode.py
+++ b/pytorch_translate/test/test_beam_decode.py
@@ -10,9 +10,7 @@ from pytorch_translate.test import utils as test_utils
 
 
 class TestBeamDecode(unittest.TestCase):
-    @unittest.skipIf(
-        torch.cuda.device_count() < 1, "No GPU available for test."
-    )
+    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_basic_generate(self):
         test_args = test_utils.ModelParamsDict()
         _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
@@ -20,7 +18,4 @@ class TestBeamDecode(unittest.TestCase):
         translator = beam_decode.SequenceGenerator([model])
         src_tokens = torch.LongTensor([[0, 0, 0], [0, 0, 0]])
         src_lengths = torch.LongTensor([3, 3])
-        translator.generate(
-            src_tokens=src_tokens,
-            src_lengths=src_lengths,
-        )
+        translator.generate(src_tokens=src_tokens, src_lengths=src_lengths)

--- a/pytorch_translate/test/test_char_encoder.py
+++ b/pytorch_translate/test/test_char_encoder.py
@@ -15,62 +15,42 @@ logger = logging.getLogger(__name__)
 
 class TestCharEncoder(unittest.TestCase):
     def _get_dummy_batch(
-        self,
-        word_delim_index,
-        pad_index,
-        bow_index=None,
-        eow_index=None,
+        self, word_delim_index, pad_index, bow_index=None, eow_index=None
     ):
         batch_size = 2
         seq_len = [3, 3]
         sent_1 = [[6, 8, 8, 5, 9, 7, 10], [12, 4, 7, 5], [6, 5]]
         sent_2 = [[8, 5, 9], [10, 6, 12, 4], [5, 7, 6, 5]]
 
-        src_tokens = torch.LongTensor([
-            sent_1[0]
-            + [word_delim_index]
-            + sent_1[1]
-            + [word_delim_index]
-            + sent_1[2],
-            [pad_index] * 2
-            + sent_2[0]
-            + [word_delim_index]
-            + sent_2[1]
-            + [word_delim_index]
-            + sent_2[2],
-        ])
-        char_batch = np.array([
-            [bow_index]
-            + sent_1[0]
-            + [eow_index],
-            [bow_index]
-            + sent_1[1]
-            + [eow_index]
-            + [pad_index] * 3,
-            [bow_index]
-            + sent_1[2]
-            + [eow_index]
-            + [pad_index] * 5,
-            [bow_index]
-            + sent_2[0]
-            + [eow_index]
-            + [pad_index] * 4,
-            [bow_index]
-            + sent_2[1]
-            + [eow_index]
-            + [pad_index] * 3,
-            [bow_index]
-            + sent_2[2]
-            + [eow_index]
-            + [pad_index] * 3
-        ])
+        src_tokens = torch.LongTensor(
+            [
+                sent_1[0]
+                + [word_delim_index]
+                + sent_1[1]
+                + [word_delim_index]
+                + sent_1[2],
+                [pad_index] * 2
+                + sent_2[0]
+                + [word_delim_index]
+                + sent_2[1]
+                + [word_delim_index]
+                + sent_2[2],
+            ]
+        )
+        char_batch = np.array(
+            [
+                [bow_index] + sent_1[0] + [eow_index],
+                [bow_index] + sent_1[1] + [eow_index] + [pad_index] * 3,
+                [bow_index] + sent_1[2] + [eow_index] + [pad_index] * 5,
+                [bow_index] + sent_2[0] + [eow_index] + [pad_index] * 4,
+                [bow_index] + sent_2[1] + [eow_index] + [pad_index] * 3,
+                [bow_index] + sent_2[2] + [eow_index] + [pad_index] * 3,
+            ]
+        )
 
         return src_tokens, batch_size, seq_len, char_batch
 
-    def _dummy_char_vocab(
-        self,
-        char_token=26,
-    ):
+    def _dummy_char_vocab(self, char_token=26):
         d = CharDictionary()
         for token in list(string.ascii_lowercase):
             d.add_symbol(token)
@@ -79,11 +59,11 @@ class TestCharEncoder(unittest.TestCase):
 
     def _get_default_model_params(self):
         model_params = {}
-        model_params['dictionary'] = self._dummy_char_vocab()
-        model_params['char_embed_dim'] = 3
-        model_params['word_embed_dim'] = 5
-        model_params['convolutions'] = ((7, 2), (8, 3))
-        model_params['dropout'] = 0
+        model_params["dictionary"] = self._dummy_char_vocab()
+        model_params["char_embed_dim"] = 3
+        model_params["word_embed_dim"] = 5
+        model_params["convolutions"] = ((7, 2), (8, 3))
+        model_params["dropout"] = 0
         return model_params
 
     def test_conv_step(self):
@@ -92,27 +72,25 @@ class TestCharEncoder(unittest.TestCase):
         char_encoder = CharEmbModel(**model_params)
 
         char_input, batch_size, seq_lengths, _ = self._get_dummy_batch(
-            char_encoder.dictionary.word_delim_index,
-            char_encoder.dictionary.pad_index,
+            char_encoder.dictionary.word_delim_index, char_encoder.dictionary.pad_index
         )
         encoder_inputs = char_encoder(char_input, seq_lengths)
         assert encoder_inputs.size() == torch.Size(
-            [batch_size, max(seq_lengths), model_params['word_embed_dim']]
+            [batch_size, max(seq_lengths), model_params["word_embed_dim"]]
         )
 
     def test_conv_pool_highway(self):
         model_params = self._get_default_model_params()
-        model_params['num_highway_layers'] = 2
+        model_params["num_highway_layers"] = 2
 
         char_encoder = CharEmbModel(**model_params)
 
         char_input, batch_size, seq_lengths, _ = self._get_dummy_batch(
-            char_encoder.dictionary.word_delim_index,
-            char_encoder.dictionary.pad_index,
+            char_encoder.dictionary.word_delim_index, char_encoder.dictionary.pad_index
         )
         encoder_inputs = char_encoder(char_input, seq_lengths)
         assert encoder_inputs.size() == torch.Size(
-            [batch_size, max(seq_lengths), model_params['word_embed_dim']]
+            [batch_size, max(seq_lengths), model_params["word_embed_dim"]]
         )
 
     def test_prepare_char_batch(self):
@@ -125,11 +103,5 @@ class TestCharEncoder(unittest.TestCase):
             char_encoder.dictionary.bow_index,
             char_encoder.dictionary.eow_index,
         )
-        word_batch = char_encoder._prepare_char_batch(
-            src_tokens,
-            left_padded=True,
-        )
-        np.testing.assert_array_equal(
-            word_batch,
-            expected_batch,
-        )
+        word_batch = char_encoder._prepare_char_batch(src_tokens, left_padded=True)
+        np.testing.assert_array_equal(word_batch, expected_batch)

--- a/pytorch_translate/test/test_onnx.py
+++ b/pytorch_translate/test/test_onnx.py
@@ -14,7 +14,7 @@ from pytorch_translate.ensemble_export import (
     DecoderBatchedStepEnsemble,
     DecoderStepEnsemble,
     EncoderEnsemble,
-    BeamSearch
+    BeamSearch,
 )
 from pytorch_translate.test import utils as test_utils
 
@@ -35,7 +35,7 @@ class TestONNX(unittest.TestCase):
         encoder_ensemble = EncoderEnsemble(model_list)
 
         tmp_dir = tempfile.mkdtemp()
-        encoder_pb_path = os.path.join(tmp_dir, 'encoder.pb')
+        encoder_pb_path = os.path.join(tmp_dir, "encoder.pb")
         encoder_ensemble.onnx_export(encoder_pb_path)
 
         # test equivalence
@@ -43,74 +43,62 @@ class TestONNX(unittest.TestCase):
         # PyTorch indexing requires int64 while support for tracing
         # pack_padded_sequence() requires int32.
         sample = next(samples)
-        src_tokens = sample['net_input']['src_tokens'][0:1].t()
-        src_lengths = sample['net_input']['src_lengths'][0:1].int()
+        src_tokens = sample["net_input"]["src_tokens"][0:1].t()
+        src_lengths = sample["net_input"]["src_lengths"][0:1].int()
 
         pytorch_encoder_outputs = encoder_ensemble(src_tokens, src_lengths)
 
-        with open(encoder_pb_path, 'r+b') as f:
+        with open(encoder_pb_path, "r+b") as f:
             onnx_model = onnx.load(f)
         onnx_encoder = caffe2_backend.prepare(onnx_model)
 
         caffe2_encoder_outputs = onnx_encoder.run(
-            (
-                src_tokens.numpy(),
-                src_lengths.numpy(),
-            ),
+            (src_tokens.numpy(), src_lengths.numpy())
         )
 
         for i in range(len(pytorch_encoder_outputs)):
             caffe2_out_value = caffe2_encoder_outputs[i]
             pytorch_out_value = pytorch_encoder_outputs[i].detach().numpy()
             np.testing.assert_allclose(
-                caffe2_out_value,
-                pytorch_out_value,
-                rtol=1e-4,
-                atol=1e-6,
+                caffe2_out_value, pytorch_out_value, rtol=1e-4, atol=1e-6
             )
 
-        encoder_ensemble.save_to_db(
-            os.path.join(tmp_dir, 'encoder.predictor_export'),
-        )
+        encoder_ensemble.save_to_db(os.path.join(tmp_dir, "encoder.predictor_export"))
 
     def test_ensemble_encoder_export_default(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         self._test_ensemble_encoder_export(test_args)
 
     def test_ensemble_encoder_export_vocab_reduction(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         lexical_dictionaries = test_utils.create_lexical_dictionaries()
         test_args.vocab_reduction_params = {
-            'lexical_dictionaries': lexical_dictionaries,
-            'num_top_words': 5,
-            'max_translation_candidates_per_word': 1,
+            "lexical_dictionaries": lexical_dictionaries,
+            "num_top_words": 5,
+            "max_translation_candidates_per_word": 1,
         }
 
         self._test_ensemble_encoder_export(test_args)
 
     def _test_ensemble_encoder_object_export(self, encoder_ensemble):
         tmp_dir = tempfile.mkdtemp()
-        encoder_pb_path = os.path.join(tmp_dir, 'encoder.pb')
+        encoder_pb_path = os.path.join(tmp_dir, "encoder.pb")
         encoder_ensemble.onnx_export(encoder_pb_path)
 
         src_dict = encoder_ensemble.models[0].src_dict
         token_list = [src_dict.unk()] * 4 + [src_dict.eos()]
         src_tokens = torch.LongTensor(
-            np.array(token_list, dtype='int64').reshape(-1, 1),
+            np.array(token_list, dtype="int64").reshape(-1, 1)
         )
-        src_lengths = torch.IntTensor(
-            np.array([len(token_list)], dtype='int32'),
-        )
+        src_lengths = torch.IntTensor(np.array([len(token_list)], dtype="int32"))
 
         pytorch_encoder_outputs = encoder_ensemble(src_tokens, src_lengths)
 
-        with open(encoder_pb_path, 'r+b') as f:
+        with open(encoder_pb_path, "r+b") as f:
             onnx_model = onnx.load(f)
         onnx_encoder = caffe2_backend.prepare(onnx_model)
 
@@ -120,26 +108,16 @@ class TestONNX(unittest.TestCase):
         src_tokens = src_tokens.repeat(1, beam_size).view(-1, srclen).numpy()
         src_lengths = src_lengths.repeat(beam_size).numpy()
 
-        caffe2_encoder_outputs = onnx_encoder.run(
-            (
-                src_tokens,
-                src_lengths,
-            ),
-        )
+        caffe2_encoder_outputs = onnx_encoder.run((src_tokens, src_lengths))
 
         for i in range(len(pytorch_encoder_outputs)):
             caffe2_out_value = caffe2_encoder_outputs[i]
             pytorch_out_value = pytorch_encoder_outputs[i].detach().numpy()
             np.testing.assert_allclose(
-                caffe2_out_value,
-                pytorch_out_value,
-                rtol=1e-4,
-                atol=1e-6,
+                caffe2_out_value, pytorch_out_value, rtol=1e-4, atol=1e-6
             )
 
-        encoder_ensemble.save_to_db(
-            os.path.join(tmp_dir, 'encoder.predictor_export'),
-        )
+        encoder_ensemble.save_to_db(os.path.join(tmp_dir, "encoder.predictor_export"))
 
     def _test_full_ensemble_export(self, test_args):
         samples, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
@@ -155,36 +133,26 @@ class TestONNX(unittest.TestCase):
         # PyTorch indexing requires int64 while support for tracing
         # pack_padded_sequence() requires int32.
         sample = next(samples)
-        src_tokens = sample['net_input']['src_tokens'][0:1].t()
-        src_lengths = sample['net_input']['src_lengths'][0:1].int()
+        src_tokens = sample["net_input"]["src_tokens"][0:1].t()
+        src_lengths = sample["net_input"]["src_lengths"][0:1].int()
 
         pytorch_encoder_outputs = encoder_ensemble(src_tokens, src_lengths)
 
-        decoder_step_ensemble = DecoderStepEnsemble(
-            model_list,
-            beam_size=5,
-        )
+        decoder_step_ensemble = DecoderStepEnsemble(model_list, beam_size=5)
 
         tmp_dir = tempfile.mkdtemp()
-        decoder_step_pb_path = os.path.join(tmp_dir, 'decoder_step.pb')
-        decoder_step_ensemble.onnx_export(
-            decoder_step_pb_path,
-            pytorch_encoder_outputs,
-        )
+        decoder_step_pb_path = os.path.join(tmp_dir, "decoder_step.pb")
+        decoder_step_ensemble.onnx_export(decoder_step_pb_path, pytorch_encoder_outputs)
 
         # single EOS
-        input_token = torch.LongTensor(
-            np.array([[model_list[0].dst_dict.eos()]]),
-        )
+        input_token = torch.LongTensor(np.array([[model_list[0].dst_dict.eos()]]))
         timestep = torch.LongTensor(np.array([[0]]))
 
         pytorch_decoder_outputs = decoder_step_ensemble(
-            input_token,
-            timestep,
-            *pytorch_encoder_outputs
+            input_token, timestep, *pytorch_encoder_outputs
         )
 
-        with open(decoder_step_pb_path, 'r+b') as f:
+        with open(decoder_step_pb_path, "r+b") as f:
             onnx_model = onnx.load(f)
         onnx_decoder = caffe2_backend.prepare(onnx_model)
 
@@ -198,34 +166,29 @@ class TestONNX(unittest.TestCase):
             caffe2_out_value = caffe2_decoder_outputs[i]
             pytorch_out_value = pytorch_decoder_outputs[i].detach().numpy()
             np.testing.assert_allclose(
-                caffe2_out_value,
-                pytorch_out_value,
-                rtol=1e-4,
-                atol=1e-6,
+                caffe2_out_value, pytorch_out_value, rtol=1e-4, atol=1e-6
             )
 
         decoder_step_ensemble.save_to_db(
-            os.path.join(tmp_dir, 'decoder_step.predictor_export'),
+            os.path.join(tmp_dir, "decoder_step.predictor_export"),
             pytorch_encoder_outputs,
         )
 
     def test_full_ensemble_export_default(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         self._test_full_ensemble_export(test_args)
 
     def test_full_ensemble_export_vocab_reduction(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         lexical_dictionaries = test_utils.create_lexical_dictionaries()
         test_args.vocab_reduction_params = {
-            'lexical_dictionaries': lexical_dictionaries,
-            'num_top_words': 5,
-            'max_translation_candidates_per_word': 1,
+            "lexical_dictionaries": lexical_dictionaries,
+            "num_top_words": 5,
+            "max_translation_candidates_per_word": 1,
         }
 
         self._test_full_ensemble_export(test_args)
@@ -245,41 +208,30 @@ class TestONNX(unittest.TestCase):
         # PyTorch indexing requires int64 while support for tracing
         # pack_padded_sequence() requires int32.
         sample = next(samples)
-        src_tokens = sample['net_input']['src_tokens'][0:1].t()
-        src_lengths = sample['net_input']['src_lengths'][0:1].int()
+        src_tokens = sample["net_input"]["src_tokens"][0:1].t()
+        src_lengths = sample["net_input"]["src_lengths"][0:1].int()
 
         pytorch_encoder_outputs = encoder_ensemble(src_tokens, src_lengths)
 
         decoder_step_ensemble = DecoderBatchedStepEnsemble(
-            model_list,
-            beam_size=beam_size,
+            model_list, beam_size=beam_size
         )
 
         tmp_dir = tempfile.mkdtemp()
-        decoder_step_pb_path = os.path.join(tmp_dir, 'decoder_step.pb')
-        decoder_step_ensemble.onnx_export(
-            decoder_step_pb_path,
-            pytorch_encoder_outputs,
-        )
+        decoder_step_pb_path = os.path.join(tmp_dir, "decoder_step.pb")
+        decoder_step_ensemble.onnx_export(decoder_step_pb_path, pytorch_encoder_outputs)
 
         # single EOS in flat array
-        input_tokens = torch.LongTensor(
-            np.array([model_list[0].dst_dict.eos()]),
-        )
+        input_tokens = torch.LongTensor(np.array([model_list[0].dst_dict.eos()]))
         prev_scores = torch.FloatTensor(np.array([0.0]))
         timestep = torch.LongTensor(np.array([0]))
 
         pytorch_first_step_outputs = decoder_step_ensemble(
-            input_tokens,
-            prev_scores,
-            timestep,
-            *pytorch_encoder_outputs
+            input_tokens, prev_scores, timestep, *pytorch_encoder_outputs
         )
 
         # next step inputs (input_tokesn shape: [beam_size])
-        next_input_tokens = torch.LongTensor(
-            np.array([i for i in range(4, 9)]),
-        )
+        next_input_tokens = torch.LongTensor(np.array([i for i in range(4, 9)]))
 
         next_prev_scores = pytorch_first_step_outputs[1]
         next_timestep = timestep + 1
@@ -290,13 +242,10 @@ class TestONNX(unittest.TestCase):
             next_states[i] = next_states[i].repeat(1, beam_size, 1)
 
         pytorch_next_step_outputs = decoder_step_ensemble(
-            next_input_tokens,
-            next_prev_scores,
-            next_timestep,
-            *next_states
+            next_input_tokens, next_prev_scores, next_timestep, *next_states
         )
 
-        with open(decoder_step_pb_path, 'r+b') as f:
+        with open(decoder_step_pb_path, "r+b") as f:
             onnx_model = onnx.load(f)
         onnx_decoder = caffe2_backend.prepare(onnx_model)
 
@@ -308,89 +257,117 @@ class TestONNX(unittest.TestCase):
         for tensor in next_states:
             decoder_inputs_numpy.append(tensor.detach().numpy())
 
-        caffe2_next_step_outputs = onnx_decoder.run(
-            tuple(decoder_inputs_numpy),
-        )
+        caffe2_next_step_outputs = onnx_decoder.run(tuple(decoder_inputs_numpy))
 
         for i in range(len(pytorch_next_step_outputs)):
             caffe2_out_value = caffe2_next_step_outputs[i]
             pytorch_out_value = pytorch_next_step_outputs[i].detach().numpy()
             np.testing.assert_allclose(
-                caffe2_out_value,
-                pytorch_out_value,
-                rtol=1e-4,
-                atol=1e-6,
+                caffe2_out_value, pytorch_out_value, rtol=1e-4, atol=1e-6
             )
 
     def test_batched_beam_decoder_default(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         self._test_batched_beam_decoder_step(test_args)
 
     def test_batched_beam_decoder_vocab_reduction(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         lexical_dictionaries = test_utils.create_lexical_dictionaries()
         test_args.vocab_reduction_params = {
-            'lexical_dictionaries': lexical_dictionaries,
-            'num_top_words': 5,
-            'max_translation_candidates_per_word': 1,
+            "lexical_dictionaries": lexical_dictionaries,
+            "num_top_words": 5,
+            "max_translation_candidates_per_word": 1,
         }
         self._test_batched_beam_decoder_step(test_args)
 
     def _test_full_beam_decoder(self, test_args):
         samples, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
         sample = next(samples)
-        src_tokens = sample['net_input']['src_tokens'][0:1].t()
-        src_lengths = sample['net_input']['src_lengths'][0:1].int()
+        src_tokens = sample["net_input"]["src_tokens"][0:1].t()
+        src_lengths = sample["net_input"]["src_lengths"][0:1].int()
 
         num_models = 3
         model_list = []
         for _ in range(num_models):
-            model_list.append(models.build_model(
-                test_args, src_dict, tgt_dict))
+            model_list.append(models.build_model(test_args, src_dict, tgt_dict))
 
-        bs = BeamSearch(model_list, src_tokens, src_lengths,
-                                 beam_size=6)
+        bs = BeamSearch(model_list, src_tokens, src_lengths, beam_size=6)
         prev_token = torch.LongTensor([0])
         prev_scores = torch.FloatTensor([0.0])
         attn_weights = torch.zeros(11)
         prev_hypos_indices = torch.zeros(6, dtype=torch.int64)
 
-        outs = bs(src_tokens, src_lengths, prev_token, prev_scores,
-                  attn_weights, prev_hypos_indices, torch.LongTensor([20]))
+        outs = bs(
+            src_tokens,
+            src_lengths,
+            prev_token,
+            prev_scores,
+            attn_weights,
+            prev_hypos_indices,
+            torch.LongTensor([20]),
+        )
 
         import io
+
         f = io.BytesIO()
         torch.onnx._export(
             bs,
-            (src_tokens, src_lengths, prev_token, prev_scores, attn_weights,
-             prev_hypos_indices, torch.LongTensor([20])),
-            f, export_params=True, verbose=False, example_outputs=outs)
+            (
+                src_tokens,
+                src_lengths,
+                prev_token,
+                prev_scores,
+                attn_weights,
+                prev_hypos_indices,
+                torch.LongTensor([20]),
+            ),
+            f,
+            export_params=True,
+            verbose=False,
+            example_outputs=outs,
+        )
 
         torch.onnx._export_to_pretty_string(
             bs,
-            (src_tokens, src_lengths, prev_token, prev_scores, attn_weights,
-             prev_hypos_indices, torch.LongTensor([20])),
-            f, export_params=True, verbose=False, example_outputs=outs)
+            (
+                src_tokens,
+                src_lengths,
+                prev_token,
+                prev_scores,
+                attn_weights,
+                prev_hypos_indices,
+                torch.LongTensor([20]),
+            ),
+            f,
+            export_params=True,
+            verbose=False,
+            example_outputs=outs,
+        )
 
         f.seek(0)
         import onnx
+
         onnx_model = onnx.load(f)
         c2_model = caffe2_backend.prepare(onnx_model)
-        c2_model.run((src_tokens.numpy(), src_lengths.numpy(),
-                      prev_token.numpy(), prev_scores.numpy(),
-                      attn_weights.numpy(), prev_hypos_indices.numpy(),
-                      np.array([20])))
+        c2_model.run(
+            (
+                src_tokens.numpy(),
+                src_lengths.numpy(),
+                prev_token.numpy(),
+                prev_scores.numpy(),
+                attn_weights.numpy(),
+                prev_hypos_indices.numpy(),
+                np.array([20]),
+            )
+        )
 
-    @unittest.skip('Probably needs updated PyTorch')
+    @unittest.skip("Probably needs updated PyTorch")
     def test_full_beam_decoder(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         self._test_full_beam_decoder(test_args)

--- a/pytorch_translate/test/test_train.py
+++ b/pytorch_translate/test/test_train.py
@@ -22,37 +22,31 @@ class TestRNNModel(unittest.TestCase):
     def test_gpu_train_step(self):
         test_args = test_utils.ModelParamsDict()
         trainer, _ = self._gpu_train_step(test_args)
-        assert trainer.get_meter('gnorm').avg > 0
+        assert trainer.get_meter("gnorm").avg > 0
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_gpu_freeze_embedding(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_freeze_embed=True,
-            decoder_freeze_embed=True,
+            encoder_freeze_embed=True, decoder_freeze_embed=True
         )
         self._gpu_train_step(test_args)
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_milstm_cell(self):
-        test_args = test_utils.ModelParamsDict(
-            cell_type='milstm',
-        )
+        test_args = test_utils.ModelParamsDict(cell_type="milstm")
         trainer, _ = self._gpu_train_step(test_args)
-        assert trainer.get_meter('gnorm').avg > 0
+        assert trainer.get_meter("gnorm").avg > 0
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_sequence_lstm_encoder(self):
         test_args = test_utils.ModelParamsDict(
-            encoder_bidirectional=True,
-            sequence_lstm=True,
+            encoder_bidirectional=True, sequence_lstm=True
         )
         trainer, _ = self._gpu_train_step(test_args)
-        assert trainer.get_meter('gnorm').avg > 0
+        assert trainer.get_meter("gnorm").avg > 0
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_layer_norm_lstm_cell(self):
-        test_args = test_utils.ModelParamsDict(
-            cell_type='layer_norm_lstm',
-        )
+        test_args = test_utils.ModelParamsDict(cell_type="layer_norm_lstm")
         trainer, _ = self._gpu_train_step(test_args)
-        assert trainer.get_meter('gnorm').avg > 0
+        assert trainer.get_meter("gnorm").avg > 0

--- a/pytorch_translate/test/test_word_dropout.py
+++ b/pytorch_translate/test/test_word_dropout.py
@@ -9,14 +9,11 @@ from pytorch_translate.test import utils as test_utils
 class TestWordDropout(unittest.TestCase):
     def test_apply_probabilistic_unking(self):
         word_dropout_params = {
-            'word_dropout_freq_threshold': 3,
-            'word_dropout_smoothing_alpha': 1,
+            "word_dropout_freq_threshold": 3,
+            "word_dropout_smoothing_alpha": 1,
         }
-        test_args = test_utils.ModelParamsDict(
-            cell_type='rnn',
-        )
+        test_args = test_utils.ModelParamsDict(cell_type="rnn")
         test_args.word_dropout_params = word_dropout_params
         samples, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
-        word_dropout_module = \
-            word_dropout.WordDropout(src_dict, word_dropout_params)
+        word_dropout_module = word_dropout.WordDropout(src_dict, word_dropout_params)
         word_dropout_module.apply_probabilistic_unking(3)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -10,10 +10,9 @@ from pytorch_translate import dictionary as pytorch_translate_dictionary
 
 
 class ModelParamsDict:
-
     def __init__(
         self,
-        cell_type='lstm',
+        cell_type="lstm",
         encoder_bidirectional=False,
         encoder_freeze_embed=False,
         decoder_freeze_embed=False,
@@ -21,7 +20,7 @@ class ModelParamsDict:
         sequence_lstm=False,
     ):
         # Model params
-        self.arch = 'rnn'
+        self.arch = "rnn"
         self.encoder_embed_dim = 10
         self.encoder_freeze_embed = encoder_freeze_embed
         self.encoder_hidden_dim = 10
@@ -37,19 +36,19 @@ class ModelParamsDict:
         self.dropout = 0
         self.decoder_dropout_in = 0
         self.decoder_dropout_out = 0
-        self.attention_type = 'dot'
+        self.attention_type = "dot"
         self.residual_level = None
         self.averaging_encoder = False
         self.cell_type = cell_type
         self.sequence_lstm = sequence_lstm
         # Training params
-        self.criterion = 'cross_entropy'
+        self.criterion = "cross_entropy"
         self.lr = [0.1]
-        self.optimizer = 'sgd'
+        self.optimizer = "sgd"
         self.momentum = 0
         self.label_smoothing_epsilon = None
         self.weight_decay = 0.0
-        self.lr_scheduler = 'fixed'
+        self.lr_scheduler = "fixed"
         self.force_anneal = 0
         self.lr_shrink = 0
         self.sentence_avg = True
@@ -61,7 +60,6 @@ class ModelParamsDict:
 
 
 class TestDataset(torch.utils.data.Dataset):
-
     def __init__(self, data):
         super().__init__()
         self.data = data
@@ -73,15 +71,12 @@ class TestDataset(torch.utils.data.Dataset):
         return len(self.data)
 
 
-def dummy_dictionary(
-    dummy_tokens=3,
-    additional_token_list=None,
-):
+def dummy_dictionary(dummy_tokens=3, additional_token_list=None):
     """First adds the amount of dummy_tokens that you specify, then
     finally the additional_token_list, which is a list of string token values"""
     d = pytorch_translate_dictionary.Dictionary()
     for i in range(dummy_tokens):
-        token = f'token_{i}'
+        token = f"token_{i}"
         d.add_symbol(token)
     if additional_token_list is not None:
         for token in additional_token_list:
@@ -91,43 +86,35 @@ def dummy_dictionary(
 
 
 def prepare_inputs(
-    test_args,
-    source_vocab_size=103,
-    target_vocab_size=103,
-    is_variable_seqlen=False,
+    test_args, source_vocab_size=103, target_vocab_size=103, is_variable_seqlen=False
 ):
     # first 100 indices are reserved for special tokens
     src_dict = dummy_dictionary(dummy_tokens=source_vocab_size - 100)
     tgt_dict = dummy_dictionary(dummy_tokens=source_vocab_size - 100)
 
-    def get_single_example(
-        sample_id,
-        src_sentence_length,
-        tgt_sentence_length,
-    ):
+    def get_single_example(sample_id, src_sentence_length, tgt_sentence_length):
         non_special_start = 4
         example = {
-            'id': sample_id,
+            "id": sample_id,
             # Note: both source and target-side sentences are expected
             # to end in the EOS marker. LanguagePairDataset then:
             # (1) moves the EOS to the start of the target, for input feeding
             # (2) it also handles left (right) padding of the source (target)
-            'source': torch.LongTensor(
+            "source": torch.LongTensor(
                 np.random.randint(
                     low=non_special_start,
                     high=len(src_dict.symbols),
                     size=src_sentence_length,
                 ).tolist()
-                + [src_dict.eos()],
+                + [src_dict.eos()]
             ),
-
-            'target': torch.LongTensor(
+            "target": torch.LongTensor(
                 np.random.randint(
                     low=non_special_start,
                     high=len(tgt_dict.symbols),
                     size=tgt_sentence_length,
                 ).tolist()
-                + [tgt_dict.eos()],
+                + [tgt_dict.eos()]
             ),
         }
         return example
@@ -135,25 +122,24 @@ def prepare_inputs(
     min_sent_len = 7
     max_sent_len = 12
     fixed_tgt_length = 12
-    dataset = TestDataset([
-        get_single_example(
-            example_id,
-            np.random.randint(
-                low=min_sent_len,
-                high=max_sent_len,
-                size=1,
-            ) if is_variable_seqlen else 10,
-            fixed_tgt_length,
-        ) for example_id in range(test_args.batch_size)
-    ])
+    dataset = TestDataset(
+        [
+            get_single_example(
+                example_id,
+                np.random.randint(low=min_sent_len, high=max_sent_len, size=1)
+                if is_variable_seqlen
+                else 10,
+                fixed_tgt_length,
+            )
+            for example_id in range(test_args.batch_size)
+        ]
+    )
     dataloader = torch.utils.data.DataLoader(
         dataset,
         batch_size=test_args.batch_size,
         collate_fn=(
             lambda samples: data.LanguagePairDataset.collate(
-                samples,
-                src_dict.pad(),
-                src_dict.eos(),
+                samples, src_dict.pad(), src_dict.eos()
             )
         ),
     )
@@ -162,32 +148,30 @@ def prepare_inputs(
 
 
 def create_lexical_dictionaries():
-    lexical_dictionary_path = write_lines_to_temp_file([
-        'a A 0.7',
-        'a B 0.3',
-        'b C 0.1',
-        'b D 0.8',
-        'b E 0.1',
-        'c A 0.3',
-        'c B 0.4',
-        'c C 0.3',
-        'd D 0.4',
-        'd E 0.3',
-        'd A 0.2',
-        'd B 0.1',
-        'e C 1.0',
-    ])
+    lexical_dictionary_path = write_lines_to_temp_file(
+        [
+            "a A 0.7",
+            "a B 0.3",
+            "b C 0.1",
+            "b D 0.8",
+            "b E 0.1",
+            "c A 0.3",
+            "c B 0.4",
+            "c C 0.3",
+            "d D 0.4",
+            "d E 0.3",
+            "d A 0.2",
+            "d B 0.1",
+            "e C 1.0",
+        ]
+    )
     return [lexical_dictionary_path]
 
 
 def write_lines_to_temp_file(lines):
-    temp_file = tempfile.NamedTemporaryFile(
-        mode='w',
-        delete=False,
-        dir='/tmp'
-    )
+    temp_file = tempfile.NamedTemporaryFile(mode="w", delete=False, dir="/tmp")
     temp_file_path = temp_file.name
     temp_file.close()
-    with codecs.open(temp_file_path, 'w', 'utf-8') as temp_file:
-        temp_file.write('\n'.join(lines) + '\n')
+    with codecs.open(temp_file_path, "w", "utf-8") as temp_file:
+        temp_file.write("\n".join(lines) + "\n")
     return temp_file_path


### PR DESCRIPTION
Summary: Applying black auto-formatting to Python test files in order to avoid creating noise on other diffs.

Differential Revision: D8244964
