### PR TITLE
Tie decoder embeddings

### DIFF
--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -41,6 +41,7 @@ class ModelParamsDict:
         self.averaging_encoder = False
         self.cell_type = cell_type
         self.sequence_lstm = sequence_lstm
+        self.decoder_tie_embeddings = False
         # Training params
         self.criterion = "cross_entropy"
         self.lr = [0.1]


### PR DESCRIPTION
Summary:
Makes it possible to tie the decoder word embeddings and the softmax weights. From my experience this is often helpful especially for small datasets (also this takes less parameters).

Here is a reference for MT (this has been introduced in LM before): https://arxiv.org/abs/1710.01329 (NAACL18)

Differential Revision: D8465257
