### PR TITLE
forced decoder network (onnx export)

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -252,7 +252,7 @@ class DecoderStepEnsemble(nn.Module):
                 prev_hiddens.append(inputs[next_state_input])
                 prev_cells.append(inputs[next_state_input + 1])
                 next_state_input += 2
-            prev_input_feed = inputs[next_state_input].view(1, -1)
+            prev_input_feed = inputs[next_state_input].view((1, -1))
             next_state_input += 1
 
             # no batching, we only care about care about "max" length
@@ -833,6 +833,304 @@ class BeamSearch(torch.jit.ScriptModule):
 
         save_caffe2_rep_to_db(
             caffe2_backend_rep=beam_search,
+            output_path=output_path,
+            input_names=self.input_names,
+            output_names=self.output_names,
+            num_workers=2 * len(self.models),
+        )
+
+
+class KnownOutputDecoderStepEnsemble(nn.Module):
+    def __init__(self, models, word_reward=0, unk_reward=0):
+        super().__init__()
+        self.models = models
+        for i, model in enumerate(self.models):
+            model.decoder.attention.src_length_masking = False
+            self._modules[f"model_{i}"] = model
+
+        self.word_reward = word_reward
+        self.unk_reward = unk_reward
+
+        dst_dict = models[0].dst_dict
+        vocab_size = len(dst_dict.indices)
+        self.word_rewards = torch.FloatTensor(vocab_size).fill_(word_reward)
+        self.word_rewards[dst_dict.eos()] = 0
+        self.word_rewards[dst_dict.unk()] = word_reward + unk_reward
+        self.vocab_size = vocab_size
+        self.unk_token = dst_dict.unk()
+
+    def forward(self, input_token, target_token, timestep, *inputs):
+        """
+        Decoder step inputs correspond one-to-one to encoder outputs.
+        """
+        log_probs_per_model = []
+        state_outputs = []
+
+        next_state_input = len(self.models)
+
+        # underlying assumption is each model has same vocab_reduction_module
+        vocab_reduction_module = self.models[0].decoder.vocab_reduction_module
+        if vocab_reduction_module is not None:
+            possible_translation_tokens = inputs[len(self.models)]
+            next_state_input += 1
+        else:
+            possible_translation_tokens = None
+
+        for i, model in enumerate(self.models):
+            encoder_output = inputs[i]
+            prev_hiddens = []
+            prev_cells = []
+
+            for _ in range(len(model.decoder.layers)):
+                prev_hiddens.append(inputs[next_state_input])
+                prev_cells.append(inputs[next_state_input + 1])
+                next_state_input += 2
+            prev_input_feed = inputs[next_state_input].view(1, -1)
+            next_state_input += 1
+
+            # no batching, we only care about care about "max" length
+            src_length_int = int(encoder_output.size()[0])
+            src_length = torch.LongTensor(np.array([src_length_int]))
+
+            # notional, not actually used for decoder computation
+            src_tokens = torch.LongTensor(np.array([[0] * src_length_int]))
+
+            encoder_out = (
+                encoder_output,
+                prev_hiddens,
+                prev_cells,
+                src_length,
+                src_tokens,
+            )
+
+            # store cached states, use evaluation mode
+            model.decoder._is_incremental_eval = True
+            model.eval()
+
+            # placeholder
+            incremental_state = {}
+
+            # cache previous state inputs
+            utils.set_incremental_state(
+                model.decoder,
+                incremental_state,
+                "cached_state",
+                (prev_hiddens, prev_cells, prev_input_feed),
+            )
+
+            decoder_output = model.decoder(
+                input_token.view(1, 1),
+                encoder_out,
+                incremental_state=incremental_state,
+                possible_translation_tokens=possible_translation_tokens,
+            )
+            logits, _, _ = decoder_output
+
+            log_probs = F.log_softmax(logits, dim=2)
+
+            log_probs_per_model.append(log_probs)
+
+            (next_hiddens, next_cells, next_input_feed) = utils.get_incremental_state(
+                model.decoder, incremental_state, "cached_state"
+            )
+
+            for h, c in zip(next_hiddens, next_cells):
+                state_outputs.extend([h, c])
+            state_outputs.append(next_input_feed)
+
+        average_log_probs = torch.mean(
+            torch.cat(log_probs_per_model, dim=0), dim=0, keepdim=True
+        )
+
+        if possible_translation_tokens is not None:
+            reduced_indices = (
+                torch.zeros(self.vocab_size).long().fill_(self.unk_token)
+            )
+            # ONNX-exportable arange (ATen op)
+            possible_translation_token_range = torch._dim_arange(
+                like=possible_translation_tokens, dim=0
+            )
+            reduced_indices[
+                possible_translation_tokens
+            ] = possible_translation_token_range
+            reduced_index = reduced_indices.index_select(dim=0, index=target_token)
+            score = average_log_probs.view((-1,)).index_select(
+                dim=0, index=reduced_index
+            )
+        else:
+            score = average_log_probs.view((-1,)).index_select(
+                dim=0, index=target_token
+            )
+
+        word_reward = self.word_rewards.index_select(0, target_token)
+        score += word_reward
+
+        self.input_names = ["prev_token", "target_token", "timestep"]
+        for i in range(len(self.models)):
+            self.input_names.append(f"fixed_input_{i}")
+
+        if possible_translation_tokens is not None:
+            self.input_names.append("possible_translation_tokens")
+
+        outputs = [score]
+        self.output_names = ["score"]
+
+        for i in range(len(self.models)):
+            self.output_names.append(f"fixed_input_{i}")
+            outputs.append(inputs[i])
+
+        if possible_translation_tokens is not None:
+            self.output_names.append("possible_translation_tokens")
+            outputs.append(possible_translation_tokens)
+
+        for i, state in enumerate(state_outputs):
+            outputs.append(state)
+            self.output_names.append(f"state_output_{i}")
+            self.input_names.append(f"state_input_{i}")
+
+        return tuple(outputs)
+
+
+class ForcedDecoder(torch.jit.ScriptModule):
+    def __init__(
+        self,
+        model_list,
+        word_reward=0,
+        unk_reward=0,
+    ):
+        super().__init__()
+        self.models = model_list
+        self.word_reward = word_reward
+        self.unk_reward = unk_reward
+
+        source_tokens = torch.LongTensor(np.ones((5, 1), dtype="int64"))
+        source_length = torch.LongTensor([5])
+
+        encoder_ens = EncoderEnsemble(self.models)
+        example_encoder_outs = encoder_ens(source_tokens, source_length)
+        self.encoder_ens = torch.jit.trace(source_tokens, source_length)(encoder_ens)
+        decoder_ens = KnownOutputDecoderStepEnsemble(
+            self.models, word_reward, unk_reward
+        )
+        prev_token = torch.LongTensor([0])
+        target_token = torch.LongTensor([0])
+        ts = torch.LongTensor([0])
+        _, *states = decoder_ens(prev_token, target_token, ts, *example_encoder_outs)
+        self.decoder_ens = torch.jit.trace(
+            prev_token, target_token, ts, *example_encoder_outs
+        )(decoder_ens)
+
+        self.input_names = [
+            "source_tokens",
+            "source_length",
+            "target_tokens",
+            "target_length",
+            "eos_token",
+            "zero",
+        ]
+        self.output_names = ["score"]
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        source_tokens,
+        source_length,
+        target_tokens,
+        target_length,
+        eos_token,
+        zero,
+    ):
+        # EncoderEnsemble expects tokens in sequence_length-first shape
+        source_tokens = source_tokens.view((-1, 1))
+        states = self.encoder_ens(source_tokens, source_length)
+
+        target_tokens = target_tokens.view((1, -1))
+        eos_token = eos_token.view((1, 1))
+        input_tokens = torch.cat([eos_token, target_tokens], dim=1)
+        output_tokens = torch.cat([target_tokens, eos_token], dim=1)
+
+        num_steps = target_length + 1
+        score = zero
+
+        (step_score, *states) = self.decoder_ens(
+            input_tokens.index_select(dim=1, index=0).view((1, 1)),
+            output_tokens.index_select(dim=1, index=0).view((1,)),
+            0,
+            *states,
+        )
+        score += step_score
+
+        for i in range(num_steps - 1):
+            (step_score, *states) = self.decoder_ens(
+                input_tokens.index_select(dim=1, index=i + 1).view((1, 1)),
+                output_tokens.index_select(dim=1, index=i + 1).view((1,)),
+                i + 1,
+                *states,
+            )
+            score += step_score
+
+        return score
+
+    def onnx_export(self, output_path):
+        source_tokens = torch.LongTensor(np.ones((1, 5), dtype="int64"))
+        source_length = torch.LongTensor([5])
+        target_tokens = torch.LongTensor(np.ones((1, 7), dtype="int64"))
+        target_length = torch.LongTensor([7])
+        eos_token = torch.LongTensor([[self.models[0].dst_dict.eos_index]])
+        zero = torch.FloatTensor([0.0])
+
+        input_tuple = (
+            source_tokens,
+            source_length,
+            target_tokens,
+            target_length,
+            eos_token,
+            zero,
+        )
+
+        example_outputs = self.forward(*input_tuple)
+
+        with open(output_path, "w+b") as netdef_file:
+            torch.onnx._export(
+                self,
+                input_tuple,
+                netdef_file,
+                verbose=False,
+                input_names=self.input_names,
+                output_names=self.output_names,
+                example_outputs=example_outputs,
+                export_type=ExportTypes.ZIP_ARCHIVE,
+            )
+
+    @staticmethod
+    def build_from_checkpoints(
+        checkpoint_filenames,
+        src_dict_filename,
+        dst_dict_filename,
+        word_reward=0,
+        unk_reward=0,
+    ):
+        models = load_models_from_checkpoints(
+            checkpoint_filenames, src_dict_filename, dst_dict_filename
+        )
+        return ForcedDecoder(
+            models,
+            word_reward=word_reward,
+            unk_reward=unk_reward,
+        )
+
+    def save_to_db(self, output_path):
+        """
+        Save encapsulated beam search.
+        """
+        tmp_dir = tempfile.mkdtemp()
+        tmp_file = os.path.join(tmp_dir, "forced_decoder.pb")
+        self.onnx_export(tmp_file)
+
+        forced_decoder = caffe2_backend.prepare_zip_archive(tmp_file)
+
+        save_caffe2_rep_to_db(
+            caffe2_backend_rep=forced_decoder,
             output_path=output_path,
             input_names=self.input_names,
             output_names=self.output_names,

--- a/pytorch_translate/onnx_forced_decoder_export.py
+++ b/pytorch_translate/onnx_forced_decoder_export.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import argparse
+
+from pytorch_translate import rnn  # noqa
+from pytorch_translate.ensemble_export import ForcedDecoder
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export pytorch_translate models to caffe2 forced decoder"
+    )
+    parser.add_argument(
+        "--checkpoint",
+        action="append",
+        nargs="+",
+        help="PyTorch checkpoint file (at least one required)",
+    )
+    parser.add_argument(
+        "--output_file",
+        default="",
+        help="File name to which to save forced decoder network",
+    )
+    parser.add_argument(
+        "--src_dict",
+        required=True,
+        help="File encoding PyTorch dictionary for source language",
+    )
+    parser.add_argument(
+        "--dst_dict",
+        required=True,
+        help="File encoding PyTorch dictionary for source language",
+    )
+    parser.add_argument(
+        "--word_reward",
+        type=float,
+        default=0.0,
+        help="Value to add for each word (besides EOS)",
+    )
+    parser.add_argument(
+        "--unk_reward",
+        type=float,
+        default=0.0,
+        help="Value to add for each word UNK token",
+    )
+
+    args = parser.parse_args()
+
+    if args.output_file == "":
+        print("No action taken. Need output_file to be specified.")
+        parser.print_help()
+        return
+
+    checkpoint_filenames = [arg[0] for arg in args.checkpoint]
+
+    forced_decoder = ForcedDecoder.build_from_checkpoints(
+        checkpoint_filenames=checkpoint_filenames,
+        src_dict_filename=args.src_dict,
+        dst_dict_filename=args.dst_dict,
+        word_reward=args.word_reward,
+        unk_reward=args.unk_reward,
+    )
+    forced_decoder.save_to_db(args.output_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
Add networks in ensemble_export.py to create a forced decoding network from PyTorch NMT checkpoints. This network takes an arbitrary numberized (source, target) pair and returns the model score for the translation, including penalties.

Vocabulary reduction networks are also supported, but note that target indices which are not in the possible_translation_tokens generated for the source input will be treated as UNK.

Differential Revision: D8336745
