### PR TITLE
Prefer fairseq<0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
-        'fairseq',
+        'fairseq<0.5.0',
     ],
     dependency_links=[
         "git+https://github.com/pytorch/fairseq.git#egg=fairseq"


### PR DESCRIPTION
We're releasing a new version of fairseq (0.5.0) with some breaking API changes, so let's depend on the old version until the relevant updates are made in pytorch-translate.