### PR TITLE
Use colon separated --path variable for ensembled generation

### DIFF
--- a/pytorch_translate/examples/generate_iwslt14.sh
+++ b/pytorch_translate/examples/generate_iwslt14.sh
@@ -29,8 +29,7 @@ python3 pytorch_translate/generate.py \
 
 python3 pytorch_translate/generate.py \
        "" \
-       --path model/averaged_checkpoint_best_0.pt \
-       --path model/averaged_checkpoint_best_1.pt \
+       --path model/averaged_checkpoint_best_0.pt:model/averaged_checkpoint_best_1.pt \
        --source-vocab-file model/dictionary-de.txt \
        --target-vocab-file model/dictionary-en.txt \
        --source-text-file data/test.tok.bpe.de \

--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -25,7 +25,7 @@ from pytorch_translate.research.multisource import multisource_data, multisource
 
 
 def generate_score(args, task, dataset_split):
-    models, _ = utils.load_ensemble_for_inference(args.path, task)
+    models, _ = utils.load_ensemble_for_inference(args.path.split(":"), task)
     return _generate_score(models, args, task, dataset_split)
 
 
@@ -89,7 +89,7 @@ def _generate_score(models, args, task, dataset_split, optimize=True):
 
     # Load ensemble
     if not args.quiet:
-        print("| loading model(s) from {}".format(", ".join(args.path)))
+        print("| loading model(s) from {}".format(", ".join(args.path.split(":"))))
 
     # Optimize ensemble for generation
     if optimize:

--- a/pytorch_translate/onnx_component_export.py
+++ b/pytorch_translate/onnx_component_export.py
@@ -16,12 +16,12 @@ def get_parser_with_args():
     parser = argparse.ArgumentParser(
         description=("Export PyTorch-trained FBTranslate models to Caffe2 components")
     )
+
     parser.add_argument(
         "--path",
         "--checkpoint",
-        action="append",
-        nargs="+",
-        help="PyTorch checkpoint file (at least one required)",
+        metavar="FILE",
+        help="path(s) to model file(s), colon separated",
     )
     parser.add_argument(
         "--encoder-output-file",
@@ -90,7 +90,7 @@ def main():
 
 def export(args):
     assert_required_args_are_set(args)
-    checkpoint_filenames = [arg[0] for arg in args.path]
+    checkpoint_filenames = args.path.split(":")
 
     if args.char_source:
         encoder_class = CharSourceEncoderEnsemble

--- a/pytorch_translate/research/adversarial/adv_train.py
+++ b/pytorch_translate/research/adversarial/adv_train.py
@@ -267,7 +267,7 @@ def setup_training(args):
         if loaded_extra_state:
             extra_state.update(loaded_extra_state)
         if loaded:
-            args.path = [checkpoint_path]
+            args.path = checkpoint_path
             calculate_bleu_on_subset(
                 args=args,
                 task=task,
@@ -770,7 +770,7 @@ def calculate_bleu_on_subset(args, task, epoch_str: str, offset, dataset_split):
 def evaluate_bleu(args, task, extra_state):
     epoch, offset = extra_state["epoch"], extra_state["batch_offset"]
     filename = _save_averaged_checkpoint(args, extra_state)
-    args.path = [filename]
+    args.path = filename
     val_bleu, translation_samples = calculate_bleu_on_subset(
         args=args,
         task=task,

--- a/pytorch_translate/research/knowledge_distillation/knowledge_distillation_loss.py
+++ b/pytorch_translate/research/knowledge_distillation/knowledge_distillation_loss.py
@@ -20,7 +20,7 @@ class KnowledgeDistillationCriterion(FairseqCriterion):
 
         # Load model ensemble from checkpoints
         self.teacher_models, self.teacher_model_args = pytorch_translate_utils.load_diverse_ensemble_for_inference(
-            [args.teacher_path], task
+            args.teacher_path.split(":"), task
         )
 
         # Move models to device and to evaluation mode
@@ -42,8 +42,7 @@ class KnowledgeDistillationCriterion(FairseqCriterion):
         parser.add_argument(
             "--teacher-path",
             metavar="FILE",
-            action="append",
-            help="path(s) to teacher model file(s)",
+            help="path(s) to teacher model file(s) colon separated",
         )
         parser.add_argument(
             "--kd-weight",

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -264,7 +264,7 @@ def setup_training(args):
         if loaded_extra_state:
             extra_state.update(loaded_extra_state)
         if loaded:
-            args.path = [checkpoint_path]
+            args.path = checkpoint_path
             calculate_bleu_on_subset(
                 args=args,
                 task=task,
@@ -770,7 +770,7 @@ def calculate_bleu_on_subset(args, task, epoch_str: str, offset, dataset_split):
 def evaluate_bleu(args, task, extra_state):
     epoch, offset = extra_state["epoch"], extra_state["batch_offset"]
     filename = _save_averaged_checkpoint(args, extra_state)
-    args.path = [filename]
+    args.path = filename
     val_bleu, translation_samples = calculate_bleu_on_subset(
         args=args,
         task=task,


### PR DESCRIPTION
Summary: In a previous fairseq update (https://github.com/pytorch/fairseq/commit/16caed313e8943f9263a5dbb3e3cede32b326ead), fairseq switched to using colon separated --path arg to specify models to ensemble for generation. Here, I incoporate those in pytorch_translate

Differential Revision: D9373526
