### PR TITLE
Initialize individual models in multi-models with checkpoints

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -542,6 +542,17 @@ def expand_generation_args(group, train=False):
                 "checkpoint, beginning after the specified number of epochs. "
             ),
         )
+        group.add_argument(
+            "--multi-model-restore-files",
+            default=None,
+            type=str,
+            nargs="+",
+            help=(
+                "If --multi-encoder = --multi-decoder > 1, this option makes "
+                "it possible to initialize individual model weights from "
+                "existing checkpoints of separate training runs."
+            ),
+        )
     return group
 
 


### PR DESCRIPTION
Summary:
This diff makes it possible to initialize the weights in the encoders and decoders in
an adaptive ensemble using checkpoints from individual training runs.

Differential Revision: D8461140
