### PR TITLE
Remove template parameter from Tensor (#9125)

### DIFF
--- a/pytorch_translate/cpp/BatchedBeamSearch.cpp
+++ b/pytorch_translate/cpp/BatchedBeamSearch.cpp
@@ -45,7 +45,7 @@ BeamSearchOutput BatchedBeamSearch::beamSearch(
 
   // Create tensor of numberizedInput
   auto inputBlob = caffe2::make_unique<caffe2::Blob>();
-  caffe2::TensorCPU* inputTensor = inputBlob->GetMutable<caffe2::TensorCPU>();
+  caffe2::TensorCPU* inputTensor = inputBlob->GetMutableTensor(caffe2::CPU);
   inputTensor->Resize(numberizedInput.size(), 1);
   auto* inputPointer = inputTensor->mutable_data<long>();
 
@@ -64,7 +64,7 @@ BeamSearchOutput BatchedBeamSearch::beamSearch(
   // Create tensor encoderLen
   auto encoderLenBlob = caffe2::make_unique<caffe2::Blob>();
   caffe2::TensorCPU* encoderLenTensor =
-      encoderLenBlob->GetMutable<caffe2::TensorCPU>();
+      encoderLenBlob->GetMutableTensor(caffe2::CPU);
   encoderLenTensor->Resize(1);
   auto* encoderLenPointer = encoderLenTensor->mutable_data<int>();
   encoderLenPointer[0] = numberizedInput.size();
@@ -152,7 +152,7 @@ TensorMap BatchedBeamSearch::prepareInitialNextInputStepMap(
 
   auto initialTimestepBlob = caffe2::make_unique<caffe2::Blob>();
   auto* initialTimestepTensor =
-      initialTimestepBlob->GetMutable<caffe2::TensorCPU>();
+      initialTimestepBlob->GetMutableTensor(caffe2::CPU);
   auto timestepDeleter = initialTimestepBlob->Release();
   if (timestepDeleter != nullptr) {
     (*trackRawPointers)[initialTimestepTensor] = timestepDeleter;
@@ -162,7 +162,7 @@ TensorMap BatchedBeamSearch::prepareInitialNextInputStepMap(
 
   auto initialPrevtokenBlob = caffe2::make_unique<caffe2::Blob>();
   auto* initialPrevtokenTensor =
-      initialPrevtokenBlob->GetMutable<caffe2::TensorCPU>();
+      initialPrevtokenBlob->GetMutableTensor(caffe2::CPU);
   auto prevtokenDeleter = initialPrevtokenBlob->Release();
   if (prevtokenDeleter != nullptr) {
     (*trackRawPointers)[initialPrevtokenTensor] = prevtokenDeleter;
@@ -172,7 +172,7 @@ TensorMap BatchedBeamSearch::prepareInitialNextInputStepMap(
 
   auto initialPrevScoresBlob = caffe2::make_unique<caffe2::Blob>();
   auto* initialPrevScoresTensor =
-      initialPrevScoresBlob->GetMutable<caffe2::TensorCPU>();
+      initialPrevScoresBlob->GetMutableTensor(caffe2::CPU);
   auto prevScoresDeleter = initialPrevScoresBlob->Release();
   if (prevScoresDeleter != nullptr) {
     (*trackRawPointers)[initialPrevScoresTensor] = prevScoresDeleter;
@@ -211,7 +211,7 @@ TensorMap BatchedBeamSearch::prepareNextInputStepMap(
 
         auto tiledEncoderOutputsBlob = caffe2::make_unique<caffe2::Blob>();
         caffe2::TensorCPU* tiledEncoderOutputTensor =
-            tiledEncoderOutputsBlob->GetMutable<caffe2::TensorCPU>();
+            tiledEncoderOutputsBlob->GetMutableTensor(caffe2::CPU);
         auto sourceLength = untiledTensor->dims()[0];
         auto hiddenSize = untiledTensor->dims()[2];
         tiledEncoderOutputTensor->Resize(sourceLength, beamSize_, hiddenSize);
@@ -255,7 +255,7 @@ TensorMap BatchedBeamSearch::prepareNextInputStepMap(
   }
 
   auto timestepBlob = caffe2::make_unique<caffe2::Blob>();
-  auto* timestepTensor = timestepBlob->GetMutable<caffe2::TensorCPU>();
+  auto* timestepTensor = timestepBlob->GetMutableTensor(caffe2::CPU);
   auto timestepDeleter = timestepBlob->Release();
   if (timestepDeleter != nullptr) {
     (*trackRawPointers)[timestepTensor] = timestepDeleter;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/9125

Closes https://github.com/pytorch/pytorch/pull/9125

Use inheritance for polymorphism, and remove template parameter
This is to change the templating in call sites, the core implementations will change later

We removed template parameter from Tensor as an effort to Pytorch and Caffe2 backend unification.

## New caffe2::Tensor class

Before Caffe2 Tensor class was compile-time fixed to bind to a particular device/context. With this change, we're making it a runtime property (stored inside the tensor), but preserve the same semantics. For example, one has to specify device type in order to create a Tensor - there are no uninitialized tensors. More specifically the changes are:

1. We added an extra argument *DeviceType* to most of the constructors of the tensor, e.g. (Tensor(DeviceType type)),
2. Semantics of constructor Tensor(const Tensor<SrcContext>& src, ContextForCopy* context); is changed, in this constructor, the second context is passed in to enable us to call the templated Copy function, it could be in a different context as source and target previously, now we'll enforce that the context should have same device type as src, if it is provided.
3. To preserve 'get-or-construct' semantics of Blob, we added specialized getter Blob::GetMutableTensor that verifies both that Blob contains a Tensor and that it's of a correct type
4. Specifically, Tensor type is not default-constructible any more (as we don't have unknown device tensors) and thus some of the code handling STL containers needs to change

For details about how the tensor class look like right now, please see https://github.com/pytorch/pytorch/blob/master/caffe2/core/tensor.h

We did a massive codemod of the fbsource and hopefully covered majority of usages. However, there are probably a few that slipped through the contbuild. You might need to refactor your custom code according the following guide:
```
# Tensor
## Type
using TensorCPU = Tensor<CPUContext>; --> using TensorCPU = Tensor;

## Construction
### As class member variable
TensorCPU x; --> Tensor x{CPU};
// TensorCPU is just Tensor<CPUContext>, if Tensor is templated on Context,
// we'll write:
Tensor<Context> x; --> Tensor x{Context::GetDeviceType()};
// In the following we'll just use TensorCPU as example
### As local variable
TensorCPU x; --> Tensor x(CPU);
### make_unique
make_unique<TensorCPU>() --> make_unique<Tensor>(CPU)
### Constructor by context
CUDAContext context;
// y is a TensorCPU
TensorCPU x(y, &context); // this constructor is removed

-->

Tensor x(y, &context, CPU);
## Containers
### Vector initialization
 vector<TensorCPU> tensors(numTensors);
 -->
 vector<TensorCPU> tensors;
 for (auto i = 0; i < numTensors; ++i) {
   tensors.emplace_back(CPU);
 }
### Vector access
No change
### Map construction
map<string, TensorCPU> tensor_map;
tensor_map.insert(std::pair<string, TensorCPU>(name, TensorCPU()));
-->
tensor_map.emplace(name, Tensor(CPU));
 
### Map access ([])
map<TensorCPU> map;
map[name]
--> 
map.emplace(name, Tensor(CPU));
 map.at(name);

# Blob
GetMutable<TensorCPU> --> GetMutableTensor(CPU)

# Note for Get function we just keep it as Get<TensorCPU>()(equivalent to Get<Tensor>()) at this moment
# Since it won't affect the current running code
# ideally it should be rewritten as following, which gives an extra verification
# on the type of tensor contained in the blob
Get<TensorCPU>() --> Get<Tensor>(CPU);
```
## Context and StaticContext

We virtualized the functions in Context in order to achieve runtime polymorphism. The static functions has been split into a StaticContext class, which has one to one correspondence with DeviceType (CPU, CUDA etc.) and it has a global singleton object. We'll store a pointer to the singleton in Tensor to indicate the context of Tensor.
Original Context class contained routines to copy between different contexts, however, most of the time the use case is between three types of copies: CopyToCPU, CopyFromCPU and CopySameDevice, therefore, in the new Context, while we still keep the one general templated function that can copy between arbitrary contexts (CopyBytes), we rewrote the other uses of the Copy into these three special variants of copies that do not rely on template.
```
# Context
Copy<int, CPUContext, CUDAContext>(...) --> CopyFromCPU<int>(...)
Copy<int, CUDAContext, CPUContext>(...) --> CopyToCPU<int>(...)
Copy<int, CUDAContext, CUDAContext>(...) --> CopySameDevice<int>(...)
Similarily,
Copy<CPUContext, CUDAContext>(...) --> CopyFromCPU(...)
We also have calls using CopyItems/CopyBytes

As a side note, the distinction between three copies is that:
- CopyBytes is copy of data pointed by raw pointers (void*)
- Copy is templated on the data type that we want to copy (T*)
- CopyItems get the type info from explicitly passed TypeMeta
```

Differential Revision: D8121878