### PR TITLE
Flip sign meaning for unk_reward and rename unkpen/unk_penalty->unk_reward, word_penalty->word_reward

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -17,8 +17,8 @@ class SequenceGenerator(torch.nn.Module):
         stop_early=True,
         normalize_scores=True,
         len_penalty=1,
-        unk_penalty=0,
-        lexicon_penalty=0,
+        unk_reward=0,
+        lexicon_reward=0,
         retain_dropout=False,
         word_reward=0,
         model_weights=None,
@@ -60,8 +60,8 @@ class SequenceGenerator(torch.nn.Module):
         self.stop_early = stop_early
         self.normalize_scores = normalize_scores
         self.len_penalty = len_penalty
-        self.unk_penalty = unk_penalty
-        self.lexicon_penalty = lexicon_penalty
+        self.unk_reward = unk_reward
+        self.lexicon_reward = lexicon_reward
         self.lexicon_indices = models[0].dst_dict.lexicon_indices_list()
         self.retain_dropout = retain_dropout
         self.word_reward = word_reward
@@ -306,9 +306,9 @@ class SequenceGenerator(torch.nn.Module):
                 # make probs contain cumulative scores for each hypothesis
                 logprobs.add_(scores[:, step - 1].view(-1, 1))
             logprobs[:, self.pad] = -math.inf  # never select pad
-            logprobs[:, self.unk] -= self.unk_penalty  # apply unk penalty
-            # external lexicon penalty
-            logprobs[:, self.lexicon_indices] -= self.lexicon_penalty
+            logprobs[:, self.unk] += self.unk_reward  # apply unk reward
+            # external lexicon reward
+            logprobs[:, self.lexicon_indices] += self.lexicon_reward
 
             logprobs += self.word_reward
             logprobs[:, self.eos] -= self.word_reward

--- a/pytorch_translate/examples/export_iwslt14.sh
+++ b/pytorch_translate/examples/export_iwslt14.sh
@@ -15,7 +15,7 @@ python3 pytorch_translate/onnx_component_export.py \
     --source-vocab-file model/dictionary-de.txt \
     --target-vocab-file model/dictionary-en.txt \
     --beam-size 6 \
-    --word-penalty 0.25 \
-    --unk-penalty -0.5 \
+    --word-reward 0.25 \
+    --unk-reward -0.5 \
     --batched-beam && \
   echo "Finished exporting encoder as ./encoder.pb and decoder as ./decoder.pb"

--- a/pytorch_translate/examples/generate_iwslt14.sh
+++ b/pytorch_translate/examples/generate_iwslt14.sh
@@ -16,7 +16,7 @@ python3 pytorch_translate/generate.py \
        --target-vocab-file model/dictionary-en.txt \
        --source-text-file data/test.tok.bpe.de \
        --target-text-file data/test.tok.bpe.en \
-       --unkpen 0.5 \
+       --unk-reward -0.5 \
        --lenpen 0 \
        --word-reward 0.25 \
        --beam 6 \
@@ -35,7 +35,7 @@ python3 pytorch_translate/generate.py \
        --target-vocab-file model/dictionary-en.txt \
        --source-text-file data/test.tok.bpe.de \
        --target-text-file data/test.tok.bpe.en \
-       --unkpen 0.5 \
+       --unk-reward -0.5 \
        --lenpen 0 \
        --word-reward 0.25 \
        --beam 6 \

--- a/pytorch_translate/examples/train_iwslt14.sh
+++ b/pytorch_translate/examples/train_iwslt14.sh
@@ -32,7 +32,7 @@ CUDA_VISIBLE_DEVICES=0 python3 pytorch_translate/train.py \
    --label-smoothing 0.1 \
    --batch-size 256 \
    --lenpen 0 \
-   --unkpen 0.5 \
+   --unk-reward -0.5 \
    --word-reward 0.25 \
    --max-tokens 9999999 \
    --encoder-layers 2 \

--- a/pytorch_translate/onnx_component_export.py
+++ b/pytorch_translate/onnx_component_export.py
@@ -49,13 +49,13 @@ def get_parser_with_args():
         help="Number of top candidates returned by each decoder step",
     )
     parser.add_argument(
-        "--word-penalty",
+        "--word-reward",
         type=float,
         default=0.0,
         help="Value to add for each word (besides EOS)",
     )
     parser.add_argument(
-        "--unk-penalty",
+        "--unk-reward",
         type=float,
         default=0.0,
         help="Value to add for each word UNK token",
@@ -105,8 +105,8 @@ def export(args):
             src_dict_filename=args.source_vocab_file,
             dst_dict_filename=args.target_vocab_file,
             beam_size=args.beam_size,
-            word_penalty=args.word_penalty,
-            unk_penalty=args.unk_penalty,
+            word_reward=args.word_reward,
+            unk_reward=args.unk_reward,
         )
 
         # need example encoder outputs to pass through network

--- a/pytorch_translate/onnx_full_export.py
+++ b/pytorch_translate/onnx_full_export.py
@@ -38,13 +38,13 @@ def main():
         help="Number of top candidates returned by each decoder step",
     )
     parser.add_argument(
-        "--word_penalty",
+        "--word_reward",
         type=float,
         default=0.0,
         help="Value to add for each word (besides EOS)",
     )
     parser.add_argument(
-        "--unk_penalty",
+        "--unk_reward",
         type=float,
         default=0.0,
         help="Value to add for each word UNK token",
@@ -64,8 +64,8 @@ def main():
         src_dict_filename=args.src_dict,
         dst_dict_filename=args.dst_dict,
         beam_size=args.beam_size,
-        word_penalty=args.word_penalty,
-        unk_penalty=args.unk_penalty,
+        word_reward=args.word_reward,
+        unk_reward=args.unk_reward,
     )
     beam_search.save_to_db(args.output_file)
 

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -82,8 +82,6 @@ def binarize_text_file(
 
 
 def preprocess_corpora(args):
-    validate_args(args)
-
     # Additional text preprocessing options could be added here before
     # binarizing.
 
@@ -164,6 +162,7 @@ def main():
     parser = argparse.ArgumentParser(description="PyTorch Translate - preprocessing")
     pytorch_translate_options.add_preprocessing_args(parser)
     args = parser.parse_args()
+    pytorch_translate_options.validate_preprocessing_args(args)
     preprocess_corpora(args)
 
 

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -114,7 +114,8 @@ def validate_and_set_default_args(args):
             save_dir=args.save_dir, dialect=args.source_lang
         )
 
-    preprocess.validate_args(args)
+    pytorch_translate_options.validate_preprocessing_args(args)
+    pytorch_translate_options.validate_generation_args(args)
 
 
 def setup_training(args):


### PR DESCRIPTION
Summary:
Also refactors some args flags/args validation code (Move flags used only by standalone generate.py binary to generate.py to avoid confusion regarding some flags with the same name)

```
find . -type f -print0 | xargs -0 sed -i 's/unk_penalty/unk_reward/g'
find . -type f -print0 | xargs -0 sed -i 's/unk-penalty/unk-reward/g'
find . -type f -print0 | xargs -0 sed -i 's/word_penalty/word_reward/g'
find . -type f -print0 | xargs -0 sed -i 's/word-penalty/word-reward/g'
find . -type f -print0 | xargs -0 sed -i 's/lexicon_penalty/lexicon_reward/g'
```

Manually rename unkpen to unk-reward or unk_reward.

Reviewed By: jhcross

Differential Revision: D8386356
