### PR TITLE
Minor fixes for fairseq models

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -275,8 +275,11 @@ def setup_training(args):
         num_shards=args.distributed_world_size,
         shard_id=args.distributed_rank,
     )
+    epoch = extra_state["epoch"]
+    if extra_state["batch_offset"] == 0:
+        epoch -= 1  # this will be incremented when we call epoch_itr.next_epoch_itr()
     epoch_itr.load_state_dict({
-        "epoch": extra_state["epoch"],
+        "epoch": epoch,
         "iterations_in_epoch": extra_state["batch_offset"],
     })
 

--- a/pytorch_translate/weighted_data.py
+++ b/pytorch_translate/weighted_data.py
@@ -59,6 +59,8 @@ class WeightedLanguagePairDataset(data.language_pair_dataset.LanguagePairDataset
         return super().__len__()
 
     def collater(self, samples):
+        if len(samples) == 0:
+            return {}
         unweighted_data = super().collater(samples)
         original_weights = torch.FloatTensor([s['weight'] for s in samples])
         # sort by descending source length


### PR DESCRIPTION
Summary:
- The reorder_encoder_out API requires a kwarg named `encoder_out` (not `encoder_out_dict`)
- Fix collating of empty sample lists
- Fix epoch counter in train.py to properly start at 1

Reviewed By: jhcross

Differential Revision: D8985232
