### PR TITLE
ONNX export for Transformer encoder

### DIFF
--- a/pytorch_translate/test/test_onnx.py
+++ b/pytorch_translate/test/test_onnx.py
@@ -12,6 +12,7 @@ from caffe2.python.onnx import backend as caffe2_backend
 from fairseq import models
 from pytorch_translate import char_source_model  # noqa (must be after rnn)
 from pytorch_translate import rnn  # noqa
+from pytorch_translate import transformer  # noqa
 from pytorch_translate import tasks
 from pytorch_translate.ensemble_export import (
     BeamSearch,
@@ -83,6 +84,10 @@ class TestONNX(unittest.TestCase):
             "max_translation_candidates_per_word": 1,
         }
 
+        self._test_ensemble_encoder_export(test_args)
+
+    def test_ensemble_transformer_encoder_export(self):
+        test_args = test_utils.ModelParamsDict(transformer=True)
         self._test_ensemble_encoder_export(test_args)
 
     def _test_ensemble_encoder_object_export(self, encoder_ensemble):

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -13,34 +13,45 @@ from pytorch_translate import (
 
 
 class ModelParamsDict:
-    def __init__(self, **kwargs):
+    def __init__(self, transformer=False, **kwargs):
         # Model params
-        self.arch = "rnn"
-        self.language_model_only = False
-        self.encoder_embed_dim = 10
-        self.encoder_embed_path = None
-        self.encoder_freeze_embed = False
-        self.encoder_hidden_dim = 10
-        self.encoder_layers = 2
-        self.encoder_bidirectional = False
-        self.encoder_dropout_in = 0
-        self.encoder_dropout_out = 0
-        self.decoder_embed_dim = 10
-        self.decoder_embed_path = None
-        self.decoder_freeze_embed = False
-        self.decoder_hidden_dim = 10
-        self.decoder_out_embed_dim = 5
-        self.decoder_out_embed_path = None
-        self.decoder_layers = 2
-        self.dropout = 0
-        self.decoder_dropout_in = 0
-        self.decoder_dropout_out = 0
-        self.attention_type = "dot"
-        self.residual_level = None
-        self.averaging_encoder = False
-        self.cell_type = "lstm"
-        self.sequence_lstm = False
-        self.decoder_tie_embeddings = False
+        if transformer:
+            self.arch = "ptt_transformer"
+            self.encoder_embed_dim = 10
+            self.encoder_ffn_embed_dim = 16
+            self.encoder_layers = 2
+            self.encoder_attention_heads = 2
+            self.decoder_embed_dim = 10
+            self.decoder_ffn_embed_dim = 16
+            self.decoder_layers = 2
+            self.decoder_attention_heads = 2
+        else:
+            self.arch = "rnn"
+            self.encoder_embed_dim = 10
+            self.encoder_embed_path = None
+            self.encoder_freeze_embed = False
+            self.encoder_hidden_dim = 10
+            self.encoder_layers = 2
+            self.encoder_bidirectional = False
+            self.encoder_dropout_in = 0
+            self.encoder_dropout_out = 0
+            self.decoder_embed_dim = 10
+            self.decoder_embed_path = None
+            self.decoder_freeze_embed = False
+            self.decoder_hidden_dim = 10
+            self.decoder_out_embed_dim = 5
+            self.decoder_out_embed_path = None
+            self.decoder_layers = 2
+            self.dropout = 0
+            self.decoder_dropout_in = 0
+            self.decoder_dropout_out = 0
+            self.attention_type = "dot"
+            self.residual_level = None
+            self.averaging_encoder = False
+            self.cell_type = "lstm"
+            self.sequence_lstm = False
+            self.decoder_tie_embeddings = False
+            self.language_model_only = False
         # Training params
         self.criterion = "cross_entropy"
         self.lr = [0.1]


### PR DESCRIPTION
Summary:
Export encoder from transformer architecture to a Caffe2 net via ONNX.

Also introduces a new code path for sinusoidal position embeddings which always inspects input tensor shape specifically for ONNX tracing (activated by flag `SinusoidalPositionalEmbedding.onnx_trace`).

Differential Revision: D9444738
