### PR TITLE
Component-based Multilingual NMT

### DIFF
--- a/pytorch_translate/dictionary.py
+++ b/pytorch_translate/dictionary.py
@@ -81,7 +81,7 @@ class Dictionary(dictionary.Dictionary):
     @classmethod
     def build_vocab_file(
         cls,
-        corpus_file: str,
+        corpus_files: List[str],
         vocab_file: str,
         max_vocab_size: int,
         tokens_with_penalty: Optional[str] = None,
@@ -90,9 +90,10 @@ class Dictionary(dictionary.Dictionary):
         d = cls()
 
         tokenize = char_tokenize if is_char_vocab else tokenizer.tokenize_line
-        tokenizer.Tokenizer.add_file_to_dictionary(
-            filename=corpus_file, dict=d, tokenize=tokenize
-        )
+        for corpus_file in corpus_files:
+            tokenizer.Tokenizer.add_file_to_dictionary(
+                filename=corpus_file, dict=d, tokenize=tokenize
+            )
 
         # Set indices to receive penalty
         if tokens_with_penalty:
@@ -123,7 +124,7 @@ class Dictionary(dictionary.Dictionary):
     @classmethod
     def build_vocab_file_if_nonexistent(
         cls,
-        corpus_file: str,
+        corpus_files: List[str],
         vocab_file: str,
         max_vocab_size: int,
         tokens_with_penalty: Optional[str] = None,
@@ -142,7 +143,7 @@ class Dictionary(dictionary.Dictionary):
             "Creating new vocab file at that path."
         )
         return cls.build_vocab_file(
-            corpus_file=corpus_file,
+            corpus_files=corpus_files,
             vocab_file=vocab_file,
             max_vocab_size=max_vocab_size,
             tokens_with_penalty=tokens_with_penalty,
@@ -160,3 +161,25 @@ class CharDictionary(Dictionary):
         self.eow_index = self.add_symbol("<eow>")
         self.word_delim_index = self.add_symbol(word_delim)
         self.nspecial += 3
+
+
+class MaxVocabDictionary(Dictionary):
+    """This dictionary takes the form of the largest dictionary supplied via push()."""
+
+    def push(self, d: Dictionary):
+        if len(d) > len(self):
+            self.copy_from(d)
+
+    def copy_from(self, d: dictionary.Dictionary):
+        """Makes self a shallow copy of d."""
+        self.unk_word = d.unk_word
+        self.pad_word = d.pad_word
+        self.eos_word = d.eos_word
+        self.symbols = d.symbols
+        self.count = d.count
+        self.indices = d.indices
+        self.pad_index = d.pad_index
+        self.eos_index = d.eos_index
+        self.unk_index = d.unk_index
+        self.nspecial = d.nspecial
+        self.lexicon_indices = d.lexicon_indices

--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -216,6 +216,26 @@ def get_parser_with_args():
         metavar="FILE",
         help="Path to text file to store the output of the model. ",
     )
+    generation_group.add_argument(
+        "--multiling-source-lang-id",
+        type=int,
+        default=None,
+        help=(
+            "Must be set for decoding with multilingual models. Set to i if "
+            "the source language is the i-th language in the training parameter "
+            "--multiling-encoder-lang (0-indexed)"
+        ),
+    )
+    generation_group.add_argument(
+        "--multiling-target-lang-id",
+        type=int,
+        default=None,
+        help=(
+            "Must be set for decoding with multilingual models. Set to i if "
+            "the target language is the i-th language in the training parameter "
+            "--multiling-decoder-lang (0-indexed)"
+        ),
+    )
 
     return parser
 

--- a/pytorch_translate/multilingual.py
+++ b/pytorch_translate/multilingual.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import torch
+import torch.nn as nn
+from fairseq.models import FairseqEncoder, FairseqIncrementalDecoder
+from pytorch_translate import data as pytorch_translate_data
+
+
+class MultilingualEncoder(FairseqEncoder):
+    """Multilingual encoder.
+
+    This encoder consists of n separate encoders. A language token ID at the
+    begin of the source sentence selects the encoder to use.
+    """
+
+    def __init__(self, dictionary, encoders, hidden_dim, num_layers):
+        super().__init__(dictionary)
+        self.dictionary = dictionary
+        self.encoders = nn.ModuleList(encoders)
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+
+    def forward(self, src_tokens, src_lengths):
+        # Fetch language IDs and remove them from src_tokens
+        # Language IDs are on the right
+        lang_ids = (
+            src_tokens[:, -1] - pytorch_translate_data.MULTILING_DIALECT_ID_OFFSET
+        )
+        src_tokens = src_tokens[:, :-1]
+        src_lengths -= 1
+        # Create tensors for collecting encoder outputs
+        bsz, seq_len = src_tokens.size()[:2]
+        all_encoder_outs = torch.zeros(seq_len, bsz, self.hidden_dim).cuda()
+        all_final_hidden = torch.zeros(self.num_layers, bsz, self.hidden_dim).cuda()
+        all_final_cell = torch.zeros(self.num_layers, bsz, self.hidden_dim).cuda()
+        # We cannot use zeros_like() for src_lengths because dtype changes
+        # from LongInt to Int
+        all_src_lengths = torch.zeros(bsz, dtype=torch.int).cuda()
+        all_src_tokens = torch.zeros_like(src_tokens)
+        for lang_id, encoder in enumerate(self.encoders):
+            indices = torch.nonzero(lang_ids == lang_id)
+            lang_bsz = indices.size(0)
+            if lang_bsz == 0:  # Language not in this batch
+                for p in encoder.parameters():
+                    p.grad = torch.zeros_like(p.data)
+                continue
+            indices = indices.squeeze(1)
+            (
+                lang_encoder_outs,
+                lang_final_hidden,
+                lang_final_cell,
+                lang_src_lengths,
+                lang_src_tokens,
+            ) = encoder(src_tokens[indices], src_lengths[indices])
+            lang_seq_len = lang_encoder_outs.size(0)
+            all_encoder_outs[:lang_seq_len, indices, :] = lang_encoder_outs
+            all_final_hidden[:, indices, :] = lang_final_hidden
+            all_final_cell[:, indices, :] = lang_final_cell
+            all_src_lengths[indices] = lang_src_lengths
+            all_src_tokens[indices] = lang_src_tokens
+        return (
+            all_encoder_outs,
+            all_final_hidden,
+            all_final_cell,
+            all_src_lengths,
+            all_src_tokens,
+        )
+
+    def max_positions(self):
+        """Maximum input length supported by the encoder."""
+        return int(1e5)  # an arbitrary large number
+
+
+class MultilingualDecoder(FairseqIncrementalDecoder):
+    """Multilingual decoder."""
+
+    def __init__(self, dictionary, decoders, hidden_dim):
+        super().__init__(dictionary)
+        self.decoders = nn.ModuleList(decoders)
+        self.hidden_dim = hidden_dim
+        self.max_vocab_size = max(len(d.dictionary) for d in decoders)
+
+    def forward(
+        self,
+        input_tokens,
+        encoder_out,
+        incremental_state=None,
+        possible_translation_tokens=None,
+    ):
+        if input_tokens.size(1) <= 1:
+            # This happens in the first time step of beam search. We return
+            # flat scores, and wait for the real work in the next time step
+            bsz = input_tokens.size(0)
+            return (
+                torch.zeros(bsz, 1, self.max_vocab_size).cuda(),
+                torch.zeros(bsz, 1, encoder_out[0].size(0)).cuda(),
+                None,
+            )
+        # Vocab reduction not implemented
+        assert possible_translation_tokens is None
+        # Fetch language IDs and remove them from input_tokens
+        # Token sequences start with <GO-token> <lang-id> ...
+        lang_ids = (
+            input_tokens[:, 1] - pytorch_translate_data.MULTILING_DIALECT_ID_OFFSET
+        )
+        if input_tokens.size(1) > 2:
+            input_tokens = torch.cat([input_tokens[:, :1], input_tokens[:, 2:]], dim=1)
+        else:
+            input_tokens = input_tokens[:, :1]
+
+        bsz, seq_len = input_tokens.size()[:2]
+        if incremental_state is None:
+            incremental_state = {lang_id: None for lang_id in range(len(self.decoders))}
+        else:
+            seq_len = 1
+        # Create tensors for collecting encoder outputs
+        # +1 for language ID
+        all_logits = torch.zeros(bsz, seq_len + 1, self.max_vocab_size).cuda()
+        all_attn_scores = torch.zeros(bsz, seq_len, encoder_out[0].size(0)).cuda()
+        for lang_id, decoder in enumerate(self.decoders):
+            if lang_id not in incremental_state:
+                incremental_state[lang_id] = {}
+            indices = torch.nonzero(lang_ids == lang_id)
+            lang_bsz = indices.size(0)
+            if lang_bsz == 0:  # Language not in this batch
+                for p in decoder.parameters():
+                    p.grad = torch.zeros_like(p.data)
+                continue
+            indices = indices.squeeze(1)
+            max_source_length = torch.max(encoder_out[3][indices])
+            lang_encoder_out = (
+                encoder_out[0][:max_source_length, indices, :],
+                encoder_out[1][:, indices, :],
+                encoder_out[2][:, indices, :],
+                encoder_out[3][indices],
+                encoder_out[4][indices, :max_source_length],
+            )
+
+            lang_logits, lang_attn_scores, _ = decoder(
+                input_tokens[indices], lang_encoder_out, incremental_state[lang_id]
+            )
+            all_attn_scores[indices, :, :max_source_length] = lang_attn_scores
+            all_logits[indices, 1:, : lang_logits.size(2)] = lang_logits
+        return all_logits, all_attn_scores, None
+
+    def reorder_incremental_state(self, incremental_state, new_order):
+        """Reorder buffered internal state (for incremental generation)."""
+        if not incremental_state:
+            return
+        for lang_id, decoder in enumerate(self.decoders):
+            decoder.reorder_incremental_state(incremental_state[lang_id], new_order)
+
+    def max_positions(self):
+        """Maximum output length supported by the decoder."""
+        return int(1e5)  # an arbitrary large number

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -201,6 +201,97 @@ def add_preprocessing_args(parser):
     )
 
     group.add_argument(
+        "--multiling-encoder-lang",
+        action="append",
+        metavar="SRC",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify a list of encoder languages. The multilingual model contains "
+        "a separate encoder for each language in this list.",
+    )
+    group.add_argument(
+        "--multiling-decoder-lang",
+        action="append",
+        metavar="TARGET",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify a list of decoder languages. The multilingual model contains "
+        "a separate decoder for each language in this list.",
+    )
+    group.add_argument(
+        "--multiling-source-lang",
+        action="append",
+        metavar="SRC",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify a list of corpus source languages, where the n-th language is "
+        "the source language of the n-th training corpus. Each entry must be "
+        "in --multiling-encoder-lang.",
+    )
+    group.add_argument(
+        "--multiling-target-lang",
+        action="append",
+        metavar="TARGET",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify a list of corpus target languages, where the n-th language is "
+        "the target language of the n-th training corpus. Each entry must be "
+        "in --multiling-decoder-lang.",
+    )
+    group.add_argument(
+        "--multiling-source-vocab-file",
+        action="append",
+        metavar="FILE",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify the path to the dictionary for the n-th entry in "
+        "--multiling-encoder-lang",
+    )
+    group.add_argument(
+        "--multiling-target-vocab-file",
+        action="append",
+        metavar="FILE",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify the path to the dictionary for the n-th entry in "
+        "--multiling-decoder-lang",
+    )
+    group.add_argument(
+        "--multiling-train-source-text-file",
+        action="append",
+        metavar="FILE",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify paths to training source samples. The n-th entry should be "
+        "in the n-th language in --multiling-source-lang.",
+    )
+    group.add_argument(
+        "--multiling-train-target-text-file",
+        action="append",
+        metavar="FILE",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify paths to training target samples. The n-th entry should be "
+        "in the n-th language in --multiling-target-lang.",
+    )
+    group.add_argument(
+        "--multiling-train-oversampling",
+        action="append",
+        type=int,
+        help="For multilingual models only. Use this argument repeatedly to "
+        "oversample corpora. The n-th training corpus is oversampled by the n-"
+        "the entry. No oversampling if not specified.",
+    )
+    group.add_argument(
+        "--multiling-eval-source-text-file",
+        action="append",
+        metavar="FILE",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify paths to eval source samples. The n-th entry should be "
+        "in the n-th language in --multiling-source-lang.",
+    )
+    group.add_argument(
+        "--multiling-eval-target-text-file",
+        action="append",
+        metavar="FILE",
+        help="For multilingual models only. Use this argument repeatedly to "
+        "specify paths to eval target samples. The n-th entry should be "
+        "in the n-th language in --multiling-target-lang.",
+    )
+
+    group.add_argument(
         "--penalized-target-tokens-file",
         default="",
         metavar="FILE",

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -319,10 +319,26 @@ def add_preprocessing_args(parser):
 
 def validate_preprocessing_args(args):
     if not (
-        (args.train_source_text_file or args.train_source_binary_path)
-        and (args.train_target_text_file or args.train_target_binary_path)
-        and (args.eval_source_text_file or args.eval_source_binary_path)
-        and (args.eval_target_text_file or args.eval_target_binary_path)
+        (
+            args.train_source_text_file
+            or args.train_source_binary_path
+            or args.multiling_train_source_text_file
+        )
+        and (
+            args.train_target_text_file
+            or args.train_target_binary_path
+            or args.multiling_train_target_text_file
+        )
+        and (
+            args.eval_source_text_file
+            or args.eval_source_binary_path
+            or args.multiling_eval_source_text_file
+        )
+        and (
+            args.eval_target_text_file
+            or args.eval_target_binary_path
+            or args.multiling_eval_target_text_file
+        )
     ):
         raise ValueError(
             "At least one of --*_text_file or --*_binary_path flags must be "

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import tempfile
-from typing import Optional
+from typing import Optional, List
 
 from pytorch_translate import char_data
 from pytorch_translate import data as pytorch_translate_data
@@ -13,10 +13,26 @@ from pytorch_translate.dictionary import Dictionary
 
 def validate_args(args):
     if not (
-        (args.train_source_text_file or args.train_source_binary_path)
-        and (args.train_target_text_file or args.train_target_binary_path)
-        and (args.eval_source_text_file or args.eval_source_binary_path)
-        and (args.eval_target_text_file or args.eval_target_binary_path)
+        (
+            args.train_source_text_file
+            or args.train_source_binary_path
+            or args.multiling_train_source_text_file
+        )
+        and (
+            args.train_target_text_file
+            or args.train_target_binary_path
+            or args.multiling_train_target_text_file
+        )
+        and (
+            args.eval_source_text_file
+            or args.eval_source_binary_path
+            or args.multiling_eval_source_text_file
+        )
+        and (
+            args.eval_target_text_file
+            or args.eval_target_binary_path
+            or args.multiling_eval_target_text_file
+        )
     ):
         raise ValueError(
             "At least one of --*_text_file or --*_binary_path flags must be "
@@ -45,6 +61,19 @@ def validate_args(args):
             )
 
 
+def maybe_generate_temp_file_path(output_path=None):
+    if not output_path:
+        fd, output_path = tempfile.mkstemp()
+        # We only need a unique file name since the helper functions
+        # take care of actually creating the file.
+        os.close(fd)
+    # numpy silently appends this suffix if it is not present, so this ensures
+    # that the correct path is returned
+    if not output_path.endswith(".npz"):
+        output_path += ".npz"
+    return output_path
+
+
 def binarize_text_file(
     text_file: str,
     dictionary: Dictionary,
@@ -54,16 +83,7 @@ def binarize_text_file(
     use_char_data: bool = False,
     char_dictionary: Optional[Dictionary] = None,
 ) -> str:
-    if not output_path:
-        fd, output_path = tempfile.mkstemp()
-        # We only need the file name.
-        os.close(fd)
-
-    # numpy silently appends this suffix if it is not present, so this ensures
-    # that the correct path is returned
-    if not output_path.endswith(".npz"):
-        output_path += ".npz"
-
+    output_path = maybe_generate_temp_file_path(output_path)
     if use_char_data:
         dataset = char_data.InMemoryNumpyWordCharDataset()
         dataset.parse(
@@ -77,16 +97,74 @@ def binarize_text_file(
         dataset = pytorch_translate_data.InMemoryNumpyDataset()
         dataset.parse(text_file, dictionary, reverse_order, append_eos)
     dataset.save(output_path)
+    return output_path
 
+
+def make_multiling_corpus_configs(
+    language_ids, text_files, dictionaries, oversampling_rates=None
+):
+    if not oversampling_rates:
+        oversampling_rates = [1] * len(language_ids)
+    assert len(language_ids) == len(text_files)
+    assert len(language_ids) == len(dictionaries)
+    assert len(language_ids) == len(oversampling_rates)
+    return [
+        pytorch_translate_data.MultilingualCorpusConfig(
+            dialect_id=i + pytorch_translate_data.MULTILING_DIALECT_ID_OFFSET,
+            data_file=p,
+            dict=d,
+            oversampling=o,
+        )
+        for i, p, d, o in zip(
+            language_ids, text_files, dictionaries, oversampling_rates
+        )
+    ]
+
+
+def binarize_text_file_multilingual(
+    corpus_configs: List[pytorch_translate_data.MultilingualCorpusConfig],
+    output_path: str,
+    append_eos: bool,
+    reverse_order: bool,
+    prepend_language_id: bool,
+) -> str:
+    output_path = maybe_generate_temp_file_path(output_path)
+    dataset = pytorch_translate_data.InMemoryNumpyDataset()
+    dataset.parse_multilingual(
+        corpus_configs,
+        reverse_order=reverse_order,
+        append_eos=append_eos,
+        prepend_language_id=prepend_language_id,
+    )
+    dataset.save(output_path)
     return output_path
 
 
 def preprocess_corpora(args):
+    args.train_source_binary_path = maybe_generate_temp_file_path(
+        args.train_source_binary_path
+    )
+    args.train_target_binary_path = maybe_generate_temp_file_path(
+        args.train_target_binary_path
+    )
+    args.eval_source_binary_path = maybe_generate_temp_file_path(
+        args.eval_source_binary_path
+    )
+    args.eval_target_binary_path = maybe_generate_temp_file_path(
+        args.eval_target_binary_path
+    )
+
     # Additional text preprocessing options could be added here before
     # binarizing.
+    if pytorch_translate_data.is_multilingual(args):
+        preprocess_corpora_multilingual(args)
+    else:
+        preprocess_corpora_bilingual(args)
 
+
+def preprocess_corpora_bilingual(args):
     source_dict = Dictionary.build_vocab_file_if_nonexistent(
-        corpus_file=args.train_source_text_file,
+        corpus_files=[args.train_source_text_file],
         vocab_file=args.source_vocab_file,
         max_vocab_size=args.source_max_vocab_size,
         tokens_with_penalty=None,
@@ -97,7 +175,7 @@ def preprocess_corpora(args):
     char_source_dict = None
     if use_char_source:
         char_source_dict = Dictionary.build_vocab_file_if_nonexistent(
-            corpus_file=args.train_source_text_file,
+            corpus_files=[args.train_source_text_file],
             vocab_file=args.char_source_vocab_file,
             max_vocab_size=args.char_source_max_vocab_size,
             tokens_with_penalty=None,
@@ -125,7 +203,7 @@ def preprocess_corpora(args):
         )
 
     target_dict = Dictionary.build_vocab_file_if_nonexistent(
-        corpus_file=args.train_target_text_file,
+        corpus_files=[args.train_target_text_file],
         vocab_file=args.target_vocab_file,
         max_vocab_size=args.target_max_vocab_size,
         tokens_with_penalty=args.penalized_target_tokens_file,
@@ -156,6 +234,103 @@ def preprocess_corpora(args):
             append_eos=True,
             reverse_order=False,
         )
+
+
+def build_vocab_multicorpus(
+    corpus_langs,
+    corpus_files,
+    vocab_langs,
+    vocab_files,
+    max_vocab_size,
+    tokens_with_penalty=None,
+):
+    lang2corpus = {lang: [] for lang in vocab_langs}
+    for lang, corpus_file in zip(corpus_langs, corpus_files):
+        lang2corpus[lang].append(corpus_file)
+    return {
+        lang: Dictionary.build_vocab_file_if_nonexistent(
+            corpus_files=lang2corpus[lang],
+            vocab_file=vocab_file,
+            max_vocab_size=max_vocab_size,
+            tokens_with_penalty=tokens_with_penalty,
+        )
+        for lang, vocab_file in zip(vocab_langs, vocab_files)
+    }
+
+
+def preprocess_corpora_multilingual(args):
+    source_dicts = build_vocab_multicorpus(
+        args.multiling_source_lang,
+        args.multiling_train_source_text_file,
+        args.multiling_encoder_lang,
+        args.multiling_source_vocab_file,
+        args.source_max_vocab_size,
+    )
+    source_corpus_lang_ids = [
+        args.multiling_encoder_lang.index(l) for l in args.multiling_source_lang
+    ]
+    source_corpus_dicts = [source_dicts[l] for l in args.multiling_source_lang]
+    binarize_text_file_multilingual(
+        corpus_configs=make_multiling_corpus_configs(
+            source_corpus_lang_ids,
+            args.multiling_train_source_text_file,
+            source_corpus_dicts,
+            args.multiling_train_oversampling,
+        ),
+        output_path=args.train_source_binary_path,
+        append_eos=args.append_eos_to_source,
+        reverse_order=args.reverse_source,
+        prepend_language_id=False,
+    )
+    binarize_text_file_multilingual(
+        corpus_configs=make_multiling_corpus_configs(
+            source_corpus_lang_ids,
+            args.multiling_eval_source_text_file,
+            source_corpus_dicts,
+            args.multiling_train_oversampling,
+        ),
+        output_path=args.eval_source_binary_path,
+        append_eos=args.append_eos_to_source,
+        reverse_order=args.reverse_source,
+        prepend_language_id=False,
+    )
+
+    target_dicts = build_vocab_multicorpus(
+        args.multiling_target_lang,
+        args.multiling_train_target_text_file,
+        args.multiling_decoder_lang,
+        args.multiling_target_vocab_file,
+        args.target_max_vocab_size,
+        args.penalized_target_tokens_file,
+    )
+    target_corpus_lang_ids = [
+        args.multiling_decoder_lang.index(l) for l in args.multiling_target_lang
+    ]
+    target_corpus_dicts = [target_dicts[l] for l in args.multiling_target_lang]
+    binarize_text_file_multilingual(
+        corpus_configs=make_multiling_corpus_configs(
+            target_corpus_lang_ids,
+            args.multiling_train_target_text_file,
+            target_corpus_dicts,
+            args.multiling_train_oversampling,
+        ),
+        output_path=args.train_target_binary_path,
+        append_eos=True,
+        reverse_order=False,
+        prepend_language_id=True,
+    )
+    binarize_text_file_multilingual(
+        corpus_configs=make_multiling_corpus_configs(
+            target_corpus_lang_ids,
+            args.multiling_eval_target_text_file,
+            target_corpus_dicts,
+            args.multiling_train_oversampling,
+        ),
+        output_path=args.eval_target_binary_path,
+        append_eos=True,
+        reverse_order=False,
+        prepend_language_id=True,
+    )
 
 
 def main():

--- a/pytorch_translate/test/test_data.py
+++ b/pytorch_translate/test/test_data.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+import unittest
+import os
+
+from pytorch_translate import data
+from pytorch_translate import dictionary
+from pytorch_translate.test import utils as test_utils
+
+
+class TestInMemoryNumpyDataset(unittest.TestCase):
+    def setUp(self):
+        self.src_txt, self.trg_txt = test_utils.create_test_text_files()
+        self.vocab_file_path = test_utils.make_temp_file()
+        self.d = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[self.src_txt, self.trg_txt],
+            vocab_file=self.vocab_file_path,
+            max_vocab_size=0,
+        )
+        # src_ref is reversed, +1 for lua
+        self.src_ref = [
+            [107, 105, 103, 101],
+            [105, 105, 103, 103, 101, 101],
+            [103, 103, 103, 103, 101, 101, 101, 101],
+            [101, 101, 101, 101, 101, 101, 101, 101, 101, 101],
+        ]
+        self.trg_ref = [
+            [102, 102, 102, 102, 102, 102, 102, 102, 102, 102],
+            [102, 102, 102, 102, 104, 104, 104, 104],
+            [102, 102, 104, 104, 106, 106],
+            [102, 104, 106, 108],
+        ]
+        self.lua_eos = self.d.eos_index + 1
+        self.num_sentences = 4
+
+    def tearDown(self):
+        os.remove(self.src_txt)
+        os.remove(self.trg_txt)
+        os.remove(self.vocab_file_path)
+
+    def test_parse(self):
+        src_dataset = data.InMemoryNumpyDataset()
+        trg_dataset = data.InMemoryNumpyDataset()
+        for _ in range(2):
+            src_dataset.parse(
+                self.src_txt, self.d, reverse_order=True, append_eos=False
+            )
+            trg_dataset.parse(
+                self.trg_txt, self.d, reverse_order=False, append_eos=True
+            )
+            self.assertEqual(self.num_sentences, len(src_dataset))
+            self.assertEqual(self.num_sentences, len(trg_dataset))
+            for i in range(self.num_sentences):
+                self.assertListEqual(self.src_ref[i], src_dataset[i].tolist())
+                self.assertListEqual(
+                    self.trg_ref[i] + [self.lua_eos], trg_dataset[i].tolist()
+                )
+
+    def test_parse_oversampling(self):
+        dataset = data.InMemoryNumpyDataset()
+        factors = [(1, 0), (3, 2), (4, 4)]
+        for o1, o2 in factors:
+            corpora = [
+                data.MultilingualCorpusConfig(
+                    dialect_id=None,
+                    data_file=self.trg_txt,
+                    dict=self.d,
+                    oversampling=o1,
+                ),
+                data.MultilingualCorpusConfig(
+                    dialect_id=None,
+                    data_file=self.trg_txt,
+                    dict=self.d,
+                    oversampling=o2,
+                ),
+            ]
+            dataset.parse_multilingual(corpora)
+            self.assertEqual((o1 + o2) * self.num_sentences, len(dataset))
+
+    def test_parse_multiling(self):
+        prepend_dataset = data.InMemoryNumpyDataset()
+        append_dataset = data.InMemoryNumpyDataset()
+        corpora = [
+            data.MultilingualCorpusConfig(
+                dialect_id=10, data_file=self.trg_txt, dict=self.d, oversampling=1
+            ),
+            data.MultilingualCorpusConfig(
+                dialect_id=11, data_file=self.trg_txt, dict=self.d, oversampling=1
+            ),
+        ]
+        lang1 = corpora[0].dialect_id + 1  # +1 for lua
+        lang2 = corpora[1].dialect_id + 1  # +1 for lua
+        prepend_dataset.parse_multilingual(
+            corpora, reverse_order=False, append_eos=False, prepend_language_id=True
+        )
+        append_dataset.parse_multilingual(
+            corpora, reverse_order=False, append_eos=False, prepend_language_id=False
+        )
+        self.assertEqual(2 * self.num_sentences, len(prepend_dataset))
+        self.assertEqual(2 * self.num_sentences, len(append_dataset))
+        for i in range(self.num_sentences):
+            self.assertListEqual([lang1] + self.trg_ref[i], prepend_dataset[i].tolist())
+            self.assertListEqual(self.trg_ref[i] + [lang1], append_dataset[i].tolist())
+            self.assertListEqual(
+                [lang2] + self.trg_ref[i],
+                prepend_dataset[i + self.num_sentences].tolist(),
+            )
+            self.assertListEqual(
+                self.trg_ref[i] + [lang2],
+                append_dataset[i + self.num_sentences].tolist(),
+            )

--- a/pytorch_translate/test/test_dictionary.py
+++ b/pytorch_translate/test/test_dictionary.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import unittest
+import os
+
+from pytorch_translate import dictionary
+from pytorch_translate.test import utils as test_utils
+
+
+class TestDictionary(unittest.TestCase):
+    def test_base(self):
+        d = dictionary.Dictionary()
+        self.assertEqual(len(d), d.nspecial)
+
+    def test_build_vocab_file(self):
+        src_txt, trg_txt = test_utils.create_test_text_files()
+        tmp_prefix = test_utils.make_temp_file()
+        src_dict1 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src1", max_vocab_size=1000
+        )
+        src_dict2 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt, src_txt, src_txt],
+            vocab_file=f"{tmp_prefix}.src2",
+            max_vocab_size=1000,
+        )
+        trg_dict1 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[trg_txt], vocab_file=f"{tmp_prefix}.trg1", max_vocab_size=1000
+        )
+        trg_dict2 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[trg_txt, trg_txt, trg_txt],
+            vocab_file=f"{tmp_prefix}.trg2",
+            max_vocab_size=1000,
+        )
+        srctrg_dict = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt, trg_txt],
+            vocab_file=f"{tmp_prefix}.srctrg",
+            max_vocab_size=1000,
+        )
+        nspecial = src_dict1.nspecial
+        self.assertEqual(len(src_dict1), nspecial + 4)
+        self.assertEqual(len(trg_dict1), nspecial + 4)
+        self.assertEqual(len(srctrg_dict), nspecial + 8)
+        for s in src_dict1.symbols:
+            self.assertIn(s, srctrg_dict.symbols)
+        for s in trg_dict1.symbols:
+            self.assertIn(s, srctrg_dict.symbols)
+        src_dict1_loaded = dictionary.Dictionary.load(f"{tmp_prefix}.src1")
+        src_dict2_loaded = dictionary.Dictionary.load(f"{tmp_prefix}.src2")
+        trg_dict1_loaded = dictionary.Dictionary.load(f"{tmp_prefix}.trg1")
+        trg_dict2_loaded = dictionary.Dictionary.load(f"{tmp_prefix}.trg2")
+        self._assert_vocab_equal(src_dict1, src_dict2)
+        self._assert_vocab_equal(src_dict1, src_dict1_loaded)
+        self._assert_vocab_equal(src_dict1, src_dict2_loaded)
+        self._assert_vocab_equal(trg_dict1, trg_dict2)
+        self._assert_vocab_equal(trg_dict1, trg_dict1_loaded)
+        self._assert_vocab_equal(trg_dict1, trg_dict2_loaded)
+        for c in range(nspecial, nspecial + 4):
+            self.assertEqual(src_dict1.count[c], src_dict1_loaded.count[c])
+            self.assertEqual(src_dict2.count[c], src_dict2_loaded.count[c])
+            self.assertEqual(src_dict1.count[c] * 3, src_dict2.count[c])
+            self.assertEqual(trg_dict1.count[c], trg_dict1_loaded.count[c])
+            self.assertEqual(trg_dict2.count[c], trg_dict2_loaded.count[c])
+            self.assertEqual(trg_dict1.count[c] * 3, trg_dict2.count[c])
+        os.remove(f"{tmp_prefix}.src1")
+        os.remove(f"{tmp_prefix}.src2")
+        os.remove(f"{tmp_prefix}.trg1")
+        os.remove(f"{tmp_prefix}.trg2")
+        os.remove(src_txt)
+        os.remove(trg_txt)
+
+    def test_build_vocab_file_max_vocab(self):
+        src_txt, trg_txt = test_utils.create_test_text_files()
+        tmp_prefix = test_utils.make_temp_file()
+        src_dict1 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src1", max_vocab_size=1
+        )
+        src_dict2 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src2", max_vocab_size=2
+        )
+        src_dict3 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src3", max_vocab_size=104
+        )
+        src_dict4 = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src4", max_vocab_size=0
+        )
+        self.assertEqual(src_dict1.nspecial + 1, len(src_dict1))
+        self.assertEqual(src_dict2.nspecial + 2, len(src_dict2))
+        self.assertEqual(src_dict3.nspecial + 4, len(src_dict3))
+        self._assert_vocab_equal(src_dict3, src_dict4)
+        os.remove(f"{tmp_prefix}.src1")
+        os.remove(f"{tmp_prefix}.src2")
+        os.remove(f"{tmp_prefix}.src3")
+        os.remove(f"{tmp_prefix}.src4")
+        os.remove(src_txt)
+        os.remove(trg_txt)
+
+    def _assert_vocab_equal(self, d1, d2):
+        self.assertDictEqual(d1.indices, d2.indices)
+        self.assertSetEqual(d1.lexicon_indices, d2.lexicon_indices)
+        self.assertListEqual(d1.symbols, d2.symbols)
+
+
+class TestMaxVocabDictionary(unittest.TestCase):
+    def test_push(self):
+        max_vocab_dict = dictionary.MaxVocabDictionary()
+        src_txt, trg_txt = test_utils.create_test_text_files()
+        tmp_prefix = test_utils.make_temp_file()
+        src_dict = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src", max_vocab_size=1000
+        )
+        srctrg_dict = dictionary.Dictionary.build_vocab_file(
+            corpus_files=[src_txt, trg_txt],
+            vocab_file=f"{tmp_prefix}.srctrg",
+            max_vocab_size=1000,
+        )
+        self.assertEqual(len(max_vocab_dict), max_vocab_dict.nspecial)
+        max_vocab_dict.push(src_dict)
+        self.assertEqual(len(max_vocab_dict), len(src_dict))
+        max_vocab_dict.push(srctrg_dict)
+        self.assertEqual(len(max_vocab_dict), len(srctrg_dict))
+        max_vocab_dict.push(src_dict)
+        self.assertEqual(len(max_vocab_dict), len(srctrg_dict))
+        os.remove(f"{tmp_prefix}.src")
+        os.remove(f"{tmp_prefix}.srctrg")
+        os.remove(src_txt)
+        os.remove(trg_txt)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -168,10 +168,35 @@ def create_lexical_dictionaries():
     return [lexical_dictionary_path]
 
 
+def create_test_text_files():
+    src = write_lines_to_temp_file(
+        [
+            "srcA srcB srcC srcD",
+            "srcA srcA srcB srcB srcC srcC",
+            "srcA srcA srcA srcA srcB srcB srcB srcB",
+            "srcA srcA srcA srcA srcA srcA srcA srcA srcA srcA",
+        ]
+    )
+    trg = write_lines_to_temp_file(
+        [
+            "trgA trgA trgA trgA trgA trgA trgA trgA trgA trgA",
+            "trgA trgA trgA trgA trgB trgB trgB trgB",
+            "trgA trgA trgB trgB trgC trgC",
+            "trgA trgB trgC trgD",
+        ]
+    )
+    return src, trg
+
+
 def write_lines_to_temp_file(lines):
+    temp_file_path = make_temp_file()
+    with codecs.open(temp_file_path, "w", "utf-8") as temp_file:
+        temp_file.write("\n".join(lines) + "\n")
+    return temp_file_path
+
+
+def make_temp_file():
     temp_file = tempfile.NamedTemporaryFile(mode="w", delete=False, dir="/tmp")
     temp_file_path = temp_file.name
     temp_file.close()
-    with codecs.open(temp_file_path, "w", "utf-8") as temp_file:
-        temp_file.write("\n".join(lines) + "\n")
     return temp_file_path

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -116,6 +116,20 @@ def validate_and_set_default_args(args):
 
     pytorch_translate_options.validate_preprocessing_args(args)
     pytorch_translate_options.validate_generation_args(args)
+    if args.multiling_encoder_lang and not args.multiling_source_vocab_file:
+        args.multiling_source_vocab_file = [
+            pytorch_translate_dictionary.default_dictionary_path(
+                save_dir=args.save_dir, dialect=f"src-{l}"
+            )
+            for l in args.multiling_encoder_lang
+        ]
+    if args.multiling_decoder_lang and not args.multiling_target_vocab_file:
+        args.multiling_target_vocab_file = [
+            pytorch_translate_dictionary.default_dictionary_path(
+                save_dir=args.save_dir, dialect=f"trg-{l}"
+            )
+            for l in args.multiling_decoder_lang
+        ]
 
 
 def setup_training(args):


### PR DESCRIPTION
Summary: This diff makes it possible to jointly train several language pairs. We train separate encoder networks for each source language, and separate decoder networks for each target language. During training, sentences from any corpus (and language pair) are mixed together in a batch, and encoder and decoder networks are selected based on the language IDs.

Differential Revision: D8187615
