### PR TITLE
make regexs be raw strings to avoid warning messages

### DIFF
--- a/pytorch_translate/dictionary.py
+++ b/pytorch_translate/dictionary.py
@@ -20,7 +20,7 @@ TAGS = [
     "@NOTRANSLATE",
 ]
 
-SPACE_NORMALIZER = re.compile("\s+")
+SPACE_NORMALIZER = re.compile(r"\s+")
 
 
 def default_dictionary_path(save_dir: str, dialect: str) -> str:


### PR DESCRIPTION
Summary: In python3 if  \s is in a string then it will print a warning message when you run the program. Making the regex a raw string gets rid of the warning message and has no effect on the regex.

Differential Revision: D9563338
