### PR TITLE
Word prediction as learned vocab reduction support for training

### DIFF
--- a/pytorch_translate/common_layers.py
+++ b/pytorch_translate/common_layers.py
@@ -195,6 +195,7 @@ class DecoderWithOutputProjection(FairseqIncrementalDecoder):
         att_weighted_src_embeds=False,
         src_embed_dim=512,
         att_weighted_activation_type="tanh",
+        predictor=None,
     ):
         super().__init__(dst_dict)
         self.project_output = project_output
@@ -203,11 +204,10 @@ class DecoderWithOutputProjection(FairseqIncrementalDecoder):
             self.out_embed_dim = out_embed_dim
             self.att_weighted_src_embeds = att_weighted_src_embeds
             self.src_embed_dim = src_embed_dim
-
             self.vocab_reduction_module = None
-            if vocab_reduction_params:
+            if vocab_reduction_params or predictor is not None:
                 self.vocab_reduction_module = vocab_reduction.VocabReduction(
-                    src_dict, dst_dict, vocab_reduction_params
+                    src_dict, dst_dict, vocab_reduction_params, predictor
                 )
 
             projection_weights = torch.FloatTensor(
@@ -273,7 +273,9 @@ class DecoderWithOutputProjection(FairseqIncrementalDecoder):
 
         if self.vocab_reduction_module and possible_translation_tokens is None:
             possible_translation_tokens = self.vocab_reduction_module(
-                src_tokens, decoder_input_tokens=decoder_input_tokens
+                src_tokens,
+                encoder_output=encoder_out,
+                decoder_input_tokens=decoder_input_tokens,
             )
 
         if possible_translation_tokens is not None:

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -989,6 +989,7 @@ class RNNDecoder(DecoderWithOutputProjection):
         att_weighted_src_embeds=False,
         src_embed_dim=512,
         att_weighted_activation_type="tanh",
+        predictor=None,
     ):
         super().__init__(
             src_dict,
@@ -1000,6 +1001,7 @@ class RNNDecoder(DecoderWithOutputProjection):
             att_weighted_src_embeds=att_weighted_src_embeds,
             src_embed_dim=src_embed_dim,
             att_weighted_activation_type=att_weighted_activation_type,
+            predictor=predictor,
         )
         encoder_hidden_dim = max(1, encoder_hidden_dim)
         self.encoder_hidden_dim = encoder_hidden_dim


### PR DESCRIPTION
Summary:
This diff enables 4 different configurations with word prediction and vocab reduction:
1. just word prediction vocab reduction (no vocab reduction)
2. word prediction vocab reduction and regular vocab reduction
3. word prediction vocab reduction and top words but no translation candidates from lexical dictionaries
4. word prediction vocab reduction and translation candidates from lexical dictionaries but no top words

Next up:
1. support for generate.py with an ensemble is coming next. Multiple models might have a different output softmax size, so our current ensembling code doesn't support that.
2. support for ensemble_export with word prediction vocab reduction
3. This still trains the word predictor via the word prediction loss in word_prediction criterion. In a future diff, I'll add the option to train the word predictor via backprop through vocab reduction.

Differential Revision: D9478700
