### PR TITLE
Update pytorch_translate for fairseq 0.5.0

### DIFF
--- a/pytorch_translate/char_source_model.py
+++ b/pytorch_translate/char_source_model.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 
 @register_model("char_source")
 class CharSourceModel(rnn.RNNModel):
-    def __init__(self, encoder, decoder):
-        super().__init__(encoder, decoder)
+    def __init__(self, task, encoder, decoder):
+        super().__init__(task, encoder, decoder)
 
     @staticmethod
     def add_args(parser):
@@ -75,8 +75,9 @@ class CharSourceModel(rnn.RNNModel):
         )
 
     @classmethod
-    def build_model(cls, args, src_dict, dst_dict):
+    def build_model(cls, args, task):
         """Build a new model instance."""
+        src_dict, dst_dict = task.source_dictionary, task.target_dictionary
         base_architecture(args)
 
         assert args.sequence_lstm, "CharRNNModel only supports sequence_lstm"
@@ -141,7 +142,7 @@ class CharSourceModel(rnn.RNNModel):
             residual_level=args.residual_level,
             averaging_encoder=args.averaging_encoder,
         )
-        return cls(encoder, decoder)
+        return cls(task, encoder, decoder)
 
     def forward(
         self, src_tokens, src_lengths, char_inds, word_lengths, prev_output_tokens

--- a/pytorch_translate/data.py
+++ b/pytorch_translate/data.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
 
-import argparse
 import numpy as np
-import os
 import torch
 
-from fairseq import data, indexed_dataset, tokenizer
+from fairseq import data, tokenizer
 from typing import NamedTuple, Optional
 
-from pytorch_translate import char_data
-from pytorch_translate import weighted_data
 from pytorch_translate import dictionary as pytorch_translate_dictionary
 
 
@@ -36,8 +32,8 @@ class ParallelCorpusConfig(NamedTuple):
     weights_file: Optional[str]
 
 
-class InMemoryNumpyDataset(indexed_dataset.IndexedDataset):
-    """analogous to fairseq.indexed_dataset.IndexedInMemoryDataset"""
+class InMemoryNumpyDataset(data.IndexedDataset):
+    """analogous to fairseq.data.IndexedInMemoryDataset"""
 
     def __init__(self):
         """Initialize empty dataset"""
@@ -48,7 +44,7 @@ class InMemoryNumpyDataset(indexed_dataset.IndexedDataset):
     def __getitem__(self, i):
         assert i < self.__len__(), f"index {i} out of range!"
         a = self.buffer[self.offsets[i] : self.offsets[i + 1]]
-        return torch.from_numpy(a)
+        return torch.from_numpy(a).long()
 
     def __len__(self):
         # offsets includes 0 and end indices for each example
@@ -167,8 +163,7 @@ class InMemoryNumpyDataset(indexed_dataset.IndexedDataset):
                         offsets.append(offsets[-1] + len(inds))
                         sizes.append(len(inds))
 
-        # +1 for Lua compatibility
-        self.buffer = np.concatenate(array_list) + 1
+        self.buffer = np.concatenate(array_list)
         self.offsets = np.array(offsets, dtype=np.int32)
         self.sizes = np.array(sizes, dtype=np.int32)
         del array_list
@@ -185,63 +180,10 @@ class InMemoryNumpyDataset(indexed_dataset.IndexedDataset):
 def is_multilingual(args):
     if hasattr(args, "multiling_encoder_lang"):
         return bool(args.multiling_encoder_lang)
-    return args.multiling_source_lang_id is not None
+    return args.multiling_source_lang is not None
 
 
-def make_language_pair_dataset_from_text(
-    source_text_file: str,
-    target_text_file: str,
-    source_dict: pytorch_translate_dictionary.Dictionary,
-    target_dict: pytorch_translate_dictionary.Dictionary,
-    append_eos: Optional[bool] = False,
-    reverse_source: Optional[bool] = True,
-    char_source_dict: Optional[pytorch_translate_dictionary.Dictionary] = None,
-) -> data.LanguagePairDataset:
-    dst_dataset = indexed_dataset.IndexedRawTextDataset(
-        path=target_text_file,
-        dictionary=target_dict,
-        # We always append EOS to the target sentence since we still want
-        # the model to output an indication the sentence has finished, even
-        # if we don't append the EOS symbol to the source sentence
-        # (to prevent the model from misaligning UNKs or other words
-        # to the frequently occurring EOS).
-        append_eos=True,
-        # We don't reverse the order of the target sentence, since
-        # even if the source sentence is fed to the model backwards,
-        # we still want the model to start outputting from the first word.
-        reverse_order=False,
-    )
-
-    if char_source_dict is not None:
-        src_dataset = char_data.InMemoryNumpyWordCharDataset()
-        src_dataset.parse(
-            path=source_text_file,
-            word_dict=source_dict,
-            char_dict=char_source_dict,
-            reverse_order=reverse_source,
-            append_eos=append_eos,
-        )
-        return char_data.LanguagePairSourceCharDataset(
-            src=src_dataset,
-            dst=dst_dataset,
-            pad_idx=source_dict.pad(),
-            eos_idx=source_dict.eos(),
-        )
-    else:
-        return data.LanguagePairDataset(
-            src=indexed_dataset.IndexedRawTextDataset(
-                path=source_text_file,
-                dictionary=source_dict,
-                append_eos=append_eos,
-                reverse_order=reverse_source,
-            ),
-            dst=dst_dataset,
-            pad_idx=source_dict.pad(),
-            eos_idx=source_dict.eos(),
-        )
-
-
-class IndexedRawTextDatasetWithLangId(indexed_dataset.IndexedRawTextDataset):
+class IndexedRawTextDatasetWithLangId(data.IndexedRawTextDataset):
     """Adds language IDs to an IndexedRawTextDataset"""
 
     def __init__(
@@ -266,9 +208,9 @@ class IndexedRawTextDatasetWithLangId(indexed_dataset.IndexedRawTextDataset):
         super(IndexedRawTextDatasetWithLangId, self).read_data(path, dictionary)
         # Postprocess self.tokens_list and self.sizes
         self.sizes += 1
-        lang_id_tensor = torch.IntTensor(
-            [self.lang_id + MULTILING_DIALECT_ID_OFFSET + 1]
-        )  # +1 for Lua compatibility
+        lang_id_tensor = torch.LongTensor(
+            [self.lang_id + MULTILING_DIALECT_ID_OFFSET]
+        )
 
         def add_lang_id(tokens):
             if self.prepend_language_id:
@@ -276,105 +218,3 @@ class IndexedRawTextDatasetWithLangId(indexed_dataset.IndexedRawTextDataset):
             return torch.cat([tokens, lang_id_tensor])
 
         self.tokens_list = [add_lang_id(t) for t in self.tokens_list]
-
-
-def make_language_pair_dataset_from_text_multilingual(
-    source_text_file: str,
-    target_text_file: str,
-    source_lang_id: int,
-    target_lang_id: int,
-    source_dict: pytorch_translate_dictionary.Dictionary,
-    target_dict: pytorch_translate_dictionary.Dictionary,
-    append_eos: Optional[bool] = False,
-    reverse_source: Optional[bool] = True,
-) -> data.LanguagePairDataset:
-    return data.LanguagePairDataset(
-        src=IndexedRawTextDatasetWithLangId(
-            path=source_text_file,
-            dictionary=source_dict,
-            lang_id=source_lang_id,
-            append_eos=append_eos,
-            reverse_order=reverse_source,
-            prepend_language_id=False,
-        ),
-        dst=IndexedRawTextDatasetWithLangId(
-            path=target_text_file,
-            dictionary=target_dict,
-            lang_id=target_lang_id,
-            append_eos=True,
-            reverse_order=False,
-            prepend_language_id=True,
-        ),
-        pad_idx=source_dict.pad(),
-        eos_idx=source_dict.eos(),
-    )
-
-
-def load_binarized_dataset(
-    train_corpus: ParallelCorpusConfig,
-    eval_corpus: ParallelCorpusConfig,
-    train_split: str,
-    eval_split: str,
-    args: argparse.Namespace,
-    use_char_source: bool = False,
-) -> data.LanguageDatasets:
-    if is_multilingual(args):  # Dummy dictionaries
-        source_dict = pytorch_translate_dictionary.Dictionary()
-        target_dict = pytorch_translate_dictionary.Dictionary()
-    else:
-        source_dict = pytorch_translate_dictionary.Dictionary.load(
-            args.source_vocab_file
-        )
-        target_dict = pytorch_translate_dictionary.Dictionary.load(
-            args.target_vocab_file
-        )
-
-    if use_char_source:
-        char_source_dict = pytorch_translate_dictionary.Dictionary.load(
-            args.char_source_vocab_file
-        )
-        # this attribute is used for CharSourceModel construction
-        args.char_source_dict_size = len(char_source_dict)
-
-    dataset = data.LanguageDatasets(
-        src=train_corpus.source.dialect,
-        dst=train_corpus.target.dialect,
-        src_dict=source_dict,
-        dst_dict=target_dict,
-    )
-
-    for split, corpus in [(train_split, train_corpus), (eval_split, eval_corpus)]:
-        if not os.path.exists(corpus.source.data_file):
-            raise ValueError(f"{corpus.source.data_file} for {split} not found!")
-        if not os.path.exists(corpus.target.data_file):
-            raise ValueError(f"{corpus.target.data_file} for {split} not found!")
-
-        dst_dataset = InMemoryNumpyDataset.create_from_file(corpus.target.data_file)
-        weights_dataset = None
-        if corpus.weights_file and os.path.exists(corpus.weights_file):
-            weights_dataset = weighted_data.IndexedWeightsDataset(
-                corpus.weights_file)
-            assert len(dst_dataset) == len(weights_dataset)
-
-        if use_char_source:
-            src_dataset = char_data.InMemoryNumpyWordCharDataset.create_from_file(
-                corpus.source.data_file
-            )
-            dataset.splits[split] = char_data.LanguagePairSourceCharDataset(
-                src=src_dataset,
-                dst=dst_dataset,
-                pad_idx=source_dict.pad(),
-                eos_idx=source_dict.eos(),
-                weights=weights_dataset,
-            )
-        else:
-            src_dataset = InMemoryNumpyDataset.create_from_file(corpus.source.data_file)
-            dataset.splits[split] = weighted_data.WeightedLanguagePairDataset(
-                src=src_dataset,
-                dst=dst_dataset,
-                pad_idx=source_dict.pad(),
-                eos_idx=source_dict.eos(),
-                weights=weights_dataset,
-            )
-
-    return dataset

--- a/pytorch_translate/onnx_component_export.py
+++ b/pytorch_translate/onnx_component_export.py
@@ -127,7 +127,7 @@ def export(args):
 
         # need example encoder outputs to pass through network
         # (source length 5 is arbitrary)
-        src_dict = encoder_ensemble.models[0].src_dict
+        src_dict = encoder_ensemble.src_dict
         token_list = [src_dict.unk()] * 4 + [src_dict.eos()]
         src_tokens = torch.LongTensor(
             np.array(token_list, dtype="int64").reshape(-1, 1)

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -16,26 +16,6 @@ def add_dataset_args(parser, train=False, gen=False):
         "This is not needed but kept for backward compatibility",
     )
     group.add_argument(
-        "-s", "--source-lang", default="src", metavar="SRC", help="source language"
-    )
-    group.add_argument(
-        "-t", "--target-lang", default="tgt", metavar="TARGET", help="target language"
-    )
-    group.add_argument(
-        "--max-source-positions",
-        default=1024,
-        type=int,
-        metavar="N",
-        help="max number of tokens in the source sequence",
-    )
-    group.add_argument(
-        "--max-target-positions",
-        default=1024,
-        type=int,
-        metavar="N",
-        help="max number of tokens in the target sequence",
-    )
-    group.add_argument(
         "--skip-invalid-size-inputs-valid-test",
         action="store_true",
         help="Ignore too long or too short lines in valid and test set",
@@ -463,7 +443,8 @@ def expand_checkpointing_args(group):
         action="store_true",
         help="Disables saving checkpoints at the end of the epoch. "
         "This differs from --no-save and --no-epoch-checkpoints in that it "
-        "still allows for intra-epoch checkpoints if --save-interval is set.",
+        "still allows for intra-epoch checkpoints if --save-interval-updates "
+        "is set.",
     )
     group.add_argument(
         "--max-checkpoints-kept",
@@ -564,7 +545,7 @@ def expand_generation_args(group, train=False):
             type=int,
             metavar="N",
             help="Does BLEU eval every N batch updates. Note that "
-            "--save-interval also affects this - we can only eval as "
+            "--save-interval-updates also affects this - we can only eval as "
             "frequently as a checkpoint is written. A value of <= 0 "
             "disables this.",
         )
@@ -614,14 +595,11 @@ def validate_generation_args(args):
 
 def add_verbosity_args(parser, train=False):
     verbosity_group = parser.add_argument_group("Verbosity")
-
-    if train:
-        verbosity_group.add_argument(
-            "--log-verbose",
-            action="store_true",
-            help="Whether to output more verbose logs for debugging/profiling.",
-        )
-
+    verbosity_group.add_argument(
+        "--log-verbose",
+        action="store_true",
+        help="Whether to output more verbose logs for debugging/profiling.",
+    )
     verbosity_group.add_argument(
         "--args-verbosity",
         default=1,

--- a/pytorch_translate/research/knowledge_distillation/knowledge_distillation_loss.py
+++ b/pytorch_translate/research/knowledge_distillation/knowledge_distillation_loss.py
@@ -12,8 +12,8 @@ from pytorch_translate import utils as pytorch_translate_utils
 @register_criterion('word_knowledge_distillation')
 class KnowledgeDistillationCriterion(FairseqCriterion):
 
-    def __init__(self, args, src_dict, dst_dict):
-        super().__init__(args, src_dict, dst_dict)
+    def __init__(self, args, task):
+        super().__init__(args, task)
         assert args.teacher_path, (
             'Please specify at least one valid file for --teacher-path'
         )
@@ -22,7 +22,7 @@ class KnowledgeDistillationCriterion(FairseqCriterion):
         # Load model ensemble from checkpoints
         self.teacher_models, self.teacher_model_args = (
             pytorch_translate_utils.load_diverse_ensemble_for_inference(
-                args.teacher_path, src_dict, dst_dict
+                [args.teacher_path], task,
             )
         )
 

--- a/pytorch_translate/research/word_prediction/word_prediction_model.py
+++ b/pytorch_translate/research/word_prediction/word_prediction_model.py
@@ -179,8 +179,9 @@ class RNNWordPredictionModel(FairseqWordPredictionModel):
         vocab_reduction.add_args(parser)
 
     @classmethod
-    def build_model(cls, args, src_dict, dst_dict):
+    def build_model(cls, args, task):
         """Build a new model instance."""
+        src_dict, dst_dict = task.source_dictionary, task.target_dictionary
         base_architecture_wp(args)
         if args.sequence_lstm:
             encoder_class = LSTMSequenceEncoder

--- a/pytorch_translate/tasks.py
+++ b/pytorch_translate/tasks.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+
+from collections import OrderedDict
+import os
+from typing import List, Optional
+
+from fairseq import data, options
+from fairseq.tasks import FairseqTask, register_task
+
+from pytorch_translate import char_data
+from pytorch_translate import data as pytorch_translate_data
+from pytorch_translate import dictionary as pytorch_translate_dictionary
+from pytorch_translate import weighted_data
+from pytorch_translate.research.multisource import multisource_data
+
+
+@register_task("pytorch_translate")
+class PytorchTranslateTask(FairseqTask):
+
+    @staticmethod
+    def add_args(parser):
+        """Add task-specific arguments to the parser."""
+        parser.add_argument(
+            "-s",
+            "--source-lang",
+            default=None,
+            metavar="SRC",
+            help="source language",
+        )
+        parser.add_argument(
+            "-t",
+            "--target-lang",
+            default=None,
+            metavar="TARGET",
+            help="target language",
+        )
+        parser.add_argument(
+            "--left-pad-source",
+            default="True",
+            type=str,
+            metavar="BOOL",
+            help="pad the source on the left (default: True)",
+        )
+        parser.add_argument(
+            "--max-source-positions",
+            default=1024,
+            type=int,
+            metavar="N",
+            help="max number of tokens in the source sequence",
+        )
+        parser.add_argument(
+            "--max-target-positions",
+            default=1024,
+            type=int,
+            metavar="N",
+            help="max number of tokens in the target sequence",
+        )
+
+    def __init__(self, args, src_dict, tgt_dict, char_source_dict=None):
+        super().__init__(args)
+        self.src_dict = src_dict
+        self.tgt_dict = tgt_dict
+        self.char_source_dict = char_source_dict
+
+    def build_model(self, args):
+        # set defaults for old model checkpoints
+        args.left_pad_source = getattr(args, "left_pad_source", True)
+        return super().build_model(args)
+
+    @classmethod
+    def setup_task(cls, args, **kwargs):
+        args.left_pad_source = options.eval_bool(args.left_pad_source)
+
+        assert not pytorch_translate_data.is_multilingual(args), \
+            "Must set `--task pytorch_translate_multilingual` for multilingual training"
+
+        # Load dictionaries
+        source_dict = pytorch_translate_dictionary.Dictionary.load(
+            args.source_vocab_file,
+        )
+        target_dict = pytorch_translate_dictionary.Dictionary.load(
+            args.target_vocab_file,
+        )
+
+        source_lang = args.source_lang or "src"
+        target_lang = args.target_lang or "tgt"
+
+        print(f"| [{source_lang}] dictionary: {len(source_dict)} types")
+        print(f"| [{target_lang}] dictionary: {len(target_dict)} types")
+
+        use_char_source = (args.char_source_vocab_file != "") or (
+            getattr(args, "arch", "") == "char_source"
+        )
+        if use_char_source:
+            char_source_dict = pytorch_translate_dictionary.Dictionary.load(
+                args.char_source_vocab_file
+            )
+            # this attribute is used for CharSourceModel construction
+            args.char_source_dict_size = len(char_source_dict)
+        else:
+            char_source_dict = None
+
+        return cls(args, source_dict, target_dict, char_source_dict)
+
+    def load_dataset(self, split, src_bin_path, tgt_bin_path, weights_file=None):
+        corpus = pytorch_translate_data.ParallelCorpusConfig(
+            source=pytorch_translate_data.CorpusConfig(
+                dialect=self.args.source_lang,
+                data_file=src_bin_path,
+            ),
+            target=pytorch_translate_data.CorpusConfig(
+                dialect=self.args.target_lang,
+                data_file=tgt_bin_path,
+            ),
+            weights_file=weights_file,
+        )
+
+        if self.args.log_verbose:
+            print("Starting to load binarized data files.", flush=True)
+
+        if not os.path.exists(corpus.source.data_file):
+            raise ValueError(f"{corpus.source.data_file} for {split} not found!")
+        if not os.path.exists(corpus.target.data_file):
+            raise ValueError(f"{corpus.target.data_file} for {split} not found!")
+
+        dst_dataset = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
+            corpus.target.data_file,
+        )
+        weights_dataset = None
+        if corpus.weights_file and os.path.exists(corpus.weights_file):
+            weights_dataset = weighted_data.IndexedWeightsDataset(
+                corpus.weights_file)
+            assert len(dst_dataset) == len(weights_dataset)
+
+        if self.char_source_dict is not None:
+            src_dataset = char_data.InMemoryNumpyWordCharDataset.create_from_file(
+                corpus.source.data_file
+            )
+            self.datasets[split] = char_data.LanguagePairSourceCharDataset(
+                src=src_dataset,
+                src_sizes=src_dataset.sizes,
+                src_dict=self.source_dictionary,
+                tgt=dst_dataset,
+                tgt_sizes=dst_dataset.sizes,
+                tgt_dict=self.target_dictionary,
+                weights=weights_dataset,
+            )
+        else:
+            src_dataset = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
+                corpus.source.data_file,
+            )
+            self.datasets[split] = weighted_data.WeightedLanguagePairDataset(
+                src=src_dataset,
+                src_sizes=src_dataset.sizes,
+                src_dict=self.source_dictionary,
+                tgt=dst_dataset,
+                tgt_sizes=dst_dataset.sizes,
+                tgt_dict=self.target_dictionary,
+                weights=weights_dataset,
+            )
+
+        if self.args.log_verbose:
+            print("Finished loading dataset", flush=True)
+
+        print(f"| {split} {len(self.datasets[split])} examples")
+
+    def load_dataset_from_text(
+        self,
+        split: str,
+        source_text_file: str,
+        target_text_file: str,
+        append_eos: Optional[bool] = False,
+        reverse_source: Optional[bool] = True,
+    ):
+        dst_dataset = data.IndexedRawTextDataset(
+            path=target_text_file,
+            dictionary=self.target_dictionary,
+            # We always append EOS to the target sentence since we still want
+            # the model to output an indication the sentence has finished, even
+            # if we don't append the EOS symbol to the source sentence
+            # (to prevent the model from misaligning UNKs or other words
+            # to the frequently occurring EOS).
+            append_eos=True,
+            # We don't reverse the order of the target sentence, since
+            # even if the source sentence is fed to the model backwards,
+            # we still want the model to start outputting from the first word.
+            reverse_order=False,
+        )
+
+        if self.char_source_dict is not None:
+            src_dataset = char_data.InMemoryNumpyWordCharDataset()
+            src_dataset.parse(
+                path=source_text_file,
+                word_dict=self.source_dictionary,
+                char_dict=self.char_source_dict,
+                reverse_order=reverse_source,
+                append_eos=append_eos,
+            )
+            self.datasets[split] = char_data.LanguagePairSourceCharDataset(
+                src_dataset, src_dataset.sizes, self.source_dictionary,
+                dst_dataset, dst_dataset.sizes, self.target_dictionary,
+            )
+        else:
+            src_dataset = data.IndexedRawTextDataset(
+                path=source_text_file,
+                dictionary=self.source_dictionary,
+                append_eos=append_eos,
+                reverse_order=reverse_source,
+            )
+            self.datasets[split] = data.LanguagePairDataset(
+                src_dataset, src_dataset.sizes, self.source_dictionary,
+                dst_dataset, dst_dataset.sizes, self.target_dictionary,
+            )
+
+        print(f"| {split} {len(self.datasets[split])} examples")
+
+    def load_multisource_dataset_from_text(
+        self,
+        split: str,
+        source_text_files: List[str],
+        target_text_file: str,
+        append_eos: Optional[bool] = False,
+        reverse_source: Optional[bool] = True,
+    ):
+        src_dataset = multisource_data.IndexedRawTextMultisentDataset(
+            path=source_text_files,
+            dictionary=self.source_dictionary,
+            append_eos=append_eos,
+            reverse_order=reverse_source,
+        )
+        dst_dataset = data.IndexedRawTextDataset(
+            path=target_text_file,
+            dictionary=self.target_dictionary,
+            # We always append EOS to the target sentence since we still want
+            # the model to output an indication the sentence has finished, even
+            # if we don't append the EOS symbol to the source sentence
+            # (to prevent the model from misaligning UNKs or other words
+            # to the frequently occurring EOS).
+            append_eos=True,
+            # We don't reverse the order of the target sentence, since
+            # even if the source sentence is fed to the model backwards,
+            # we still want the model to start outputting from the first word.
+            reverse_order=False,
+        )
+        self.datasets[split] = multisource_data.MultisourceLanguagePairDataset(
+            src_dataset, src_dataset.sizes, self.source_dictionary,
+            dst_dataset, dst_dataset.sizes, self.target_dictionary,
+        )
+
+    @property
+    def source_dictionary(self):
+        return self.src_dict
+
+    @property
+    def target_dictionary(self):
+        return self.tgt_dict
+
+
+# We don't @register_task since this is mostly used for unit tests and export
+class DictionaryHolderTask(FairseqTask):
+    """A simplified Task that just holds the dictionaries."""
+
+    def __init__(self, src_dict, dst_dict):
+        super().__init__(args=None)
+        self.src_dict = src_dict
+        self.dst_dict = dst_dict
+
+    @property
+    def source_dictionary(self):
+        return self.src_dict
+
+    @property
+    def target_dictionary(self):
+        return self.dst_dict
+
+
+@register_task("pytorch_translate_multilingual")
+class PytorchTranslateMultilingualTask(PytorchTranslateTask):
+
+    def __init__(self, args, source_dictionaries, target_dictionaries):
+        self.source_dictionaries = source_dictionaries
+        self.target_dictionaries = target_dictionaries
+
+        # Mapping from language IDs to language codes. During training
+        # this list is fully populated. During generation we typically
+        # have only a single source/target dictionary, thus it is important to
+        # call set_encoder/decoder_langs to properly populate these.
+        self.encoder_langs = list(source_dictionaries.keys())
+        self.decoder_langs = list(target_dictionaries.keys())
+
+        self.src_dict = pytorch_translate_dictionary.MaxVocabDictionary()
+        for d in source_dictionaries.values():
+            self.src_dict.push(d)
+        self.tgt_dict = pytorch_translate_dictionary.MaxVocabDictionary()
+        for d in target_dictionaries.values():
+            self.tgt_dict.push(d)
+
+        super().__init__(args, self.src_dict, self.tgt_dict)
+
+    @classmethod
+    def setup_task(cls, args, **kwargs):
+        assert pytorch_translate_data.is_multilingual(args), \
+            "Must set `--task pytorch_translate_multilingual` for multilingual training"
+        args.left_pad_source = options.eval_bool(args.left_pad_source)
+
+        def load_dicts(langs, paths):
+            dicts = OrderedDict()
+            for lang, dict_path in zip(langs, paths):
+                d = pytorch_translate_dictionary.Dictionary.load(dict_path)
+                dicts[lang] = d
+                print(f"| [{lang}] dictionary: {len(d)} types")
+            return dicts
+
+        if not hasattr(args, "multiling_source_vocab_file"):
+            args.multiling_encoder_lang = args.multiling_source_lang
+            args.multiling_source_vocab_file = [args.source_vocab_file]
+        if not hasattr(args, "multiling_target_vocab_file"):
+            args.multiling_decoder_lang = args.multiling_target_lang
+            args.multiling_target_vocab_file = [args.target_vocab_file]
+
+        # Load dictionaries
+        src_dicts = load_dicts(
+            args.multiling_encoder_lang,
+            args.multiling_source_vocab_file,
+        )
+        tgt_dicts = load_dicts(
+            args.multiling_decoder_lang,
+            args.multiling_target_vocab_file,
+        )
+
+        return cls(args, src_dicts, tgt_dicts)
+
+    def load_dataset_from_text_multilingual(
+        self,
+        split: str,
+        source_text_file: str,
+        target_text_file: str,
+        source_lang_id: int,
+        target_lang_id: int,
+        append_eos: Optional[bool] = False,
+        reverse_source: Optional[bool] = True,
+    ):
+        src_dataset = pytorch_translate_data.IndexedRawTextDatasetWithLangId(
+            path=source_text_file,
+            dictionary=self.source_dictionary,
+            lang_id=source_lang_id,
+            append_eos=append_eos,
+            reverse_order=reverse_source,
+            prepend_language_id=False,
+        )
+        dst_dataset = pytorch_translate_data.IndexedRawTextDatasetWithLangId(
+            path=target_text_file,
+            dictionary=self.target_dictionary,
+            lang_id=target_lang_id,
+            append_eos=True,
+            reverse_order=False,
+            prepend_language_id=True,
+        )
+        self.datasets[split] = data.LanguagePairDataset(
+            src_dataset, src_dataset.sizes, self.source_dictionary,
+            dst_dataset, dst_dataset.sizes, self.target_dictionary,
+        )
+        print(f"| {split} {len(self.datasets[split])} examples")
+
+    def set_encoder_langs(self, encoder_langs):
+        self.encoder_langs = encoder_langs
+
+    def set_decoder_langs(self, decoder_langs):
+        self.decoder_langs = decoder_langs
+
+    def get_encoder_lang_id(self, lang_code):
+        return self.encoder_langs.index(lang_code)
+
+    def get_decoder_lang_id(self, lang_code):
+        return self.decoder_langs.index(lang_code)
+
+    def get_encoder_lang_code(self, lang_id):
+        return self.encoder_langs[lang_id]
+
+    def get_decoder_lang_code(self, lang_id):
+        return self.decoder_langs[lang_id]

--- a/pytorch_translate/test/test_beam_decode.py
+++ b/pytorch_translate/test/test_beam_decode.py
@@ -4,10 +4,10 @@ import numpy as np
 import torch
 import unittest
 
-from fairseq import models
 from pytorch_translate import beam_decode
 from pytorch_translate import rnn  # noqa
 from pytorch_translate import char_source_model  # noqa (must be after rnn)
+from pytorch_translate import tasks
 from pytorch_translate.test import utils as test_utils
 
 
@@ -16,8 +16,9 @@ class TestBeamDecode(unittest.TestCase):
     def test_basic_generate(self):
         test_args = test_utils.ModelParamsDict()
         _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
-        model = models.build_model(test_args, src_dict, tgt_dict)
-        translator = beam_decode.SequenceGenerator([model])
+        task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
+        model = task.build_model(test_args)
+        translator = beam_decode.SequenceGenerator([model], task.target_dictionary)
         src_tokens = torch.LongTensor([[0, 0, 0], [0, 0, 0]])
         src_lengths = torch.LongTensor([3, 3])
         encoder_input = (src_tokens, src_lengths)
@@ -33,8 +34,9 @@ class TestBeamDecode(unittest.TestCase):
         test_args.char_rnn_layers = 2
 
         _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
-        model = models.build_model(test_args, src_dict, tgt_dict)
-        translator = beam_decode.SequenceGenerator([model])
+        task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
+        model = task.build_model(test_args)
+        translator = beam_decode.SequenceGenerator([model], task.target_dictionary)
         src_tokens = torch.LongTensor([[0, 0, 0], [0, 0, 0]])
         src_lengths = torch.LongTensor([3, 3])
         char_inds = torch.LongTensor(np.zeros((2, 3, 5)))

--- a/pytorch_translate/test/test_data.py
+++ b/pytorch_translate/test/test_data.py
@@ -16,24 +16,24 @@ class TestInMemoryNumpyDataset(unittest.TestCase):
             corpus_files=[self.src_txt, self.trg_txt],
             vocab_file=self.vocab_file_path,
             max_vocab_size=0,
+            padding_factor=1,  # don't add extra padding symbols
         )
-        # src_ref is reversed, +1 for lua
+        # src_ref is reversed
         self.src_ref = [
-            [107, 105, 103, 101],
-            [105, 105, 103, 103, 101, 101],
-            [103, 103, 103, 103, 101, 101, 101, 101],
-            [101, 101, 101, 101, 101, 101, 101, 101, 101, 101],
+            [106, 104, 102, 100],
+            [104, 104, 102, 102, 100, 100],
+            [102, 102, 102, 102, 100, 100, 100, 100],
+            [100, 100, 100, 100, 100, 100, 100, 100, 100, 100],
         ]
         self.trg_ref = [
-            [102, 102, 102, 102, 102, 102, 102, 102, 102, 102],
-            [102, 102, 102, 102, 104, 104, 104, 104],
-            [102, 102, 104, 104, 106, 106],
-            [102, 104, 106, 108],
+            [101, 101, 101, 101, 101, 101, 101, 101, 101, 101],
+            [101, 101, 101, 101, 103, 103, 103, 103],
+            [101, 101, 103, 103, 105, 105],
+            [101, 103, 105, 107],
         ]
         self.src_txt_numberized, self.trg_txt_numberized = test_utils.create_test_numberized_data_files(
             self.src_ref, self.trg_ref, reverse_source=True
         )
-        self.lua_eos = self.d.eos_index + 1
         self.num_sentences = 4
 
     def tearDown(self):
@@ -56,7 +56,7 @@ class TestInMemoryNumpyDataset(unittest.TestCase):
             for i in range(self.num_sentences):
                 self.assertListEqual(self.src_ref[i], src_dataset[i].tolist())
                 self.assertListEqual(
-                    self.trg_ref[i] + [self.lua_eos], trg_dataset[i].tolist()
+                    self.trg_ref[i] + [self.d.eos_index], trg_dataset[i].tolist()
                 )
 
     def test_parse_numberize(self):
@@ -82,7 +82,7 @@ class TestInMemoryNumpyDataset(unittest.TestCase):
             for i in range(self.num_sentences):
                 self.assertListEqual(self.src_ref[i], src_dataset[i].tolist())
                 self.assertListEqual(
-                    self.trg_ref[i] + [self.lua_eos], trg_dataset[i].tolist()
+                    self.trg_ref[i] + [self.d.eos_index], trg_dataset[i].tolist()
                 )
 
     def test_parse_oversampling(self):
@@ -117,8 +117,8 @@ class TestInMemoryNumpyDataset(unittest.TestCase):
                 dialect_id=11, data_file=self.trg_txt, dict=self.d, oversampling=1
             ),
         ]
-        lang1 = corpora[0].dialect_id + 1  # +1 for lua
-        lang2 = corpora[1].dialect_id + 1  # +1 for lua
+        lang1 = corpora[0].dialect_id
+        lang2 = corpora[1].dialect_id
         prepend_dataset.parse_multilingual(
             corpora, reverse_order=False, append_eos=False, prepend_language_id=True
         )

--- a/pytorch_translate/test/test_dictionary.py
+++ b/pytorch_translate/test/test_dictionary.py
@@ -22,6 +22,7 @@ class TestDictionary(unittest.TestCase):
             corpus_files=[src_txt, src_txt, src_txt],
             vocab_file=f"{tmp_prefix}.src2",
             max_vocab_size=1000,
+            padding_factor=1,
         )
         trg_dict1 = dictionary.Dictionary.build_vocab_file(
             corpus_files=[trg_txt], vocab_file=f"{tmp_prefix}.trg1", max_vocab_size=1000
@@ -30,11 +31,13 @@ class TestDictionary(unittest.TestCase):
             corpus_files=[trg_txt, trg_txt, trg_txt],
             vocab_file=f"{tmp_prefix}.trg2",
             max_vocab_size=1000,
+            padding_factor=1,
         )
         srctrg_dict = dictionary.Dictionary.build_vocab_file(
             corpus_files=[src_txt, trg_txt],
             vocab_file=f"{tmp_prefix}.srctrg",
             max_vocab_size=1000,
+            padding_factor=1,
         )
         nspecial = src_dict1.nspecial
         self.assertEqual(len(src_dict1), nspecial + 4)
@@ -72,16 +75,28 @@ class TestDictionary(unittest.TestCase):
         src_txt, trg_txt = test_utils.create_test_text_files()
         tmp_prefix = test_utils.make_temp_file()
         src_dict1 = dictionary.Dictionary.build_vocab_file(
-            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src1", max_vocab_size=1
+            corpus_files=[src_txt],
+            vocab_file=f"{tmp_prefix}.src1",
+            max_vocab_size=1,
+            padding_factor=1,
         )
         src_dict2 = dictionary.Dictionary.build_vocab_file(
-            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src2", max_vocab_size=2
+            corpus_files=[src_txt],
+            vocab_file=f"{tmp_prefix}.src2",
+            max_vocab_size=2,
+            padding_factor=1,
         )
         src_dict3 = dictionary.Dictionary.build_vocab_file(
-            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src3", max_vocab_size=104
+            corpus_files=[src_txt],
+            vocab_file=f"{tmp_prefix}.src3",
+            max_vocab_size=104,
+            padding_factor=1,
         )
         src_dict4 = dictionary.Dictionary.build_vocab_file(
-            corpus_files=[src_txt], vocab_file=f"{tmp_prefix}.src4", max_vocab_size=0
+            corpus_files=[src_txt],
+            vocab_file=f"{tmp_prefix}.src4",
+            max_vocab_size=0,
+            padding_factor=1,
         )
         self.assertEqual(src_dict1.nspecial + 1, len(src_dict1))
         self.assertEqual(src_dict2.nspecial + 2, len(src_dict2))

--- a/pytorch_translate/test/test_train.py
+++ b/pytorch_translate/test/test_train.py
@@ -4,18 +4,19 @@ import torch
 import unittest
 import numpy as np
 
-from fairseq import criterions, models
 from fairseq.trainer import Trainer
 from pytorch_translate import rnn  # noqa
+from pytorch_translate import tasks
 from pytorch_translate.test import utils as test_utils
 
 
 class TestRNNModel(unittest.TestCase):
     def _gpu_train_step(self, test_args):
         samples, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
-        model = models.build_model(test_args, src_dict, tgt_dict)
-        criterion = criterions.build_criterion(test_args, src_dict, tgt_dict)
-        trainer = Trainer(test_args, model, criterion)
+        task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
+        model = task.build_model(test_args)
+        criterion = task.build_criterion(test_args)
+        trainer = Trainer(test_args, task, model, criterion)
         logging_dict = trainer.train_step(next(samples))
         return trainer, logging_dict
 

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -43,7 +43,7 @@ class ModelParamsDict:
         self.lr = [0.1]
         self.optimizer = "sgd"
         self.momentum = 0
-        self.label_smoothing_epsilon = None
+        self.label_smoothing = None
         self.weight_decay = 0.0
         self.lr_scheduler = "fixed"
         self.force_anneal = 0
@@ -54,6 +54,8 @@ class ModelParamsDict:
         self.vocab_reduction_params = None
         self.word_dropout_params = None
         self.distributed_world_size = 1
+        self.seed = 1
+        self.left_pad_source = "True"
         # Modified params
         for param, value in kwargs.items():
             assert hasattr(self, param), (
@@ -141,7 +143,7 @@ def prepare_inputs(
         dataset,
         batch_size=test_args.batch_size,
         collate_fn=(
-            lambda samples: data.LanguagePairDataset.collate(
+            lambda samples: data.language_pair_dataset.collate(
                 samples, src_dict.pad(), src_dict.eos()
             )
         ),
@@ -198,13 +200,12 @@ def create_test_numberized_data_files(src_ref, trg_ref, reverse_source=True):
     if reverse_source:
         src_ref = [reversed(line) for line in src_ref]
 
-    # we subtract 1 because the reference has +1 added for Lua compatibility
     # during parsing
     src = write_lines_to_temp_file(
-        [" ".join([str(ind - 1) for ind in line]) for line in src_ref]
+        [" ".join([str(ind) for ind in line]) for line in src_ref]
     )
     trg = write_lines_to_temp_file(
-        [" ".join([str(ind - 1) for ind in line]) for line in trg_ref]
+        [" ".join([str(ind) for ind in line]) for line in trg_ref]
     )
     return src, trg
 

--- a/pytorch_translate/train_with_tensorboard.py
+++ b/pytorch_translate/train_with_tensorboard.py
@@ -22,10 +22,14 @@ def single_process_tensorboard(args):
         tensorboard_logger.configure(
             args.save_dir + "/runs/" + args.tensorboard_dir)
 
-    extra_state, trainer, dataset = train.setup_training(args)
+    extra_state, trainer, task, epoch_itr = train.setup_training(args)
 
     train_iterator = train.train(
-        args=args, extra_state=extra_state, trainer=trainer, dataset=dataset
+        args=args,
+        extra_state=extra_state,
+        trainer=trainer,
+        task=task,
+        epoch_itr=epoch_itr,
     )
 
     for num_updates, stats in train_iterator:

--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -144,7 +144,7 @@ class BucketStopwatchMeter(object):
         return result
 
 
-def load_diverse_ensemble_for_inference(filenames, src_dict, dst_dict):
+def load_diverse_ensemble_for_inference(filenames, task):
     """Load an ensemble of diverse models for inference.
 
     This method is similar to fairseq.utils.load_ensemble_for_inference
@@ -152,8 +152,7 @@ def load_diverse_ensemble_for_inference(filenames, src_dict, dst_dict):
 
     Args:
         filenames: List of file names to checkpoints
-        src_dict: Source dictionary
-        dst_dict: Target dictionary
+        task: FairseqTask
 
     Return:
         models, args: Tuple of lists. models contains the loaded models, args
@@ -176,7 +175,7 @@ def load_diverse_ensemble_for_inference(filenames, src_dict, dst_dict):
     # build ensemble
     ensemble = []
     for state in states:
-        model = models.build_model(state["args"], src_dict, dst_dict)
+        model = task.build_model(state["args"])
         model.load_state_dict(state["model"])
         ensemble.append(model)
     return ensemble, [s["args"] for s in states]

--- a/pytorch_translate/weighted_criterions.py
+++ b/pytorch_translate/weighted_criterions.py
@@ -8,8 +8,8 @@ from fairseq import utils
 
 @register_criterion("weighted_label_smoothed_cross_entropy")
 class WeightedLabelSmoothedCrossEntropyCriterion(FairseqCriterion):
-    def __init__(self, args, src_dict, dst_dict):
-        super().__init__(args, src_dict, dst_dict)
+    def __init__(self, args, task):
+        super().__init__(args, task)
         self.eps = args.label_smoothing
 
     @classmethod

--- a/pytorch_translate/weighted_data.py
+++ b/pytorch_translate/weighted_data.py
@@ -2,10 +2,10 @@
 
 import torch
 
-from fairseq import data, indexed_dataset
+from fairseq import data
 
 
-class IndexedWeightsDataset(indexed_dataset.IndexedDataset):
+class IndexedWeightsDataset(data.IndexedDataset):
     def __init__(self, path):
         self.values = []
         self.read_data(path)
@@ -33,8 +33,17 @@ class WeightedLanguagePairDataset(data.LanguagePairDataset):
     has a weight in [0.0, 1.0], which will be used to weigh the loss.
     """
 
-    def __init__(self, src, dst, pad_idx, eos_idx, weights=None):
-        super().__init__(src, dst, pad_idx, eos_idx)
+    def __init__(
+        self, src, src_sizes, src_dict,
+        tgt=None, tgt_sizes=None, tgt_dict=None,
+        weights=None,
+        **kwargs,
+    ):
+        super().__init__(
+            src, src_sizes, src_dict,
+            tgt, tgt_sizes, tgt_dict,
+            **kwargs
+        )
         self.weights = weights
 
     def __getitem__(self, i):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'fairseq',
     ],
     dependency_links=[
-        'git+https://github.com/pytorch/fairseq.git@v0.4.0#egg=fairseq',
+        'git+https://github.com/pytorch/fairseq.git#egg=fairseq',
     ],
     test_suite='pytorch_translate',
 )


### PR DESCRIPTION
Summary:
The latest version of fairseq introduces several enhancements, including FP16
training, Transformer, and the concept of a FairseqTask that holds the
dictionaries and loads any FairseqDatasets.

To update pytorch_translate we move the relevant dataloading to two new FairseqTasks:
- PytorchTranslateTask: main translation task
- PytorchTranslateMultilingualTask: a variant of the above for multilingual translation
- DictionaryHolderTask: a simplified task that just holds the dictionaries (no datasets), mostly for unit tests

Changelog:
- add support for FP16 training (`--fp16`)
- args.path is now colon-separated instead of argparse append
- `--save-interval` renamed to `--save-interval-updates`
- IndexedDataset no longer has Lua +1/-1 hacks
- pad dictionaries and batches to multiples of 8
- don't read dictionaries from models, pass them explicitly (e.g., pass tgt_dict to beam search explicitly).
- fairseq.utils.make_variable and utils.maybe_no_grad are deprecated
- dictionary pruning is moved to Dictionary.finalize (instead of Dictionary.save)
- LanguagePairDataset.LEFT_PAD_* constants are deprecated

Reviewed By: liezl200

Differential Revision: D8553019
