### PR TITLE
MLP attention

### DIFF
--- a/pytorch_translate/attention/attention_utils.py
+++ b/pytorch_translate/attention/attention_utils.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import torch
+import torch.nn.functional as F
+import numpy as np
 
 
 def create_src_lengths_mask(batch_size, src_lengths):
@@ -26,3 +28,16 @@ def create_src_lengths_mask(batch_size, src_lengths):
     )
     # returns [batch_size, max_seq_len]
     return (src_indices < src_lengths).int().detach()
+
+
+def masked_softmax(scores, src_lengths, src_length_masking=True):
+    """Apply source length masking then softmax.
+    Input and output have shape bsz x src_len"""
+    if src_length_masking:
+        bsz, max_src_len = scores.size()
+        # compute masks
+        src_mask = create_src_lengths_mask(bsz, src_lengths)
+        # Fill pad positions with -inf
+        scores = scores.masked_fill(src_mask == 0, -np.inf)
+
+    return F.softmax(scores, dim=-1)

--- a/pytorch_translate/attention/mlp_attention.py
+++ b/pytorch_translate/attention/mlp_attention.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from pytorch_translate.attention import (
+    BaseAttention,
+    register_attention,
+    attention_utils,
+)
+from pytorch_translate.common_layers import Linear
+
+
+@register_attention('mlp')
+class MLPAttention(BaseAttention):
+    """The original attention from Badhanau et al. (2014)
+    https://arxiv.org/abs/1409.0473 based on a Multi-Layer Perceptron.
+
+    The attention score between position i in the encoder and position j in the
+    decoder is:
+    alpha_ij = V_a * tanh(W_ae * enc_i + W_ad * dec_j + b_a)
+    """
+
+    def __init__(self, decoder_hidden_state_dim, context_dim, **kwargs):
+        super().__init__(decoder_hidden_state_dim, context_dim)
+
+        self.context_dim = context_dim
+        self.attention_dim = kwargs.get("attention_dim", context_dim)
+        # W_ae and b_a
+        self.encoder_proj = Linear(
+            context_dim, self.attention_dim, bias=True
+        )
+        # W_ad
+        self.decoder_proj = Linear(
+            decoder_hidden_state_dim, self.attention_dim, bias=False
+        )
+        # V_a
+        self.to_scores = Linear(
+            self.attention_dim, 1, bias=False
+        )
+        self.src_length_masking = kwargs.get("src_length_masking", True)
+
+    def forward(self, decoder_state, source_hids, src_lengths):
+        """The expected input dimensions are:
+
+        decoder_state: bsz x decoder_hidden_state_dim
+        source_hids: src_len x bsz x context_dim
+        src_lengths: bsz
+        """
+        src_len, bsz, _ = source_hids.size()
+        # (src_len*bsz) x context_dim (to feed through linear)
+        flat_source_hids = source_hids.view(-1, self.context_dim)
+        # (src_len*bsz) x attention_dim
+        encoder_component = self.encoder_proj(flat_source_hids)
+        # src_len x bsz x attention_dim
+        encoder_component = encoder_component.view(src_len, bsz, self.attention_dim)
+        # 1 x bsz x attention_dim
+        decoder_component = self.decoder_proj(decoder_state).unsqueeze(0)
+        # Sum with broadcasting and apply the non linearity
+        # src_len x bsz x attention_dim
+        hidden_att = F.tanh(
+            (decoder_component + encoder_component).view(-1, self.attention_dim)
+        )
+        # Project onto the reals to get attentions scores (bsz x src_len)
+        attn_scores = self.to_scores(hidden_att).view(src_len, bsz).t()
+
+        # Mask + softmax (src_len x bsz)
+        normalized_masked_attn_scores = attention_utils.masked_softmax(
+            attn_scores, src_lengths, self.src_length_masking
+        ).t()
+
+        # Sum weighted sources (bsz x context_dim)
+        attn_weighted_context = (
+            source_hids * normalized_masked_attn_scores.unsqueeze(2)
+        ).sum(0)
+
+        return attn_weighted_context, normalized_masked_attn_scores

--- a/pytorch_translate/test/test_attention.py
+++ b/pytorch_translate/test/test_attention.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import unittest
+import torch
+
+from pytorch_translate.attention import attention_utils
+
+from pytorch_translate.attention import dot_attention
+from pytorch_translate.attention import mlp_attention
+
+
+class TestAttention(unittest.TestCase):
+
+    def setUp(self):
+        self.bsz = 10
+        self.src_len = 5
+        self.ctx_dim = 3
+        self.dec_dim = 4
+        self.att_dim = 2
+
+    def test_masked_softmax(self):
+        scores = torch.rand(20, 20)
+        lengths = torch.arange(start=1, end=21)
+
+        masked_normalized_scores = attention_utils.masked_softmax(
+            scores, lengths, src_length_masking=True
+        )
+
+        for i in range(20):
+            scores_sum = masked_normalized_scores[i].numpy().sum()
+            self.assertAlmostEqual(scores_sum, 1, places=6)
+
+    def _test_attention(self, attention):
+        dummy_source_hids = torch.rand(self.src_len, self.bsz, self.ctx_dim)
+        dummy_decoder_state = torch.rand(self.bsz, self.dec_dim)
+        dummy_src_lengths = torch.fmod(torch.arange(self.bsz), self.src_len) + 1
+        attention(dummy_decoder_state, dummy_source_hids, dummy_src_lengths)
+
+    def test_dot_attention(self):
+        self._test_attention(
+            dot_attention.DotAttention(
+                self.dec_dim,
+                self.ctx_dim,
+                src_length_masking=True,
+                force_projection=True,
+            )
+        )
+
+    def test_mlp_attention(self):
+        self._test_attention(
+            mlp_attention.MLPAttention(
+                self.dec_dim,
+                self.ctx_dim,
+                src_length_masking=True,
+                attention_dim=self.att_dim,
+            )
+        )


### PR DESCRIPTION
Summary:
This implements the MLP style attention from the original paper.

This also reformats the `dot_attention` a little bit and adds unit tests for masking, dot and MLP attention

Differential Revision: D8811304
