### PR TITLE
onnx exporter for char_source arch

### DIFF
--- a/pytorch_translate/char_encoder.py
+++ b/pytorch_translate/char_encoder.py
@@ -87,9 +87,10 @@ class CharCNNModel(nn.Module):
         ])
         conv_output_dim = sum(out_dim for (out_dim, _) in self.convolutions_params)
 
-        self.highway_layers = nn.ModuleList(
-            [HighwayLayer(conv_output_dim)] * self.num_highway_layers
-        )
+        highway_layers = []
+        for _ in range(self.num_highway_layers):
+            highway_layers.append(HighwayLayer(conv_output_dim))
+        self.highway_layers = nn.ModuleList(highway_layers)
 
     def forward(self, char_inds_flat):
         x = self.embed_chars(char_inds_flat)


### PR DESCRIPTION
Summary: Class to export encoder models with architecture char_source to Caffe2 via ONNX. Support for this architecture in exporter script to follow. (Currently only character-CNN is supported, but work is ongoing with ONNX developers to add support for character-RNN.)

Reviewed By: xianxl

Differential Revision: D8342074
