### PR TITLE
Consolidate default extra_state

### DIFF
--- a/pytorch_translate/multi_model.py
+++ b/pytorch_translate/multi_model.py
@@ -688,10 +688,3 @@ def import_individual_models(restore_files, trainer):
     trainer.model.load_state_dict(model_state, strict=False)
     print(f"|  Imported {len(model_state)} parameters.")
     trainer._optim_history = []
-    return {
-        "epoch": 1,
-        "batch_offset": 0,
-        "val_loss": None,
-        "start_time": time.time(),
-        "last_bleu_eval": 0,
-    }

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -590,7 +590,10 @@ def validate_generation_args(args):
         "Argument --lenpen is IGNORED by pytorch_translate. Use "
         "--length-penalty instead."
     )
-    pass
+    if "generate_bleu_eval_avg_checkpoints" in args:
+        assert (
+            args.generate_bleu_eval_avg_checkpoints >= 1
+        ), "--generate-bleu-eval-avg-checkpoints must be >= 1."
 
 
 def add_verbosity_args(parser, train=False):


### PR DESCRIPTION
Summary:
In addition, fixed loading from checkpoint without restoring state after fairseq 0.5.0 update

Also removed some unused imports - and Black was responsible for the import reordering

(I kind of wish fairseq and we were using a protocol buffer-like thing for extra_state instead of dict - so we can define the expected fields instead of just having arbitrary strings, and being able to extend fairseq's protocol buffer w/ our own fields)

Differential Revision: D9004061
