### PR TITLE
default for args.language_model_only in base_architecture()

### DIFF
--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -1282,6 +1282,7 @@ def base_architecture(args):
         args, "att_weighted_activation_type", "tanh"
     )
     args.adaptive_softmax_cutoff = getattr(args, "adaptive_softmax_cutoff", None)
+    args.language_model_only = getattr(args, "language_model_only", False)
 
 
 @register_model_architecture("rnn", "rnn_big_test")


### PR DESCRIPTION
Summary: Default argument added for backward compatibility with existing saved models.

Reviewed By: lhu17

Differential Revision: D9409756
