### PR TITLE
Remove template parameter from Tensor (#13)

### DIFF
--- a/pytorch_translate/cpp/BatchedBeamSearch.cpp
+++ b/pytorch_translate/cpp/BatchedBeamSearch.cpp
@@ -45,7 +45,7 @@ BeamSearchOutput BatchedBeamSearch::beamSearch(
 
   // Create tensor of numberizedInput
   auto inputBlob = caffe2::make_unique<caffe2::Blob>();
-  caffe2::TensorCPU* inputTensor = inputBlob->GetMutable<caffe2::TensorCPU>();
+  caffe2::TensorCPU* inputTensor = inputBlob->GetMutableTensor(caffe2::CPU);
   inputTensor->Resize(numberizedInput.size(), 1);
   auto* inputPointer = inputTensor->mutable_data<long>();
 
@@ -64,7 +64,7 @@ BeamSearchOutput BatchedBeamSearch::beamSearch(
   // Create tensor encoderLen
   auto encoderLenBlob = caffe2::make_unique<caffe2::Blob>();
   caffe2::TensorCPU* encoderLenTensor =
-      encoderLenBlob->GetMutable<caffe2::TensorCPU>();
+      encoderLenBlob->GetMutableTensor(caffe2::CPU);
   encoderLenTensor->Resize(1);
   auto* encoderLenPointer = encoderLenTensor->mutable_data<int>();
   encoderLenPointer[0] = numberizedInput.size();
@@ -152,7 +152,7 @@ TensorMap BatchedBeamSearch::prepareInitialNextInputStepMap(
 
   auto initialTimestepBlob = caffe2::make_unique<caffe2::Blob>();
   auto* initialTimestepTensor =
-      initialTimestepBlob->GetMutable<caffe2::TensorCPU>();
+      initialTimestepBlob->GetMutableTensor(caffe2::CPU);
   auto timestepDeleter = initialTimestepBlob->Release();
   if (timestepDeleter != nullptr) {
     (*trackRawPointers)[initialTimestepTensor] = timestepDeleter;
@@ -162,7 +162,7 @@ TensorMap BatchedBeamSearch::prepareInitialNextInputStepMap(
 
   auto initialPrevtokenBlob = caffe2::make_unique<caffe2::Blob>();
   auto* initialPrevtokenTensor =
-      initialPrevtokenBlob->GetMutable<caffe2::TensorCPU>();
+      initialPrevtokenBlob->GetMutableTensor(caffe2::CPU);
   auto prevtokenDeleter = initialPrevtokenBlob->Release();
   if (prevtokenDeleter != nullptr) {
     (*trackRawPointers)[initialPrevtokenTensor] = prevtokenDeleter;
@@ -172,7 +172,7 @@ TensorMap BatchedBeamSearch::prepareInitialNextInputStepMap(
 
   auto initialPrevScoresBlob = caffe2::make_unique<caffe2::Blob>();
   auto* initialPrevScoresTensor =
-      initialPrevScoresBlob->GetMutable<caffe2::TensorCPU>();
+      initialPrevScoresBlob->GetMutableTensor(caffe2::CPU);
   auto prevScoresDeleter = initialPrevScoresBlob->Release();
   if (prevScoresDeleter != nullptr) {
     (*trackRawPointers)[initialPrevScoresTensor] = prevScoresDeleter;
@@ -211,7 +211,7 @@ TensorMap BatchedBeamSearch::prepareNextInputStepMap(
 
         auto tiledEncoderOutputsBlob = caffe2::make_unique<caffe2::Blob>();
         caffe2::TensorCPU* tiledEncoderOutputTensor =
-            tiledEncoderOutputsBlob->GetMutable<caffe2::TensorCPU>();
+            tiledEncoderOutputsBlob->GetMutableTensor(caffe2::CPU);
         auto sourceLength = untiledTensor->dims()[0];
         auto hiddenSize = untiledTensor->dims()[2];
         tiledEncoderOutputTensor->Resize(sourceLength, beamSize_, hiddenSize);
@@ -255,7 +255,7 @@ TensorMap BatchedBeamSearch::prepareNextInputStepMap(
   }
 
   auto timestepBlob = caffe2::make_unique<caffe2::Blob>();
-  auto* timestepTensor = timestepBlob->GetMutable<caffe2::TensorCPU>();
+  auto* timestepTensor = timestepBlob->GetMutableTensor(caffe2::CPU);
   auto timestepDeleter = timestepBlob->Release();
   if (timestepDeleter != nullptr) {
     (*trackRawPointers)[timestepTensor] = timestepDeleter;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/weakly-supervised-action-detection/pull/13

Pull Request resolved: https://github.com/pytorch/translate/pull/166

Pull Request resolved: https://github.com/pytorch/pytorch/pull/9125

Closes https://github.com/pytorch/pytorch/pull/9125

Use inheritance for polymorphism, and remove template parameter
This is to change the templating in call sites, the core implementations will change later

Before Caffe2 Tensor class was compile-time fixed to bind to a particular device/context. With this change, we're making it a runtime property (stored inside the tensor), but preserve the same semantics. For example, one has to specify device type in order to create a Tensor - there are no uninitialized tensors. More specifically the changes are:

1. We added an extra argument *DeviceType* to most of the constructors of the tensor, e.g. (Tensor(DeviceType type)),
2. Semantics of constructor Tensor(const Tensor<SrcContext>& src, ContextForCopy* context); is changed, in this constructor, the second context is passed in to enable us to call the templated Copy function, it could be in a different context as source and target previously, now we'll enforce that the context should have same device type as src, if it is provided.
3. To preserve 'get-or-construct' semantics of Blob, we added specialized getter Blob::GetMutableTensor that verifies both that Blob contains a Tensor and that it's of a correct type
4. Specifically, Tensor type is not default-constructible any more (as we don't have unknown device tensors) and thus some of the code handling STL containers needs to change

Note: Some changes are postponed just to keep this diff a bit smaller. Please see `TODO`s.

Reviewed By: ezyang, houseroad

Differential Revision: D9024330
