### PR TITLE
move torch_find to utils

### DIFF
--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -32,22 +32,8 @@ from pytorch_translate.common_layers import (
 from pytorch_translate.multi_model import MultiDecoder, MultiEncoder
 from pytorch_translate.multilingual import MultilingualDecoder, MultilingualEncoder
 from pytorch_translate.ngram import NGramDecoder
-from pytorch_translate.utils import maybe_cat, maybe_cuda
+from pytorch_translate.utils import maybe_cat, maybe_cuda, torch_find
 from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_packed_sequence
-
-
-def torch_find(index, query, vocab_size):
-    """
-    Finds elements of query from index, outputting the last (max) index for each
-    query.
-    preconditions:  (1) index and query are flat arrays (can be different sizes)
-                    (2) all tokens in index and query have values < vocab_size
-    """
-    full_to_index = maybe_cuda(torch.zeros(vocab_size).long())
-    index_shape_range = maybe_cuda(torch.arange(index.shape[0]).long())
-    full_to_index[index] = index_shape_range
-    result = full_to_index[query]
-    return result
 
 
 def reorder_encoder_output(encoder_out, new_order):

--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -292,3 +292,17 @@ def load_embedding(embedding, dictionary, pretrained_embed):
     else:
         embed_dict = utils.parse_embedding(pretrained_embed)
         utils.load_embedding(embed_dict, dictionary, embedding)
+
+
+def torch_find(index, query, vocab_size):
+    """
+    Finds elements of query from index, outputting the last (max) index for each
+    query.
+    preconditions:  (1) index and query are flat arrays (can be different sizes)
+                    (2) all tokens in index and query have values < vocab_size
+    """
+    full_to_index = maybe_cuda(torch.zeros(vocab_size).long())
+    index_shape_range = maybe_cuda(torch.arange(index.shape[0]).long())
+    full_to_index[index] = index_shape_range
+    result = full_to_index[query]
+    return result

--- a/pytorch_translate/word_prediction/word_prediction_model.py
+++ b/pytorch_translate/word_prediction/word_prediction_model.py
@@ -2,12 +2,8 @@
 
 from fairseq.models import FairseqModel, register_model, register_model_architecture
 from pytorch_translate import rnn
-from pytorch_translate.rnn import (
-    LSTMSequenceEncoder,
-    RNNDecoder,
-    RNNEncoder,
-    torch_find,
-)
+from pytorch_translate.rnn import LSTMSequenceEncoder, RNNDecoder, RNNEncoder
+from pytorch_translate.utils import torch_find
 from pytorch_translate.word_prediction import word_predictor
 
 


### PR DESCRIPTION
Summary: This is a general utility used in several places, so let's move it to utils.py

Differential Revision: D9374682
