### PR TITLE
Small refactor in get_parser_with_args for train.py

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -53,8 +53,8 @@ from pytorch_translate import rnn  # noqa; noqa
 from pytorch_translate import char_source_model  # noqa; noqa
 
 
-def get_parser_with_args():
-    parser = options.get_parser("Trainer", default_task="pytorch_translate")
+def get_parser_with_args(default_task="pytorch_translate"):
+    parser = options.get_parser("Trainer", default_task=default_task)
     pytorch_translate_options.add_verbosity_args(parser, train=True)
     pytorch_translate_options.add_dataset_args(parser, train=True, gen=True)
     options.add_distributed_training_args(parser)


### PR DESCRIPTION
Summary: Adds default_task argument. Note that we don't generally have to change default_task unless we want to create a new binary (as a developer). The user can config the task by using the --task flag

Reviewed By: xianxl

Differential Revision: D10203344
