### PR TITLE
Add options and preprocessing code for semisupervised translation task

### DIFF
--- a/pytorch_translate/constants.py
+++ b/pytorch_translate/constants.py
@@ -2,3 +2,5 @@
 
 AVERAGED_CHECKPOINT_BEST_FILENAME = "averaged_checkpoint_best.pt"
 LAST_CHECKPOINT_FILENAME = "checkpoint_last.pt"
+
+MONOLINGUAL_DATA_IDENTIFIER = "_mono_"

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -377,6 +377,38 @@ def validate_preprocessing_args(args):
                 f"for it to be written to."
             )
 
+    if args.task == "pytorch_translate_semisupervised" and not (
+        (
+            hasattr(args, "train_mono_source_binary_path")
+            and args.train_mono_source_binary_path
+        )
+        or (
+            hasattr(args, "train_mono_target_binary_path")
+            and args.train_mono_target_binary_path
+        )
+        or (
+            hasattr(args, "train_mono_source_text_file")
+            and args.train_mono_source_text_file
+        )
+        or (
+            hasattr(args, "train_mono_target_text_file")
+            and args.train_mono_target_text_file
+        )
+    ):
+        raise ValueError(
+            "For semisupervised training, at least one of --*_text_file or "
+            "--*_binary_path flags must be specified for at least one of "
+            "--train_mono_{source, target}_*"
+        )
+
+        for file_type in ("train_mono_source_text_file", "train_mono_target_text_file"):
+            file_path = getattr(args, file_type)
+            if file_path and not os.path.isfile(file_path):
+                raise ValueError(
+                    f"Please specify an existing text file for --{file_type}="
+                    f"{file_path}"
+                )
+
 
 def expand_optimization_args(group):
     """Expands the optimization related arguments with pytorch_translate

--- a/pytorch_translate/tasks.py
+++ b/pytorch_translate/tasks.py
@@ -387,3 +387,60 @@ class PytorchTranslateMultilingualTask(PytorchTranslateTask):
 
     def get_decoder_lang_code(self, lang_id):
         return self.decoder_langs[lang_id]
+
+
+@register_task("pytorch_translate_semi_supervised")
+class PytorchTranslateSemiSupervised(PytorchTranslateTask):
+    @staticmethod
+    def add_args(parser):
+        super.add_args(parser)
+
+        """Add semi-supervised arguments to the parser."""
+        parser.add_argument(
+            "--train-mono-source-binary-path",
+            default="",
+            help="Path for the binary file containing monolingual source "
+            "training examples.",
+        )
+        parser.add_argument(
+            "--train-mono-target-binary-path",
+            default="",
+            help="Path for the binary file containing monolingual target "
+            "training examples.",
+        )
+        parser.add_argument(
+            "--train-mono-target-binary-path",
+            default="",
+            help="Path for the binary file containing monolingual target "
+            "training examples.",
+        )
+        parser.add_argument(
+            "--add-monolingual-data-to-build-vocab",
+            action="store_true",
+            help="If True, use monolingual data (in addition to parallel data) "
+            "to build vocabs.",
+        )
+
+    def load_monolingual_dataset(self, split, bin_path, is_source=False):
+        if self.args.log_verbose:
+            print("Starting to load binarized monolingual data file.", flush=True)
+
+        if not os.path.exists(bin_path):
+            raise ValueError(f"{bin_path} for {split} not found!")
+
+        if self.char_source_dict is not None and is_source:
+            self.datasets[
+                split
+            ] = char_data.InMemoryNumpyWordCharDataset.create_from_file(path=bin_path)
+
+        else:
+            self.datasets[
+                split
+            ] = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
+                path=bin_path
+            )
+
+        if self.args.log_verbose:
+            print("Finished loading dataset", flush=True)
+
+        print(f"| {split} {len(self.datasets[split])} examples")

--- a/pytorch_translate/test/test_options.py
+++ b/pytorch_translate/test/test_options.py
@@ -16,6 +16,7 @@ class TestOptions(unittest.TestCase):
         args.eval_target_text_file = test_utils.make_temp_file()
         args.source_vocab_file = test_utils.make_temp_file()
         args.target_vocab_file = test_utils.make_temp_file()
+        args.task = "pytorch_translate"
         return args
 
     def test_validate_preprocesing_args(self):
@@ -37,4 +38,45 @@ class TestOptions(unittest.TestCase):
         """ We expect a ValueError when a filepath is invalid """
         args = self.get_common_data_args_namespace()
         args.train_source_text_file = "nonexistent_file_path"
+        self.assertRaises(ValueError, options.validate_preprocessing_args, args)
+
+    def test_validate_preprocessing_args_monolingual(self):
+        """
+        Make sure we pass validation with the semisupervised training
+        task when the required monolingual source and target data is
+        set.
+        """
+        args = self.get_common_data_args_namespace()
+        args.task = "pytorch_translate_semisupervised"
+        args.train_mono_source_binary_path = test_utils.make_temp_file()
+        args.train_mono_target_text_file = test_utils.make_temp_file()
+        options.validate_preprocessing_args(args)
+
+    def test_validate_preprocessing_args_monolingual_source_only(self):
+        """
+        Make sure we pass validation with the semisupervised training
+        task when we only have monolingual source data.
+        """
+        args = self.get_common_data_args_namespace()
+        args.task = "pytorch_translate_semisupervised"
+        args.train_mono_source_binary_path = test_utils.make_temp_file()
+        options.validate_preprocessing_args(args)
+
+    def test_validate_preprocessing_args_monolingual_target_only(self):
+        """
+        Make sure we pass validation with the semisupervised training
+        task when we only have monolingual source data.
+        """
+        args = self.get_common_data_args_namespace()
+        args.task = "pytorch_translate_semisupervised"
+        args.train_mono_target_binary_path = test_utils.make_temp_file()
+        options.validate_preprocessing_args(args)
+
+    def test_validate_preprocessing_args_monolingual_fails_with_missing(self):
+        """
+        We expect a ValueError with the semisupervised task if there's
+        no monolingual data at all.
+        """
+        args = self.get_common_data_args_namespace()
+        args.task = "pytorch_translate_semisupervised"
         self.assertRaises(ValueError, options.validate_preprocessing_args, args)

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -32,6 +32,7 @@ from pytorch_translate import weighted_criterions  # noqa
 from pytorch_translate import (
     average_checkpoints,
     constants,
+    data as pytorch_translate_data,
     dictionary as pytorch_translate_dictionary,
     generate,
     multi_model,
@@ -191,6 +192,19 @@ def setup_training_model(args):
         args.train_target_binary_path,
         weights_file=getattr(args, "train_weights_path", None),
     )
+    if args.task == "pytorch_translate_semisupervised":
+        task.load_monolingual_dataset(
+            split=args.train_subset
+            + constants.MONOLINGUAL_DATA_IDENTIFIER
+            + args.source_lang,
+            bin_path=args.train_mono_source_binary_path,
+        )
+        task.load_monolingual_dataset(
+            split=args.train_subset
+            + constants.MONOLINGUAL_DATA_IDENTIFIER
+            + args.target_lang,
+            bin_path=args.train_mono_target_binary_path,
+        )
     task.load_dataset(
         args.valid_subset, args.eval_source_binary_path, args.eval_target_binary_path
     )


### PR DESCRIPTION
Summary:
This adds a "pytorch_translate_semisupervised" task which allows us to preprocess monolingual data.

A couple notes:
- monolingual data flags are task-specific flags
- this shouldn't affect our current bilingual setup
- pytorch_translate_semisupervised inherits pytorch_translate task and all relevant functions
- we expect to always have at least a little bit of parallel data (even something like 5 dummy examples is enough) to reduce complexity / branching code
- you can have unbalanced monolingual data. It is valid to specify no source monolingual data but some target monolingual data and vice versa. However, you will get errors if you try to train with pytorch_translate_semisupervised WITHOUT specifying AT LEAST ONE monolingual data file (for either source or target)

Differential Revision: D10228123
