### PR TITLE
use fairseq conventions for loading pretrained embeddings

### DIFF
--- a/pytorch_translate/ngram.py
+++ b/pytorch_translate/ngram.py
@@ -4,7 +4,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from fairseq import utils
-from pytorch_translate import attention
+from pytorch_translate import (
+    attention,
+    utils as pytorch_translate_utils,
+)
 from pytorch_translate.common_layers import (
     DecoderWithOutputProjection,
     Embedding,
@@ -71,6 +74,10 @@ class NGramDecoder(DecoderWithOutputProjection):
             embedding_dim=embed_dim,
             padding_idx=padding_idx,
             freeze_embed=freeze_embed,
+        )
+        pytorch_translate_utils.load_embedding(
+            embedding=self.embed_tokens,
+            dictionary=dst_dict,
             pretrained_embed=pretrained_embed,
         )
 

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -17,7 +17,7 @@ class ModelParamsDict:
         # Model params
         self.arch = "rnn"
         self.encoder_embed_dim = 10
-        self.encoder_pretrained_embed = None
+        self.encoder_embed_path = None
         self.encoder_freeze_embed = False
         self.encoder_hidden_dim = 10
         self.encoder_layers = 2
@@ -25,11 +25,11 @@ class ModelParamsDict:
         self.encoder_dropout_in = 0
         self.encoder_dropout_out = 0
         self.decoder_embed_dim = 10
-        self.decoder_pretrained_embed = None
+        self.decoder_embed_path = None
         self.decoder_freeze_embed = False
         self.decoder_hidden_dim = 10
         self.decoder_out_embed_dim = 5
-        self.decoder_out_pretrained_embed = None
+        self.decoder_out_embed_path = None
         self.decoder_layers = 2
         self.dropout = 0
         self.decoder_dropout_in = 0
@@ -190,6 +190,36 @@ def create_lexical_dictionaries():
     )
     return [lexical_dictionary_path]
 
+
+def create_pretrained_embed(dictionary, embed_dim):
+    """Creates a dummy embedding file in the format accepted by fairseq. An
+    embedding file has the following format: the first line has vocabulary size
+    and dimension. The following lines contain word and space-separated
+    embedding values.
+
+    Example:
+        2 5
+        the -0.0230 -0.0264  0.0287  0.0171  0.1403
+        at -0.0395 -0.1286  0.0275  0.0254 -0.0932
+
+    Arguments:
+        dictionary (fairseq.data.dictionary.Dictionary): dictionary with
+            sample tokens as entries
+        embed_dim (int): embedding dimension to be generated
+
+    Returns:
+        Path to a text file with dummy embeddings in the format described above.
+    """
+
+    embed_weights = np.random.random((len(dictionary), embed_dim))
+    pretrained_embed_path = write_lines_to_temp_file(
+        ["{} {}".format(len(dictionary), embed_dim)] +
+        [
+            "{} {}".format(token, " ".join([str(val) for val in embedding]))
+            for token, embedding in zip(dictionary.symbols, embed_weights)
+        ]
+    )
+    return pretrained_embed_path, embed_weights
 
 def create_test_text_files():
     src = write_lines_to_temp_file(

--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -7,7 +7,7 @@ import os
 import time
 
 import torch
-from fairseq import models
+from fairseq import utils
 
 
 # Helper type for argparse to enable flippable boolean flags. For example,
@@ -269,3 +269,26 @@ def average_tensors(tensor_list, norm_fn=None, weights=None):
     for f, w, t in zip(norm_fn, weights, tensor_list):
         acc += w * f(t, dim=-1)
     return acc
+
+
+def load_embedding(embedding, dictionary, pretrained_embed):
+    """Loads pretrained embeddings.
+
+    Loads pretrained embeddings into a nn.Embedding layer. pretrained_embed
+    can either be a nn.Embedding layer, in which case the embedding is set
+    to the pretrained_embed argument, or a path to an embedding file.
+
+    Arguments:
+        embedding (nn.Embedding): Embedding layer whose weights are to be set.
+        dictionary (fairseq.data.dictionary.Dictionary): dictionary with the
+            same vocabulary size as the embedding argument.
+        pretrained_embed (Union(string, nn.Embedding)): source of the
+            weights to be loaded.
+    """
+    if pretrained_embed is None:
+        pass
+    elif isinstance(pretrained_embed, torch.nn.Embedding):
+        embedding.weight = pretrained_embed.weight
+    else:
+        embed_dict = utils.parse_embedding(pretrained_embed)
+        utils.load_embedding(embed_dict, dictionary, embedding)


### PR DESCRIPTION
Summary: Changes pytorch_translate.transformer to use Embedding in common_layers, which allows freezing embedding weights. Also changed the pretrained embedding format to match fairseq

Reviewed By: liezl200

Differential Revision: D9023952
