### PR TITLE
Implemented prune/retrain as an optional part of training

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -407,6 +407,23 @@ def expand_optimization_args(group):
         "by --generate-bleu-eval-interval in how frequently we run BLEU eval "
         "in the first place. A value of < 0 disables this.",
     )
+    group.add_argument(
+        "--pruning-percentile",
+        type=int,
+        default=0,
+        help="Proportion of weights to prune after initially training to either "
+        "BLEU score stagnation or time limit. A value <=0 disables pruning.",
+    )
+    group.add_argument(
+        "--retrain-lr-ratio",
+        type=float,
+        default=0.0,
+        help="Learning rate for retraining the model after pruning is performed "
+        "relative to learning rate before pruning. Affected by lr scheduler. "
+        "Retraining is not performed if --pruning-percentile is set to disable "
+        "pruning.",
+    )
+
     return group
 
 


### PR DESCRIPTION
Summary:
Added class-blind pruning based on magnitude so that training proceeds as usual, then
upon BLEU/validation stagnation, prunes a set percentage of weights by magnitude, and then retrains
the network with those pruned weights fixed at zero.

Reviewed By: liezl200

Differential Revision: D8426149
