### PR TITLE
add back pad_idx and eos_idx

### DIFF
--- a/pytorch_translate/data.py
+++ b/pytorch_translate/data.py
@@ -134,6 +134,8 @@ def make_language_pair_dataset_from_text(
                 reverse_order=reverse_source,
             ),
             dst=dst_dataset,
+            pad_idx=source_dict.pad(),
+            eos_idx=source_dict.eos(),
         )
 
 


### PR DESCRIPTION
Summary: IndexedRawTextDataset constructor needs both pad_idx and eos_idx.

Reviewed By: jhcross

Differential Revision: D8407787
