### PR TITLE
ONNX export for Character-RNN (#101)

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -12,7 +12,7 @@ import torch.onnx.operators
 from torch.onnx import ExportTypes
 
 from fairseq import utils
-from pytorch_translate import dictionary, rnn  # noqa
+from pytorch_translate import char_source_model, dictionary, rnn  # noqa
 
 from caffe2.python.predictor import predictor_exporter
 from caffe2.python import core, dyndep, workspace
@@ -1143,6 +1143,8 @@ class CharSourceEncoderEnsemble(nn.Module):
         super().__init__()
         self.models = models
         for i, model in enumerate(self.models):
+            if isinstance(model.encoder, char_source_model.CharRNNEncoder):
+                model.encoder.onnx_export_model = True
             self._modules[f"model_{i}"] = model
 
     def forward(self, src_tokens, src_lengths, char_inds, word_lengths):


### PR DESCRIPTION
Summary:
Closes https://github.com/pytorch/translate/pull/101

Enables ONNX export for CharRNNEncoder by short-circuiting the code path with unsupported operations (sort) and tracing an already-sorted (or rather uniform-word-length) example in PyTorch. This should work because ONNX/Caffe2 do not have the constraint that a batch of sequence input to LSTM be sorted in descending order of length.

Reviewed By: xianxl

Differential Revision: D8371501
