### PR TITLE
Fix transformer import in `generate.py`

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -9,6 +9,7 @@ import torch
 from fairseq import bleu, data, options, progress_bar, tasks, tokenizer, utils
 from fairseq.meters import StopwatchMeter, TimeMeter
 from pytorch_translate import rnn  # noqa
+from pytorch_translate import transformer  # noqa
 from pytorch_translate import (
     beam_decode,
     char_data,


### PR DESCRIPTION
Summary:
This fixes an issue where running `generate.py` with a transformer model would break with the following error:

```
KeyError: 'ptt_transformer'
```

Created from Diffusion's 'Open in Editor' feature.

Differential Revision: D9162897
