### PR TITLE
remove bad dropout application from CharRNNEncoder

### DIFF
--- a/pytorch_translate/char_source_model.py
+++ b/pytorch_translate/char_source_model.py
@@ -361,11 +361,6 @@ class CharRNNEncoder(FairseqEncoder):
             final_hiddens.append(h_last)
             final_cells.append(c_last)
 
-            if self.dropout_out != 0:
-                current_output = F.dropout(
-                    current_output, p=self.dropout_out, training=self.training
-                )
-
             if self.residual_level is not None and i >= self.residual_level:
                 packed_input[0] = packed_input.clone()[0] + current_output[0]
             else:


### PR DESCRIPTION
Summary: This application of dropout was broken (when dropout nonzero) because input is a PackedSequence. In any case it was a logic error because it's redundant to the dropout already performed within the LSTMSequenceEncoder.LSTM module.

Differential Revision: D8518377
