### PR TITLE
Word prediction criterion logging output bugfix

### DIFF
--- a/pytorch_translate/word_prediction/word_prediction_criterion.py
+++ b/pytorch_translate/word_prediction/word_prediction_criterion.py
@@ -69,7 +69,9 @@ class WordPredictionCriterion(LabelSmoothedCrossEntropyCriterion):
         }
 
         if reduce:
-            logging_output['loss'] = utils.item(logging_output['loss'])
+            logging_output["translation_loss"] = utils.item(
+                logging_output["translation_loss"]
+            )
             logging_output['word_prediction_loss'] = utils.item(
                 logging_output['word_prediction_loss'])
 


### PR DESCRIPTION
Summary: Noticed this when running the test plan from D9012503 as a baseline / first test for NGVR

Differential Revision: D9296644
