### PR TITLE
More verbosity options for arguments logging

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -360,6 +360,7 @@ def add_args(parser):
 
 def get_parser_with_args():
     parser = options.get_parser("Generation")
+    pytorch_translate_options.add_verbosity_args(parser)
     pytorch_translate_options.add_dataset_args(parser, gen=True)
     generation_group = options.add_generation_args(parser)
     pytorch_translate_options.expand_generation_args(generation_group)
@@ -474,7 +475,7 @@ def validate_args(args):
 
 
 def generate(args):
-    print(args)
+    pytorch_translate_options.print_args(args)
 
     src_dict = pytorch_translate_dictionary.Dictionary.load(args.source_vocab_file)
     dst_dict = pytorch_translate_dictionary.Dictionary.load(args.target_vocab_file)

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -567,3 +567,40 @@ def validate_generation_args(args):
         "--length-penalty instead."
     )
     pass
+
+
+def add_verbosity_args(parser, train=False):
+    verbosity_group = parser.add_argument_group("Verbosity")
+
+    if train:
+        verbosity_group.add_argument(
+            "--log-verbose",
+            action="store_true",
+            help="Whether to output more verbose logs for debugging/profiling.",
+        )
+
+    verbosity_group.add_argument(
+        "--args-verbosity",
+        default=1,
+        type=int,
+        choices=[0, 1, 2],
+        help="Level of verbosity when printing the arguments (0: don't print "
+        "the arguments; 1: print the Namespace object; 2: print all the "
+        "arguments, one per line). The default is 1."
+        "one per line)",
+    )
+    return verbosity_group
+
+
+def print_args(args):
+    args_verbosity = getattr(args, "args_verbosity", 1)
+    if args_verbosity == 2:
+        args_sorted = sorted(vars(args).items())
+        for name, value in args_sorted:
+            print(f"{name}={value}")
+    elif args_verbosity == 1:
+        print(args)
+    elif args_verbosity == 0:
+        return
+    else:
+        raise ValueError("Please specify an argument verbosity level between 0 and 2")

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -342,9 +342,11 @@ def preprocess_corpora_multilingual(args):
 
 def main():
     parser = argparse.ArgumentParser(description="PyTorch Translate - preprocessing")
+    pytorch_translate_options.add_verbosity_args(parser)
     pytorch_translate_options.add_preprocessing_args(parser)
     args = parser.parse_args()
     pytorch_translate_options.validate_preprocessing_args(args)
+    pytorch_translate_options.print_args(args)
     preprocess_corpora(args)
 
 

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -41,11 +41,7 @@ from pytorch_translate.research.knowledge_distillation import (  # noqa
 
 def get_parser_with_args():
     parser = options.get_parser("Trainer")
-    parser.add_argument(
-        "--log-verbose",
-        action="store_true",
-        help="Whether to output more verbose logs for debugging/profiling.",
-    )
+    pytorch_translate_options.add_verbosity_args(parser, train=True)
     pytorch_translate_options.add_dataset_args(parser, train=True, gen=True)
     options.add_distributed_training_args(parser)
     # Adds args related to training (validation and stopping criterions).
@@ -941,5 +937,5 @@ if __name__ == "__main__":
     parser = get_parser_with_args()
     args = options.parse_args_and_arch(parser)
     validate_and_set_default_args(args)
-    print(args)
+    pytorch_translate_options.print_args(args)
     main(args, single_process_main)


### PR DESCRIPTION
Summary:
This adds a `--args-verbosity` for finer-grained control over argument dumping:

- 0: don't print the argument
- 1 **(default)**: dump the `argparse.Namespace` object (original behavior)
- 2: print one parameter per line with the following format: `{name}={value}`

Differential Revision: D8630069
