### PR TITLE
Using LMs and translation models together in adaptive ensembles

### DIFF
--- a/pytorch_translate/multi_model.py
+++ b/pytorch_translate/multi_model.py
@@ -468,6 +468,7 @@ class MultiDecoder(FairseqIncrementalDecoder):
         dst_dict,
         decoders,
         combination_strategy,
+        is_lm=None,
         split_encoder=False,
         vocab_reduction_params=None,
         training_schedule="complete",
@@ -480,13 +481,21 @@ class MultiDecoder(FairseqIncrementalDecoder):
             decoders (list): List of DecoderWithOutputProjection.
             combination_strategy (string): Name of the combination strategy.
                 Passed through to `create_strategy()`.
+            is_lm (list): List of booleans determining whether the n-th
+                decoder is a language model. If None, none of the decoders are
+                considered an LM.
             split_encoder (bool): If true, split encoder output, each decoder
                 gets its own split.
             vocab_reduction_params: For vocabular reduction.
             training_schedule (str): Training strategy.
         """
         super().__init__(dst_dict)
+        if is_lm is None:
+            is_lm = [False] * len(decoders)
         assert not any(decoder.project_output for decoder in decoders)
+        assert len(is_lm) == len(decoders)
+        self.attentive_decoder_ids = [i for i, b in enumerate(is_lm) if not b]
+        self.decoders_is_lm = is_lm
         self.decoders = nn.ModuleList(decoders)
         vocab_reduction_module = None
         if vocab_reduction_params:
@@ -560,7 +569,7 @@ class MultiDecoder(FairseqIncrementalDecoder):
                 )
             )
         mean_attn_scores = average_tensors(
-            [attn_scores for _, attn_scores in decoder_outs if attn_scores is not None]
+            [decoder_outs[decoder_id][1] for decoder_id in self.attentive_decoder_ids]
         )
         select_single = None
         if self.separate_training and not unfreeze_combi_strat:
@@ -575,14 +584,8 @@ class MultiDecoder(FairseqIncrementalDecoder):
         return logits, mean_attn_scores, possible_translation_tokens
 
     def _get_contexts(self, encoder_out):
+        encoder_outs, final_hidden, final_cell, src_lengths, src_tokens = encoder_out
         if self.split_encoder:
-            (
-                encoder_outs,
-                final_hidden,
-                final_cell,
-                src_lengths,
-                src_tokens,
-            ) = encoder_out
             split_encoder_outs = []
             offset = 0
             for decoder in self.decoders:
@@ -598,8 +601,17 @@ class MultiDecoder(FairseqIncrementalDecoder):
                 )
                 offset = next_offset
             assert offset == encoder_outs.size(2)
-            return split_encoder_outs
-        return [encoder_out] * len(self.decoders)
+        else:
+            split_encoder_outs = [encoder_out] * len(self.decoders)
+        if any(self.decoders_is_lm):
+            num_layers, bsz, _ = final_cell.size()
+            ones = torch.ones((num_layers, bsz, 1)).type_as(final_cell)
+            dummy_out = torch.ones((1, bsz, 1)).type_as(final_cell)
+            lm_encoder_outs = dummy_out, ones, ones, src_lengths, src_tokens
+            for decoder_id, is_lm in enumerate(self.decoders_is_lm):
+                if is_lm:
+                    split_encoder_outs[decoder_id] = lm_encoder_outs
+        return split_encoder_outs
 
     def reorder_incremental_state(self, incremental_state, new_order):
         """Reorder buffered internal state (for incremental generation)."""

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -295,6 +295,16 @@ class RNNModel(FairseqModel):
                 "strategy."
             ),
         )
+        parser.add_argument(
+            "--multi-decoder-is-lm",
+            default=None,
+            type=int,
+            nargs="+",
+            help=(
+                "If specified, sets --attention-type=no and --encoder-hidden-dim=0"
+                "for the n-th decoder in an adaptive ensemble."
+            ),
+        )
 
         # Args for vocab reduction
         vocab_reduction.add_args(parser)
@@ -325,8 +335,13 @@ class RNNModel(FairseqModel):
 
     @staticmethod
     def build_single_decoder(
-        args, src_dict, dst_dict, ngram_decoder=None, project_output=True
+        args, src_dict, dst_dict, ngram_decoder=None, project_output=True, is_lm=False
     ):
+        attention_type = args.attention_type
+        encoder_hidden_dim = args.encoder_hidden_dim
+        if is_lm:
+            attention_type = "no"
+            encoder_hidden_dim = 0
         if ngram_decoder:
             if args.ngram_activation_type == "relu":
                 activation_fn = nn.ReLU
@@ -341,13 +356,13 @@ class RNNModel(FairseqModel):
                 src_dict=src_dict,
                 dst_dict=dst_dict,
                 n=ngram_decoder,
-                encoder_hidden_dim=args.encoder_hidden_dim,
+                encoder_hidden_dim=encoder_hidden_dim,
                 embed_dim=args.decoder_embed_dim,
                 freeze_embed=args.decoder_freeze_embed,
                 out_embed_dim=args.decoder_out_embed_dim,
                 num_layers=args.decoder_layers,
                 hidden_dim=args.decoder_hidden_dim,
-                attention_type=args.attention_type,
+                attention_type=attention_type,
                 dropout_in=args.decoder_dropout_in,
                 dropout_out=args.decoder_dropout_out,
                 residual_level=args.residual_level,
@@ -359,14 +374,14 @@ class RNNModel(FairseqModel):
                 src_dict=src_dict,
                 dst_dict=dst_dict,
                 vocab_reduction_params=args.vocab_reduction_params,
-                encoder_hidden_dim=args.encoder_hidden_dim,
+                encoder_hidden_dim=encoder_hidden_dim,
                 embed_dim=args.decoder_embed_dim,
                 freeze_embed=args.decoder_freeze_embed,
                 out_embed_dim=args.decoder_out_embed_dim,
                 cell_type=args.cell_type,
                 num_layers=args.decoder_layers,
                 hidden_dim=args.decoder_hidden_dim,
-                attention_type=args.attention_type,
+                attention_type=attention_type,
                 dropout_in=args.decoder_dropout_in,
                 dropout_out=args.decoder_dropout_out,
                 residual_level=args.residual_level,
@@ -401,17 +416,22 @@ class RNNModel(FairseqModel):
                 if len(ngram_decoder_args) == 1:
                     ngram_decoder_args = [ngram_decoder_args[0]] * args.multi_decoder
                 assert len(ngram_decoder_args) == args.multi_decoder
+            is_lm_args = [False] * args.multi_decoder
+            if args.multi_decoder_is_lm is not None:
+                is_lm_args = list(map(bool, args.multi_decoder_is_lm))
+            assert len(is_lm_args) == args.multi_decoder
             decoders = [
                 RNNModel.build_single_decoder(
-                    args, src_dict, dst_dict, n, project_output=False
+                    args, src_dict, dst_dict, n, project_output=False, is_lm=is_lm
                 )
-                for n in ngram_decoder_args
+                for is_lm, n in zip(is_lm_args, ngram_decoder_args)
             ]
             decoder = MultiDecoder(
                 src_dict,
                 dst_dict,
                 decoders=decoders,
                 combination_strategy=args.multi_decoder_combination_strategy,
+                is_lm=is_lm_args,
                 split_encoder=args.multi_encoder is not None,
                 vocab_reduction_params=args.vocab_reduction_params,
                 training_schedule=args.multi_model_training_schedule,
@@ -1068,6 +1088,7 @@ def base_architecture(args):
     args.ngram_decoder = getattr(args, "ngram_decoder", None)
     args.multi_encoder = getattr(args, "multi_encoder", None)
     args.multi_decoder = getattr(args, "multi_decoder", None)
+    args.multi_decoder_is_lm = getattr(args, "multi_decoder_is_lm", None)
     args.multiling_encoder_lang = getattr(args, "multiling_encoder_lang", None)
     args.multi_model_training_schedule = getattr(
         args, "multi_model_training_schedule", "complete"


### PR DESCRIPTION
Summary: This diff introduces --multi-decoder-is-lm to use an LM together with a translation model in an adaptive ensemble. The LM can be pretrained on monolingual data, loaded via --multi-model-restore-files, and frozen with --multi-model-training-schedule freeze_dec_0

Reviewed By: jhcross

Differential Revision: D8702760
