### PR TITLE
convert fp16 back to fp32 before averaging

### DIFF
--- a/pytorch_translate/average_checkpoints.py
+++ b/pytorch_translate/average_checkpoints.py
@@ -51,6 +51,8 @@ def average_checkpoints(inputs: Iterable[str]) -> Dict[str, Any]:
     for k, v in params_dict.items():
         summed_v = None
         for x in v:
+            if isinstance(x, torch.HalfTensor):
+                x = x.float()
             summed_v = summed_v + x if summed_v is not None else x
         if summed_v is not None:
             averaged_params[k] = summed_v / len(v)


### PR DESCRIPTION
Summary: Division by scalar is not supported for HalfTensor, so we should convert back to FP32 for averaging.

Differential Revision: D9197098
