### PR TITLE
Introduce NoAttention type

### DIFF
--- a/pytorch_translate/attention/__init__.py
+++ b/pytorch_translate/attention/__init__.py
@@ -12,12 +12,12 @@ ATTENTION_REGISTRY = {}
 def build_attention(
     attention_type,
     decoder_hidden_state_dim,
-    encoder_output_dim,
+    context_dim,
     **kwargs
 ):
     return ATTENTION_REGISTRY[attention_type](
         decoder_hidden_state_dim,
-        encoder_output_dim,
+        context_dim,
         **kwargs
     )
 

--- a/pytorch_translate/attention/base_attention.py
+++ b/pytorch_translate/attention/base_attention.py
@@ -4,19 +4,19 @@ import torch.nn as nn
 
 
 class BaseAttention(nn.Module):
-    def __init__(self, decoder_hidden_state_dim, encoder_output_dim):
+    def __init__(self, decoder_hidden_state_dim, context_dim):
         super().__init__()
         self.decoder_hidden_state_dim = decoder_hidden_state_dim
-        self.encoder_output_dim = encoder_output_dim
+        self.context_dim = context_dim
 
     def forward(self, decoder_state, source_hids, src_lengths):
         """
         Input
             decoder_state: bsz x decoder_hidden_state_dim
-            source_hids: srclen x bsz x encoder_output_dim
+            source_hids: srclen x bsz x context_dim
             src_lengths: bsz x 1, actual sequence lengths
         Output
-            output: bsz x encoder_output_dim
+            output: bsz x context_dim
             attn_scores: max_src_len x bsz
         """
         raise NotImplementedError

--- a/pytorch_translate/attention/dot_attention.py
+++ b/pytorch_translate/attention/dot_attention.py
@@ -15,19 +15,19 @@ from pytorch_translate.common_layers import Linear
 @register_attention('dot')
 class DotAttention(BaseAttention):
 
-    def __init__(self, decoder_hidden_state_dim, encoder_output_dim, **kwargs):
-        super().__init__(decoder_hidden_state_dim, encoder_output_dim)
+    def __init__(self, decoder_hidden_state_dim, context_dim, **kwargs):
+        super().__init__(decoder_hidden_state_dim, context_dim)
 
         self.input_proj = None
         force_projection = kwargs.get("force_projection", False)
-        if force_projection or decoder_hidden_state_dim != encoder_output_dim:
+        if force_projection or decoder_hidden_state_dim != context_dim:
             self.input_proj = Linear(
-                decoder_hidden_state_dim, encoder_output_dim, bias=True
+                decoder_hidden_state_dim, context_dim, bias=True
             )
         self.src_length_masking = kwargs.get("src_length_masking", True)
 
     def forward(self, decoder_state, source_hids, src_lengths):
-        # decoder_state: bsz x encoder_output_dim
+        # decoder_state: bsz x context_dim
         if self.input_proj is not None:
             decoder_state = self.input_proj(decoder_state)
         # compute attention

--- a/pytorch_translate/attention/multihead_attention.py
+++ b/pytorch_translate/attention/multihead_attention.py
@@ -137,7 +137,7 @@ class MultiheadAttention(BaseAttention):
     Inputs
       init:
         decoder_hidden_state_dim : dimensionality of decoder hidden state
-        encoder_output_dim : dimensionality of encoder output
+        context_dim : dimensionality of encoder output
         kwargs :
           nheads : integer # of attention heads
           unseen_mask: if True, only attend to previous sequence positions
@@ -156,9 +156,9 @@ class MultiheadAttention(BaseAttention):
     Output
       result : [batch_size, sequence length, d_model]
     """
-    def __init__(self, decoder_hidden_state_dim, encoder_output_dim, **kwargs):
-        super().__init__(decoder_hidden_state_dim, encoder_output_dim)
-        assert decoder_hidden_state_dim == encoder_output_dim
+    def __init__(self, decoder_hidden_state_dim, context_dim, **kwargs):
+        super().__init__(decoder_hidden_state_dim, context_dim)
+        assert decoder_hidden_state_dim == context_dim
         d_model = decoder_hidden_state_dim  # for brevity
         self.nheads = kwargs.get("nheads", 1)
         assert d_model % self.nheads == 0

--- a/pytorch_translate/attention/no_attention.py
+++ b/pytorch_translate/attention/no_attention.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import torch
+from pytorch_translate.attention import BaseAttention, register_attention
+
+
+@register_attention("no")
+class NoAttention(BaseAttention):
+    def __init__(self, decoder_hidden_state_dim, context_dim, **kwargs):
+        super().__init__(decoder_hidden_state_dim, 0)
+
+    def forward(self, decoder_state, source_hids, src_lengths):
+        return None, torch.zeros(1, src_lengths.shape[0])

--- a/pytorch_translate/attention/pooling_attention.py
+++ b/pytorch_translate/attention/pooling_attention.py
@@ -13,13 +13,13 @@ from pytorch_translate.attention import (
 @register_attention('pooling')
 class PoolingAttention(BaseAttention):
 
-    def __init__(self, decoder_hidden_state_dim, encoder_output_dim, **kwargs):
-        super().__init__(decoder_hidden_state_dim, encoder_output_dim)
+    def __init__(self, decoder_hidden_state_dim, context_dim, **kwargs):
+        super().__init__(decoder_hidden_state_dim, context_dim)
 
         self.pool_type = kwargs.get("pool_type", "mean")
 
     def forward(self, decoder_state, source_hids, src_lengths):
-        assert self.decoder_hidden_state_dim == self.encoder_output_dim
+        assert self.decoder_hidden_state_dim == self.context_dim
         max_src_len = source_hids.size()[0]
         assert max_src_len == src_lengths.data.max()
         batch_size = source_hids.size()[1]
@@ -53,19 +53,19 @@ class PoolingAttention(BaseAttention):
 
 @register_attention('max')
 class MaxPoolingAttention(PoolingAttention):
-    def __init__(self, decoder_hidden_state_dim, encoder_output_dim, **kwargs):
+    def __init__(self, decoder_hidden_state_dim, context_dim, **kwargs):
         super().__init__(
             decoder_hidden_state_dim,
-            encoder_output_dim,
+            context_dim,
             pool_type="max",
         )
 
 
 @register_attention('mean')
 class MeanPoolingAttention(PoolingAttention):
-    def __init__(self, decoder_hidden_state_dim, encoder_output_dim, **kwargs):
+    def __init__(self, decoder_hidden_state_dim, context_dim, **kwargs):
         super().__init__(
             decoder_hidden_state_dim,
-            encoder_output_dim,
+            context_dim,
             pool_type="mean",
         )

--- a/pytorch_translate/multi_model.py
+++ b/pytorch_translate/multi_model.py
@@ -295,12 +295,34 @@ class BottleneckStrategy(MultiDecoderCombinationStrategy):
 class BaseWeightedStrategy(MultiDecoderCombinationStrategy):
     """Base class for strategies with explicitly learned weights."""
 
-    def __init__(self, out_embed_dims, vocab_size, vocab_reduction_module=None):
+    def __init__(
+        self,
+        out_embed_dims,
+        vocab_size,
+        vocab_reduction_module=None,
+        hidden_layer_size=32,
+        activation_fn=torch.nn.ReLU,
+        softmax_fn=torch.exp,
+    ):
+        """Initializes a combination strategy with explicit weights.
+
+        Args:
+            out_embed_dims (list): List of output dimensionalities of the
+                decoders.
+            vocab_size (int): Size of the output projection.
+            vocab_reduction_module: For vocabulary reduction
+            hidden_layer_size (int): Size of the hidden layer of the gating
+                network.
+            activation_fn: Non-linearity at the hidden layer.
+            softmax_fn: Function to use for normalization (exp or sigmoid).
+        """
         super().__init__(out_embed_dims, vocab_size, vocab_reduction_module)
-        self.weight_projection = Linear(
-            sum(out_embed_dims), len(out_embed_dims), bias=True
+        self.gating_network = nn.Sequential(
+            Linear(sum(out_embed_dims), hidden_layer_size, bias=True),
+            activation_fn(),
+            Linear(hidden_layer_size, len(out_embed_dims), bias=True),
         )
-        self.activation_fn = torch.nn.Sigmoid()
+        self.softmax_fn = softmax_fn
 
     def compute_weights(self, unprojected_outs, select_single=None):
         """Derive interpolation weights from unprojected decoder outputs.
@@ -319,9 +341,7 @@ class BaseWeightedStrategy(MultiDecoderCombinationStrategy):
             ret = torch.zeros((sz[0], sz[1], len(unprojected_outs))).cuda()
             ret[:, :, select_single] = 1.0
             return ret
-        logits = self.activation_fn(
-            self.weight_projection(torch.cat(unprojected_outs, 2))
-        )
+        logits = self.softmax_fn(self.gating_network(torch.cat(unprojected_outs, 2)))
         return logits / torch.sum(logits, dim=2, keepdim=True)
 
 

--- a/pytorch_translate/test/test_utils.py
+++ b/pytorch_translate/test/test_utils.py
@@ -34,3 +34,29 @@ class TestAverageTensors(unittest.TestCase):
         npt.assert_allclose(
             pytorch_utils.average_tensors([a, b], norm_fn=F.softmax), expected
         )
+
+
+class TestMaybeCat(unittest.TestCase):
+    def test_cat(self):
+        a = torch.IntTensor([[1, 2, 3], [4, 5, 6]])
+        b = torch.IntTensor([[11, 12, 13], [14, 15, 16]])
+        ab = torch.IntTensor([[1, 2, 3, 11, 12, 13], [4, 5, 6, 14, 15, 16]])
+        npt.assert_array_equal(pytorch_utils.maybe_cat([a, b], dim=1), ab)
+        npt.assert_array_equal(
+            pytorch_utils.maybe_cat([a, None, b, None, None], dim=1), ab
+        )
+        npt.assert_array_equal(
+            pytorch_utils.maybe_cat([None, None, a, None], dim=1), a
+        )
+
+    def test_nullable(self):
+        a = torch.IntTensor([[1, 2, 3], [4, 5, 6]])
+        pytorch_utils.maybe_cat([a, None], 1)
+        pytorch_utils.maybe_cat([a, None], 1, nullable=[True, True])
+        pytorch_utils.maybe_cat([a, None], 1, nullable=[False, True])
+        with self.assertRaises(RuntimeError):
+            pytorch_utils.maybe_cat([a, None], 1, nullable=[False, False])
+        with self.assertRaises(RuntimeError):
+            pytorch_utils.maybe_cat([None, None], 1)
+        with self.assertRaises(RuntimeError):
+            pytorch_utils.maybe_cat([], 1)


### PR DESCRIPTION
Summary:
RNNDecoder currently allows attention_type to be None, but setting it to None is not accessible
via command-line, and setting it programmatically crashes.

Introduces a new NoAttention attention type, which is a dummy implementation of `BaseAttention`
for not using any attention. This attention type replaces the attention_type=None use case from before.

We also rename AttentionType.encoder_output_dim to AttentionType.context_dim since it is set to 0 for NoAttention.

Reviewed By: yukatherin

Differential Revision: D8654417
