### PR TITLE
multihead_attention: pre-transpose incremental state

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -416,7 +416,7 @@ class DecoderBatchedStepEnsemble(nn.Module):
                 attn_weights_per_model.append(attn_scores)
 
                 state_outputs.extend(attention_states)
-                beam_axis_per_state.extend([1 for _ in attention_states])
+                beam_axis_per_state.extend([0 for _ in attention_states])
             else:
                 raise RuntimeError(f"Not a supported model: {type(model)}")
 

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -520,12 +520,15 @@ class TransformerDecoder(FairseqIncrementalDecoder):
             for _ in range(2):
                 dummy_state_shape = torch.cat(
                     [
-                        torch.LongTensor([0]),
                         batch_size.view(1),
-                        torch.LongTensor([layer.embed_dim]),
+                        torch.LongTensor([layer.self_attn.num_heads]),
+                        torch.LongTensor([0]),
+                        torch.LongTensor([layer.self_attn.head_dim]),
                     ]
                 )
-                dummy_state = torch.zeros([0, 1, layer.embed_dim])
+                dummy_state = torch.zeros(
+                    [1, layer.self_attn.num_heads, 0, layer.self_attn.head_dim]
+                )
                 reshaped_dummy_state = torch.onnx.operators.reshape_from_tensor_shape(
                     dummy_state, dummy_state_shape
                 )
@@ -535,6 +538,23 @@ class TransformerDecoder(FairseqIncrementalDecoder):
             # output and remain the same throughout decoding
             key = layer.encoder_attn.in_proj_k(encoder_x)
             value = layer.encoder_attn.in_proj_v(encoder_x)
+
+            # (key, value) kept in shape (bsz, num_heads, seq_len, head_dim)
+            # to avoid repeated transpose operations
+            seq_len, batch_size_int, _ = encoder_x.shape
+            num_heads = layer.encoder_attn.num_heads
+            head_dim = layer.encoder_attn.head_dim
+            key = (
+                key.view(seq_len, batch_size_int * num_heads, head_dim)
+                .transpose(0, 1)
+                .view(batch_size_int, num_heads, seq_len, head_dim)
+            )
+            value = (
+                value.view(seq_len, batch_size_int * num_heads, head_dim)
+                .transpose(0, 1)
+                .view(batch_size_int, num_heads, seq_len, head_dim)
+            )
+
             states.extend([key, value])
 
         return states


### PR DESCRIPTION
Summary:
Though transpose operations are essentially free during PyTorch execution, they can result in costly operations when exported to Caffe2 inference nets via ONNX tracing, especially when applied repeatedly to large tensors.

For this reason, we update `MultiheadAttention` to store its incremental state with shape (bsz, num_heads, seq_len, head_dim), that is after transposing the projected input. This should result in non-trivially faster exported models without changing the semantics or speed of PyTorch execution.

Differential Revision: D10186506
