### PR TITLE
fix beam search unit test for char_source

### DIFF
--- a/pytorch_translate/test/test_beam_decode.py
+++ b/pytorch_translate/test/test_beam_decode.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+import numpy as np
 import torch
 import unittest
 
 from fairseq import models
 from pytorch_translate import beam_decode
 from pytorch_translate import rnn  # noqa
+from pytorch_translate import char_source_model  # noqa (must be after rnn)
 from pytorch_translate.test import utils as test_utils
 
 
@@ -18,4 +20,24 @@ class TestBeamDecode(unittest.TestCase):
         translator = beam_decode.SequenceGenerator([model])
         src_tokens = torch.LongTensor([[0, 0, 0], [0, 0, 0]])
         src_lengths = torch.LongTensor([3, 3])
-        translator.generate(src_tokens=src_tokens, src_lengths=src_lengths)
+        encoder_input = (src_tokens, src_lengths)
+        translator.generate(encoder_input, maxlen=7)
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
+    def test_char_rnn_generate(self):
+        test_args = test_utils.ModelParamsDict(sequence_lstm=True)
+        test_args.arch = "char_source"
+        test_args.char_source_dict_size = 126
+        test_args.char_embed_dim = 8
+        test_args.char_rnn_units = 12
+        test_args.char_rnn_layers = 2
+
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        model = models.build_model(test_args, src_dict, tgt_dict)
+        translator = beam_decode.SequenceGenerator([model])
+        src_tokens = torch.LongTensor([[0, 0, 0], [0, 0, 0]])
+        src_lengths = torch.LongTensor([3, 3])
+        char_inds = torch.LongTensor(np.zeros((2, 3, 5)))
+        word_lengths = torch.LongTensor([[5, 5, 5], [5, 5, 5]])
+        encoder_input = (src_tokens, src_lengths, char_inds, word_lengths)
+        translator.generate(encoder_input, maxlen=7)


### PR DESCRIPTION
Summary: D8181361 changed the signature of SequenceGenerator.generate(), breaking the GPU-only unit test_basic_generate (thanks to myleott for catching!). This fixes that call and introduces an analogous test for the char_source architecture.

Differential Revision: D8406814
