### PR TITLE
Ensembling support in generation for models with different output softmax size

### DIFF
--- a/pytorch_translate/common_layers.py
+++ b/pytorch_translate/common_layers.py
@@ -195,6 +195,7 @@ class DecoderWithOutputProjection(FairseqIncrementalDecoder):
         att_weighted_src_embeds=False,
         src_embed_dim=512,
         att_weighted_activation_type="tanh",
+        predictor=None,
     ):
         super().__init__(dst_dict)
         self.project_output = project_output
@@ -203,11 +204,10 @@ class DecoderWithOutputProjection(FairseqIncrementalDecoder):
             self.out_embed_dim = out_embed_dim
             self.att_weighted_src_embeds = att_weighted_src_embeds
             self.src_embed_dim = src_embed_dim
-
             self.vocab_reduction_module = None
-            if vocab_reduction_params:
+            if vocab_reduction_params or predictor is not None:
                 self.vocab_reduction_module = vocab_reduction.VocabReduction(
-                    src_dict, dst_dict, vocab_reduction_params
+                    src_dict, dst_dict, vocab_reduction_params, predictor
                 )
 
             projection_weights = torch.FloatTensor(
@@ -273,7 +273,9 @@ class DecoderWithOutputProjection(FairseqIncrementalDecoder):
 
         if self.vocab_reduction_module and possible_translation_tokens is None:
             possible_translation_tokens = self.vocab_reduction_module(
-                src_tokens, decoder_input_tokens=decoder_input_tokens
+                src_tokens,
+                encoder_output=encoder_out,
+                decoder_input_tokens=decoder_input_tokens,
             )
 
         if possible_translation_tokens is not None:

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -989,6 +989,7 @@ class RNNDecoder(DecoderWithOutputProjection):
         att_weighted_src_embeds=False,
         src_embed_dim=512,
         att_weighted_activation_type="tanh",
+        predictor=None,
     ):
         super().__init__(
             src_dict,
@@ -1000,6 +1001,7 @@ class RNNDecoder(DecoderWithOutputProjection):
             att_weighted_src_embeds=att_weighted_src_embeds,
             src_embed_dim=src_embed_dim,
             att_weighted_activation_type=att_weighted_activation_type,
+            predictor=predictor,
         )
         encoder_hidden_dim = max(1, encoder_hidden_dim)
         self.encoder_hidden_dim = encoder_hidden_dim

--- a/pytorch_translate/test/test_beam_decode.py
+++ b/pytorch_translate/test/test_beam_decode.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import Any, List
 
 import numpy as np
 import torch
@@ -42,3 +43,58 @@ class TestBeamDecode(unittest.TestCase):
         word_lengths = torch.LongTensor([[5, 5, 5], [5, 5, 5]])
         encoder_input = (src_tokens, src_lengths, char_inds, word_lengths)
         translator.generate(encoder_input, maxlen=7)
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
+    def test_gather_probs_with_vr(self):
+        """ Tests gather_probs when there is vocab reduction """
+        all_translation_tokens: List[Any] = [
+            torch.LongTensor([3, 7, 8, 9]),
+            torch.LongTensor([0, 3, 5]),
+        ]
+        all_probs: List[Any] = [
+            torch.FloatTensor(
+                [[0.25, 0.25, 0.25, 0.25], [0.25, 0.25, 0.25, 0.25]]
+            ).cuda(),
+            torch.FloatTensor([[0.4, 0.5, 0.1], [0.4, 0.5, 0.1]]).cuda(),
+        ]
+        avg_probs, possible_translation_tokens = beam_decode.SequenceGenerator.gather_probs(
+            all_translation_tokens=all_translation_tokens, all_probs=all_probs
+        )
+        avg_probs = avg_probs.detach().cpu().numpy()
+        possible_translation_tokens = possible_translation_tokens.detach().cpu().numpy()
+
+        avg_probs_ref = sorted([0.4, 0.75, 0.1, 0.25, 0.25, 0.25])
+        possible_translation_tokens_ref = sorted([0, 3, 5, 7, 8, 9])
+
+        np.testing.assert_allclose(
+            actual=np.sort(avg_probs[0]), desired=np.array(avg_probs_ref), atol=1e-5
+        )
+        np.testing.assert_allclose(
+            actual=np.sort(possible_translation_tokens),
+            desired=np.array(possible_translation_tokens_ref),
+        )
+        np.testing.assert_allclose(
+            actual=np.sort(possible_translation_tokens),
+            desired=np.array(possible_translation_tokens_ref),
+        )
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
+    def test_gather_probs_without_vr(self):
+        """ Tests gather_probs when there is no vocab reduction """
+        all_probs: List[Any] = [
+            torch.FloatTensor([[0.25, 0.25, 0.25, 0.25], [0.25, 0.25, 0.25, 0.25]]),
+            torch.FloatTensor([[0.4, 0.2, 0.1, 0.3], [0.4, 0.2, 0.1, 0.3]]),
+        ]
+        all_translation_tokens: List[Any] = [None, None]
+        avg_probs, possible_translation_tokens = beam_decode.SequenceGenerator.gather_probs(
+            all_translation_tokens=all_translation_tokens, all_probs=all_probs
+        )
+
+        assert possible_translation_tokens is None
+        avg_probs_ref = [0.65, 0.45, 0.35, 0.55]
+        np.testing.assert_allclose(
+            actual=avg_probs[0], desired=np.array(avg_probs_ref), atol=1e-5
+        )
+        np.testing.assert_allclose(
+            actual=avg_probs[1], desired=np.array(avg_probs_ref), atol=1e-5
+        )


### PR DESCRIPTION
Summary:
In general, this diff enables the ensembling of multiple models with different sizes of output softmax (for example where model 1 outputs a set of 10 translation candidates + 10 probabilities for each of those candidates, and model 2 outputs a set of 20 translation candidates + 20 probabilities for each of those candidates). See documentation in comments for a full example.

The context of this diff is to allow ensembling of multiple models trained with word prediction vocab reduction.

Differential Revision: D9504725
