### PR TITLE
Optimize dot attention sum

### DIFF
--- a/pytorch_translate/attention/dot_attention.py
+++ b/pytorch_translate/attention/dot_attention.py
@@ -41,7 +41,9 @@ class DotAttention(BaseAttention):
 
         # Sum weighted sources
         attn_weighted_context = (
-            source_hids * normalized_masked_attn_scores.unsqueeze(2)
-        ).sum(1)
+            (source_hids * normalized_masked_attn_scores.unsqueeze(2))
+            .contiguous()
+            .sum(1)
+        )
 
         return attn_weighted_context, normalized_masked_attn_scores.t()


### PR DESCRIPTION
Summary: Calling `contiguous()` makes the proceeding `sum()` call >100x faster on CPU in benchmarking. It goes from 4ms per call to 0.031 ms

Reviewed By: ezyang

Differential Revision: D10036392
