### PR TITLE
use prepare_for_onnx_export_()

### DIFF
--- a/pytorch_translate/attention/dot_attention.py
+++ b/pytorch_translate/attention/dot_attention.py
@@ -22,6 +22,9 @@ class DotAttention(BaseAttention):
             self.input_proj = Linear(decoder_hidden_state_dim, context_dim, bias=True)
         self.src_length_masking = kwargs.get("src_length_masking", True)
 
+    def prepare_for_onnx_export_(self, **kwargs):
+        self.src_length_masking = False
+
     def forward(self, decoder_state, source_hids, src_lengths):
         # Reshape to bsz x src_len x context_dim
         source_hids = source_hids.transpose(0, 1)

--- a/pytorch_translate/attention/mlp_attention.py
+++ b/pytorch_translate/attention/mlp_attention.py
@@ -36,6 +36,9 @@ class MLPAttention(BaseAttention):
         self.to_scores = Linear(self.attention_dim, 1, bias=False)
         self.src_length_masking = kwargs.get("src_length_masking", True)
 
+    def prepare_for_onnx_export_(self, **kwargs):
+        self.src_length_masking = False
+
     def forward(self, decoder_state, source_hids, src_lengths):
         """The expected input dimensions are:
 

--- a/pytorch_translate/char_source_model.py
+++ b/pytorch_translate/char_source_model.py
@@ -262,6 +262,9 @@ class CharRNNEncoder(FairseqEncoder):
         # (enables ONNX tracing of length-sorted input with batch_size = 1)
         self.onnx_export_model = False
 
+    def prepare_for_onnx_export_(self, **kwargs):
+        self.onnx_export_model = True
+
     def forward(self, src_tokens, src_lengths, char_inds, word_lengths):
 
         # char_inds has shape (batch_size, max_words_per_sent, max_word_len)

--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -236,7 +236,7 @@ class DecoderBatchedStepEnsemble(nn.Module):
         super().__init__()
         self.models = models
         for i, model in enumerate(self.models):
-            model.decoder.attention.src_length_masking = False
+            model.prepare_for_onnx_export_()
             self._modules[f"model_{i}"] = model
 
         self.tgt_dict = tgt_dict
@@ -695,9 +695,7 @@ class KnownOutputDecoderStepEnsemble(nn.Module):
         self.models = models
         self.tgt_dict = tgt_dict
         for i, model in enumerate(self.models):
-            if isinstance(model.encoder, char_source_model.CharRNNEncoder):
-                model.encoder.onnx_export_model = True
-            model.decoder.attention.src_length_masking = False
+            model.prepare_for_onnx_export_()
             self._modules[f"model_{i}"] = model
 
         self.word_reward = word_reward
@@ -987,8 +985,7 @@ class CharSourceEncoderEnsemble(nn.Module):
         self.models = models
         self.src_dict = src_dict
         for i, model in enumerate(self.models):
-            if isinstance(model.encoder, char_source_model.CharRNNEncoder):
-                model.encoder.onnx_export_model = True
+            model.prepare_for_onnx_export_()
             self._modules[f"model_{i}"] = model
 
     def forward(self, src_tokens, src_lengths, char_inds, word_lengths):


### PR DESCRIPTION
Summary: All ONNX-tracing-specific code paths should be enabled through `prepare_for_onnx_export()_` for consistency.

Reviewed By: myleott

Differential Revision: D9473087
