### PR TITLE
Use maybe_cuda() more often

### DIFF
--- a/pytorch_translate/multi_model.py
+++ b/pytorch_translate/multi_model.py
@@ -468,6 +468,7 @@ class MultiDecoder(FairseqIncrementalDecoder):
         dst_dict,
         decoders,
         combination_strategy,
+        is_lm=None,
         split_encoder=False,
         vocab_reduction_params=None,
         training_schedule="complete",
@@ -480,13 +481,21 @@ class MultiDecoder(FairseqIncrementalDecoder):
             decoders (list): List of DecoderWithOutputProjection.
             combination_strategy (string): Name of the combination strategy.
                 Passed through to `create_strategy()`.
+            is_lm (list): List of booleans determining whether the n-th
+                decoder is a language model. If None, none of the decoders are
+                considered an LM.
             split_encoder (bool): If true, split encoder output, each decoder
                 gets its own split.
             vocab_reduction_params: For vocabular reduction.
             training_schedule (str): Training strategy.
         """
         super().__init__(dst_dict)
+        if is_lm is None:
+            is_lm = [False] * len(decoders)
         assert not any(decoder.project_output for decoder in decoders)
+        assert len(is_lm) == len(decoders)
+        self.attentive_decoder_ids = [i for i, b in enumerate(is_lm) if not b]
+        self.decoders_is_lm = is_lm
         self.decoders = nn.ModuleList(decoders)
         vocab_reduction_module = None
         if vocab_reduction_params:
@@ -560,7 +569,7 @@ class MultiDecoder(FairseqIncrementalDecoder):
                 )
             )
         mean_attn_scores = average_tensors(
-            [attn_scores for _, attn_scores in decoder_outs if attn_scores is not None]
+            [decoder_outs[decoder_id][1] for decoder_id in self.attentive_decoder_ids]
         )
         select_single = None
         if self.separate_training and not unfreeze_combi_strat:
@@ -575,14 +584,8 @@ class MultiDecoder(FairseqIncrementalDecoder):
         return logits, mean_attn_scores, possible_translation_tokens
 
     def _get_contexts(self, encoder_out):
+        encoder_outs, final_hidden, final_cell, src_lengths, src_tokens = encoder_out
         if self.split_encoder:
-            (
-                encoder_outs,
-                final_hidden,
-                final_cell,
-                src_lengths,
-                src_tokens,
-            ) = encoder_out
             split_encoder_outs = []
             offset = 0
             for decoder in self.decoders:
@@ -598,8 +601,17 @@ class MultiDecoder(FairseqIncrementalDecoder):
                 )
                 offset = next_offset
             assert offset == encoder_outs.size(2)
-            return split_encoder_outs
-        return [encoder_out] * len(self.decoders)
+        else:
+            split_encoder_outs = [encoder_out] * len(self.decoders)
+        if any(self.decoders_is_lm):
+            num_layers, bsz, _ = final_cell.size()
+            ones = torch.ones((num_layers, bsz, 1)).type_as(final_cell)
+            dummy_out = torch.ones((1, bsz, 1)).type_as(final_cell)
+            lm_encoder_outs = dummy_out, ones, ones, src_lengths, src_tokens
+            for decoder_id, is_lm in enumerate(self.decoders_is_lm):
+                if is_lm:
+                    split_encoder_outs[decoder_id] = lm_encoder_outs
+        return split_encoder_outs
 
     def reorder_incremental_state(self, incremental_state, new_order):
         """Reorder buffered internal state (for incremental generation)."""

--- a/pytorch_translate/multi_model.py
+++ b/pytorch_translate/multi_model.py
@@ -8,7 +8,7 @@ from fairseq.models import FairseqEncoder, FairseqIncrementalDecoder
 from pytorch_translate.common_layers import Linear, OutputProjection
 from pytorch_translate import vocab_reduction
 from torch.serialization import default_restore_location
-from pytorch_translate.utils import average_tensors
+from pytorch_translate.utils import average_tensors, maybe_cuda
 import torch.nn.functional as F
 
 
@@ -300,6 +300,7 @@ class BaseWeightedStrategy(MultiDecoderCombinationStrategy):
         out_embed_dims,
         vocab_size,
         vocab_reduction_module=None,
+        fixed_weights=None,
         hidden_layer_size=32,
         activation_fn=torch.nn.ReLU,
         norm_fn=torch.exp,
@@ -311,18 +312,25 @@ class BaseWeightedStrategy(MultiDecoderCombinationStrategy):
                 decoders.
             vocab_size (int): Size of the output projection.
             vocab_reduction_module: For vocabulary reduction
+            fixed_weights (list): If not None, use these fixed weights rather
+                than a gating network.
             hidden_layer_size (int): Size of the hidden layer of the gating
                 network.
             activation_fn: Non-linearity at the hidden layer.
             norm_fn: Function to use for normalization (exp or sigmoid).
         """
         super().__init__(out_embed_dims, vocab_size, vocab_reduction_module)
-        self.gating_network = nn.Sequential(
-            Linear(sum(out_embed_dims), hidden_layer_size, bias=True),
-            activation_fn(),
-            Linear(hidden_layer_size, len(out_embed_dims), bias=True),
-        )
-        self.norm_fn = norm_fn
+        if fixed_weights is None:
+            self.fixed_weights = None
+            self.gating_network = nn.Sequential(
+                Linear(sum(out_embed_dims), hidden_layer_size, bias=True),
+                activation_fn(),
+                Linear(hidden_layer_size, len(out_embed_dims), bias=True),
+            )
+            self.norm_fn = norm_fn
+        else:
+            assert len(fixed_weights) == len(out_embed_dims)
+            self.fixed_weights = maybe_cuda(torch.Tensor(fixed_weights).view(1, 1, -1))
 
     def compute_weights(self, unprojected_outs, select_single=None):
         """Derive interpolation weights from unprojected decoder outputs.
@@ -338,9 +346,11 @@ class BaseWeightedStrategy(MultiDecoderCombinationStrategy):
         """
         if select_single is not None:
             sz = unprojected_outs[0].size()
-            ret = torch.zeros((sz[0], sz[1], len(unprojected_outs))).cuda()
+            ret = maybe_cuda(torch.zeros((sz[0], sz[1], len(unprojected_outs))))
             ret[:, :, select_single] = 1.0
             return ret
+        if self.fixed_weights is not None:
+            return self.fixed_weights
         logits = self.norm_fn(self.gating_network(torch.cat(unprojected_outs, 2)))
         return logits / torch.sum(logits, dim=2, keepdim=True)
 
@@ -355,8 +365,9 @@ class WeightedStrategy(BaseWeightedStrategy):
         vocab_reduction_module=None,
         norm_fn=None,
         to_log=False,
+        fixed_weights=None,
     ):
-        super().__init__(out_embed_dims, vocab_size)
+        super().__init__(out_embed_dims, vocab_size, fixed_weights=fixed_weights)
         assert vocab_reduction_module is None
         self.output_projections = nn.ModuleList(
             [OutputProjection(dim, vocab_size) for dim in out_embed_dims]
@@ -410,7 +421,9 @@ class WeightedUnprojectedStrategy(BaseWeightedStrategy):
         )
 
 
-def create_strategy(strategy_name, out_embed_dims, vocab_size, vocab_reduction_module):
+def create_strategy(
+    strategy_name, out_embed_dims, vocab_size, vocab_reduction_module, fixed_weights
+):
     if "-" in strategy_name:
         strategy_name, strategy_modifier = strategy_name.split("-")
     else:
@@ -437,6 +450,7 @@ def create_strategy(strategy_name, out_embed_dims, vocab_size, vocab_reduction_m
             vocab_reduction_module,
             norm_fn=norm_fn,
             to_log=to_log,
+            fixed_weights=fixed_weights,
         )
     elif strategy_name == "unprojected":
         return UnprojectedStrategy(out_embed_dims, vocab_size, vocab_reduction_module)
@@ -472,6 +486,7 @@ class MultiDecoder(FairseqIncrementalDecoder):
         split_encoder=False,
         vocab_reduction_params=None,
         training_schedule="complete",
+        fixed_weights=None,
     ):
         """Create a new multi-decoder instance.
 
@@ -488,6 +503,8 @@ class MultiDecoder(FairseqIncrementalDecoder):
                 gets its own split.
             vocab_reduction_params: For vocabular reduction.
             training_schedule (str): Training strategy.
+            fixed_weights (list): None or list of floats. If specified, use
+                these fixed model weights in weighted* combination strategies.
         """
         super().__init__(dst_dict)
         if is_lm is None:
@@ -507,6 +524,7 @@ class MultiDecoder(FairseqIncrementalDecoder):
             [decoder.out_embed_dim for decoder in decoders],
             len(dst_dict),
             vocab_reduction_module,
+            fixed_weights,
         )
         self.split_encoder = split_encoder
         self.unfreeze_single = False

--- a/pytorch_translate/research/word_prediction/word_prediction_criterion.py
+++ b/pytorch_translate/research/word_prediction/word_prediction_criterion.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 
 from fairseq.criterions import FairseqCriterion, register_criterion
 from fairseq import utils
+from pytorch_translate.utils import maybe_cuda
 
 
 @register_criterion('word_prediction')
@@ -32,7 +33,7 @@ class WordPredictionCriterion(FairseqCriterion):
         prediction_lprobs = model.get_predictor_normalized_probs(
             predictor_output, log_probs=True)
         # prevent domination of padding idx
-        non_padding_mask = torch.ones(prediction_lprobs.size(1)).cuda()
+        non_padding_mask = maybe_cuda(torch.ones(prediction_lprobs.size(1)))
         non_padding_mask[model.encoder.padding_idx] = 0
         prediction_lprobs = prediction_lprobs * non_padding_mask.unsqueeze(0)
 

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -30,7 +30,7 @@ from pytorch_translate.common_layers import (
     DecoderWithOutputProjection,
 )
 from pytorch_translate import attention
-from pytorch_translate.utils import maybe_cat
+from pytorch_translate.utils import maybe_cat, maybe_cuda
 
 
 def torch_find(index, query, vocab_size):
@@ -40,12 +40,8 @@ def torch_find(index, query, vocab_size):
     preconditions:  (1) index and query are flat arrays (can be different sizes)
                     (2) all tokens in index and query have values < vocab_size
     """
-    full_to_index = (torch.zeros(vocab_size)).long()
-    if torch.cuda.is_available():
-        full_to_index = full_to_index.cuda()
-    index_shape_range = torch.arange(index.shape[0]).long()
-    if torch.cuda.is_available():
-        index_shape_range = index_shape_range.cuda()
+    full_to_index = maybe_cuda(torch.zeros(vocab_size).long())
+    index_shape_range = maybe_cuda(torch.arange(index.shape[0]).long())
     full_to_index[index] = index_shape_range
     result = full_to_index[query]
     return result
@@ -697,7 +693,7 @@ class DummyEncoder(FairseqEncoder):
 
     def forward(self, src_tokens, src_lengths):
         bsz = src_lengths.size(0)
-        ones = torch.ones((self.num_layers, bsz, 1)).cuda()
+        ones = maybe_cuda(torch.ones((self.num_layers, bsz, 1)))
         dummy_out = torch.ones((1, bsz, 1))
         return dummy_out, ones, ones, src_lengths, src_tokens
 

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -270,6 +270,16 @@ class RNNModel(FairseqModel):
             ),
         )
         parser.add_argument(
+            "--multi-model-fixed-weights",
+            default=None,
+            type=float,
+            nargs="+",
+            help=(
+                "Used for weighted* combination strategies. If specified, use "
+                "these fixed model weights rather than a gating network."
+            ),
+        )
+        parser.add_argument(
             "--multi-model-training-schedule",
             default="complete",
             type=str,
@@ -435,6 +445,7 @@ class RNNModel(FairseqModel):
                 split_encoder=args.multi_encoder is not None,
                 vocab_reduction_params=args.vocab_reduction_params,
                 training_schedule=args.multi_model_training_schedule,
+                fixed_weights=args.multi_model_fixed_weights,
             )
         else:
             if args.multi_encoder:
@@ -1093,6 +1104,7 @@ def base_architecture(args):
     args.multi_model_training_schedule = getattr(
         args, "multi_model_training_schedule", "complete"
     )
+    args.multi_model_fixed_weights = getattr(args, "multi_model_fixed_weights", None)
     args.cell_type = getattr(args, "cell_type", "lstm")
     args.ngram_activation_type = getattr(args, "ngram_activation_type", "relu")
     vocab_reduction.set_arg_defaults(args)

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -295,6 +295,16 @@ class RNNModel(FairseqModel):
                 "strategy."
             ),
         )
+        parser.add_argument(
+            "--multi-decoder-is-lm",
+            default=None,
+            type=int,
+            nargs="+",
+            help=(
+                "If specified, sets --attention-type=no and --encoder-hidden-dim=0"
+                "for the n-th decoder in an adaptive ensemble."
+            ),
+        )
 
         # Args for vocab reduction
         vocab_reduction.add_args(parser)
@@ -325,8 +335,13 @@ class RNNModel(FairseqModel):
 
     @staticmethod
     def build_single_decoder(
-        args, src_dict, dst_dict, ngram_decoder=None, project_output=True
+        args, src_dict, dst_dict, ngram_decoder=None, project_output=True, is_lm=False
     ):
+        attention_type = args.attention_type
+        encoder_hidden_dim = args.encoder_hidden_dim
+        if is_lm:
+            attention_type = "no"
+            encoder_hidden_dim = 0
         if ngram_decoder:
             if args.ngram_activation_type == "relu":
                 activation_fn = nn.ReLU
@@ -341,13 +356,13 @@ class RNNModel(FairseqModel):
                 src_dict=src_dict,
                 dst_dict=dst_dict,
                 n=ngram_decoder,
-                encoder_hidden_dim=args.encoder_hidden_dim,
+                encoder_hidden_dim=encoder_hidden_dim,
                 embed_dim=args.decoder_embed_dim,
                 freeze_embed=args.decoder_freeze_embed,
                 out_embed_dim=args.decoder_out_embed_dim,
                 num_layers=args.decoder_layers,
                 hidden_dim=args.decoder_hidden_dim,
-                attention_type=args.attention_type,
+                attention_type=attention_type,
                 dropout_in=args.decoder_dropout_in,
                 dropout_out=args.decoder_dropout_out,
                 residual_level=args.residual_level,
@@ -359,14 +374,14 @@ class RNNModel(FairseqModel):
                 src_dict=src_dict,
                 dst_dict=dst_dict,
                 vocab_reduction_params=args.vocab_reduction_params,
-                encoder_hidden_dim=args.encoder_hidden_dim,
+                encoder_hidden_dim=encoder_hidden_dim,
                 embed_dim=args.decoder_embed_dim,
                 freeze_embed=args.decoder_freeze_embed,
                 out_embed_dim=args.decoder_out_embed_dim,
                 cell_type=args.cell_type,
                 num_layers=args.decoder_layers,
                 hidden_dim=args.decoder_hidden_dim,
-                attention_type=args.attention_type,
+                attention_type=attention_type,
                 dropout_in=args.decoder_dropout_in,
                 dropout_out=args.decoder_dropout_out,
                 residual_level=args.residual_level,
@@ -401,17 +416,22 @@ class RNNModel(FairseqModel):
                 if len(ngram_decoder_args) == 1:
                     ngram_decoder_args = [ngram_decoder_args[0]] * args.multi_decoder
                 assert len(ngram_decoder_args) == args.multi_decoder
+            is_lm_args = [False] * args.multi_decoder
+            if args.multi_decoder_is_lm is not None:
+                is_lm_args = list(map(bool, args.multi_decoder_is_lm))
+            assert len(is_lm_args) == args.multi_decoder
             decoders = [
                 RNNModel.build_single_decoder(
-                    args, src_dict, dst_dict, n, project_output=False
+                    args, src_dict, dst_dict, n, project_output=False, is_lm=is_lm
                 )
-                for n in ngram_decoder_args
+                for is_lm, n in zip(is_lm_args, ngram_decoder_args)
             ]
             decoder = MultiDecoder(
                 src_dict,
                 dst_dict,
                 decoders=decoders,
                 combination_strategy=args.multi_decoder_combination_strategy,
+                is_lm=is_lm_args,
                 split_encoder=args.multi_encoder is not None,
                 vocab_reduction_params=args.vocab_reduction_params,
                 training_schedule=args.multi_model_training_schedule,
@@ -1068,6 +1088,7 @@ def base_architecture(args):
     args.ngram_decoder = getattr(args, "ngram_decoder", None)
     args.multi_encoder = getattr(args, "multi_encoder", None)
     args.multi_decoder = getattr(args, "multi_decoder", None)
+    args.multi_decoder_is_lm = getattr(args, "multi_decoder_is_lm", None)
     args.multiling_encoder_lang = getattr(args, "multiling_encoder_lang", None)
     args.multi_model_training_schedule = getattr(
         args, "multi_model_training_schedule", "complete"

--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -224,6 +224,13 @@ def maybe_cat(tensors, dim, nullable=None):
     return torch.cat(filtered, dim=dim)
 
 
+def maybe_cuda(t):
+    """Calls `cuda()` on `t` if cuda is available."""
+    if torch.cuda.is_available():
+        return t.cuda()
+    return t
+
+
 def average_tensors(tensor_list, norm_fn=None, weights=None):
     """Averages a list of tensors.
 


### PR DESCRIPTION
Summary:
.cuda() call should be conditioned on cuda availability. Use maybe_cuda() throughout the pytorch_translate codebase instead of
calling .cuda() directly to improve portability to CPU.

Reviewed By: jhcross

Differential Revision: D8757267
