### PR TITLE
Add test_options.py to test PyTorch Translate data options validation

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -319,24 +319,36 @@ def add_preprocessing_args(parser):
 def validate_preprocessing_args(args):
     if not (
         (
-            args.train_source_text_file
-            or args.train_source_binary_path
-            or args.multiling_train_source_text_file
+            hasattr(args, "train_source_text_file")
+            and args.train_source_text_file
+            or hasattr(args, "train_source_binary_path")
+            and args.train_source_binary_path
+            or hasattr(args, "multiling_train_source_text_file")
+            and args.multiling_train_source_text_file
         )
         and (
-            args.train_target_text_file
-            or args.train_target_binary_path
-            or args.multiling_train_target_text_file
+            hasattr(args, "train_target_text_file")
+            and args.train_target_text_file
+            or hasattr(args, "train_target_binary_path")
+            and args.train_target_binary_path
+            or hasattr(args, "multiling_train_target_text_file")
+            and args.multiling_train_target_text_file
         )
         and (
-            args.eval_source_text_file
-            or args.eval_source_binary_path
-            or args.multiling_eval_source_text_file
+            hasattr(args, "eval_source_text_file")
+            and args.eval_source_text_file
+            or hasattr(args, "eval_source_binary_path")
+            and args.eval_source_binary_path
+            or hasattr(args, "multiling_eval_source_text_file")
+            and args.multiling_eval_source_text_file
         )
         and (
-            args.eval_target_text_file
-            or args.eval_target_binary_path
-            or args.multiling_eval_target_text_file
+            hasattr(args, "eval_target_text_file")
+            and args.eval_target_text_file
+            or hasattr(args, "eval_target_binary_path")
+            and args.eval_target_binary_path
+            or hasattr(args, "multiling_eval_target_text_file")
+            and args.multiling_eval_target_text_file
         )
     ):
         raise ValueError(

--- a/pytorch_translate/test/test_options.py
+++ b/pytorch_translate/test/test_options.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import argparse
+import unittest
+
+from pytorch_translate import options
+from pytorch_translate.test import utils as test_utils
+
+
+class TestOptions(unittest.TestCase):
+    def get_common_data_args_namespace(self):
+        args = argparse.Namespace()
+        args.train_source_text_file = test_utils.make_temp_file()
+        args.train_target_text_file = test_utils.make_temp_file()
+        args.eval_source_text_file = test_utils.make_temp_file()
+        args.eval_target_text_file = test_utils.make_temp_file()
+        args.source_vocab_file = test_utils.make_temp_file()
+        args.target_vocab_file = test_utils.make_temp_file()
+        return args
+
+    def test_validate_preprocesing_args(self):
+        """ Make sure we validation passes with the minimum args required. """
+        args = self.get_common_data_args_namespace()
+        options.validate_preprocessing_args(args)
+
+    def test_validate_fails_for_missing_preprocessing_arg(self):
+        """
+        We expect a ValueError when filepaths for a certain data type is
+        missing. In this case, train source is not set at all -- no text file or
+        binary path corresponds to this required data.
+        """
+        args = self.get_common_data_args_namespace()
+        args.train_source_text_file = None
+        self.assertRaises(ValueError, options.validate_preprocessing_args, args)
+
+    def test_validate_fails_for_invalid_file(self):
+        """ We expect a ValueError when a filepath is invalid """
+        args = self.get_common_data_args_namespace()
+        args.train_source_text_file = "nonexistent_file_path"
+        self.assertRaises(ValueError, options.validate_preprocessing_args, args)


### PR DESCRIPTION
Summary: This adds a few basic unittests to make sure our args validation code works as expected. I've only added preprocessing args validation but this can be extended to add a unittest for all the other args validation functions.

Differential Revision: D10221274
