### PR TITLE
pretrained embeddings

### DIFF
--- a/pytorch_translate/ngram.py
+++ b/pytorch_translate/ngram.py
@@ -43,6 +43,8 @@ class NGramDecoder(DecoderWithOutputProjection):
         residual_level=None,
         activation_fn=nn.ReLU,
         project_output=True,
+        pretrained_embed=None,
+        projection_pretrained_embed=None,
     ):
         super().__init__(
             src_dict,
@@ -50,6 +52,7 @@ class NGramDecoder(DecoderWithOutputProjection):
             vocab_reduction_params,
             out_embed_dim,
             project_output=project_output,
+            pretrained_embed=projection_pretrained_embed,
         )
         self.history_len = n - 1
         self.encoder_hidden_dim = encoder_hidden_dim
@@ -70,6 +73,7 @@ class NGramDecoder(DecoderWithOutputProjection):
             embedding_dim=embed_dim,
             padding_idx=padding_idx,
             freeze_embed=freeze_embed,
+            pretrained_embed=pretrained_embed,
         )
 
         self.history_conv = nn.Sequential(

--- a/pytorch_translate/test/test_train.py
+++ b/pytorch_translate/test/test_train.py
@@ -2,6 +2,7 @@
 
 import torch
 import unittest
+import numpy as np
 
 from fairseq import criterions, models
 from fairseq.trainer import Trainer
@@ -29,6 +30,39 @@ class TestRNNModel(unittest.TestCase):
         test_args = test_utils.ModelParamsDict(
             encoder_freeze_embed=True, decoder_freeze_embed=True
         )
+        self._gpu_train_step(test_args)
+
+    def test_load_pretrained_embedding(self):
+        encoder_embedding = open(test_utils.make_temp_file(), "wb")
+        test_args = test_utils.ModelParamsDict(
+            encoder_pretrained_embed=encoder_embedding.name,
+        )
+        # The vocabulary defaults to 103 in test_utils.prepare_inputs.
+        embed_array = np.random.random((103, test_args.encoder_embed_dim))
+        np.save(encoder_embedding, embed_array)
+        encoder_embedding.close()
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        model = models.build_model(test_args, src_dict, tgt_dict)
+        assert np.allclose(
+            model.encoder.embed_tokens.weight.data.numpy(),
+            embed_array,
+        )
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
+    def test_gpu_pretrained_embedding(self):
+        encoder_embedding = open(test_utils.make_temp_file(), "wb")
+        decoder_embedding = open(test_utils.make_temp_file(), "wb")
+        test_args = test_utils.ModelParamsDict(
+            encoder_pretrained_embed=encoder_embedding.name,
+            decoder_pretrained_embed=decoder_embedding.name,
+            encoder_freeze_embed=True,
+            decoder_freeze_embed=True,
+        )
+        # The vocabulary defaults to 103 in test_utils.prepare_inputs.
+        np.save(encoder_embedding, np.zeros((103, test_args.encoder_embed_dim)))
+        encoder_embedding.close()
+        np.save(decoder_embedding, np.zeros((103, test_args.decoder_embed_dim)))
+        decoder_embedding.close()
         self._gpu_train_step(test_args)
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -15,6 +15,7 @@ class ModelParamsDict:
         # Model params
         self.arch = "rnn"
         self.encoder_embed_dim = 10
+        self.encoder_pretrained_embed = None
         self.encoder_freeze_embed = False
         self.encoder_hidden_dim = 10
         self.encoder_layers = 2
@@ -22,9 +23,11 @@ class ModelParamsDict:
         self.encoder_dropout_in = 0
         self.encoder_dropout_out = 0
         self.decoder_embed_dim = 10
+        self.decoder_pretrained_embed = None
         self.decoder_freeze_embed = False
         self.decoder_hidden_dim = 10
         self.decoder_out_embed_dim = 5
+        self.decoder_out_pretrained_embed = None
         self.decoder_layers = 2
         self.dropout = 0
         self.decoder_dropout_in = 0


### PR DESCRIPTION
Summary: Added command-line flag to train.py to allow loading pretrained embeddings from a .npy file. This is the first part of a two-commit stack to support pretrained embeddings in fbtranslate.

Differential Revision: D8828501
