### PR TITLE
Run translate tests instead of fairseq tests

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -2,7 +2,7 @@
 # Builds PyTorch Translate and runs basic tests.
 
 pip uninstall -y pytorch-translate
-python3 setup.py build develop
+sudo python3 setup.py build develop
 pushd pytorch_translate/cpp || exit
 
 mkdir build && pushd build || exit

--- a/docker/jenkins/install_prereqs.sh
+++ b/docker/jenkins/install_prereqs.sh
@@ -39,3 +39,6 @@ conda install -y numpy==1.14 --no-deps --force
 echo "Starting to install ONNX"
 git clone --recursive https://github.com/onnx/onnx.git
 yes | pip install ./onnx 2>&1 | tee ONNX_OUT
+
+# train with tensorboard
+yes | pip install tensorboard_logger

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     dependency_links=[
         'git+https://github.com/pytorch/fairseq.git@v0.4.0#egg=fairseq',
     ],
-    test_suite='tests',
+    test_suite='pytorch_translate',
 )


### PR DESCRIPTION
Summary: `python3 setup.py test` should run translate tests, not fairseq tests.

Differential Revision: D8859221
