### PR TITLE
Initialize training state variables

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -273,6 +273,8 @@ def train(args, extra_state, trainer, dataset):
     do_prune = (args.pruning_percentile > 0)
     extra_state["retraining"] = False
     prune_masks = None
+    stop_training_mid_epoch = False
+    stop_training_end_of_epoch = False
     while lr > args.min_lr and extra_state["epoch"] <= max_epoch:
         """Train the model for one epoch."""
 


### PR DESCRIPTION
Summary: Just to be safe, initialize stopping condition variables before training

Reviewed By: xianxl, warut-vijit

Differential Revision: D8593128
