### PR TITLE
Add test_preprocess.py to test PyTorch Translate preprocessing correctness

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -319,24 +319,36 @@ def add_preprocessing_args(parser):
 def validate_preprocessing_args(args):
     if not (
         (
-            args.train_source_text_file
-            or args.train_source_binary_path
-            or args.multiling_train_source_text_file
+            hasattr(args, "train_source_text_file")
+            and args.train_source_text_file
+            or hasattr(args, "train_source_binary_path")
+            and args.train_source_binary_path
+            or hasattr(args, "multiling_train_source_text_file")
+            and args.multiling_train_source_text_file
         )
         and (
-            args.train_target_text_file
-            or args.train_target_binary_path
-            or args.multiling_train_target_text_file
+            hasattr(args, "train_target_text_file")
+            and args.train_target_text_file
+            or hasattr(args, "train_target_binary_path")
+            and args.train_target_binary_path
+            or hasattr(args, "multiling_train_target_text_file")
+            and args.multiling_train_target_text_file
         )
         and (
-            args.eval_source_text_file
-            or args.eval_source_binary_path
-            or args.multiling_eval_source_text_file
+            hasattr(args, "eval_source_text_file")
+            and args.eval_source_text_file
+            or hasattr(args, "eval_source_binary_path")
+            and args.eval_source_binary_path
+            or hasattr(args, "multiling_eval_source_text_file")
+            and args.multiling_eval_source_text_file
         )
         and (
-            args.eval_target_text_file
-            or args.eval_target_binary_path
-            or args.multiling_eval_target_text_file
+            hasattr(args, "eval_target_text_file")
+            and args.eval_target_text_file
+            or hasattr(args, "eval_target_binary_path")
+            and args.eval_target_binary_path
+            or hasattr(args, "multiling_eval_target_text_file")
+            and args.multiling_eval_target_text_file
         )
     ):
         raise ValueError(

--- a/pytorch_translate/test/test_options.py
+++ b/pytorch_translate/test/test_options.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import argparse
+import unittest
+
+from pytorch_translate import options
+from pytorch_translate.test import utils as test_utils
+
+
+class TestOptions(unittest.TestCase):
+    def get_common_data_args_namespace(self):
+        args = argparse.Namespace()
+        args.train_source_text_file = test_utils.make_temp_file()
+        args.train_target_text_file = test_utils.make_temp_file()
+        args.eval_source_text_file = test_utils.make_temp_file()
+        args.eval_target_text_file = test_utils.make_temp_file()
+        args.source_vocab_file = test_utils.make_temp_file()
+        args.target_vocab_file = test_utils.make_temp_file()
+        return args
+
+    def test_validate_preprocesing_args(self):
+        """ Make sure we validation passes with the minimum args required. """
+        args = self.get_common_data_args_namespace()
+        options.validate_preprocessing_args(args)
+
+    def test_validate_fails_for_missing_preprocessing_arg(self):
+        """
+        We expect a ValueError when filepaths for a certain data type is
+        missing. In this case, train source is not set at all -- no text file or
+        binary path corresponds to this required data.
+        """
+        args = self.get_common_data_args_namespace()
+        args.train_source_text_file = None
+        self.assertRaises(ValueError, options.validate_preprocessing_args, args)
+
+    def test_validate_fails_for_invalid_file(self):
+        """ We expect a ValueError when a filepath is invalid """
+        args = self.get_common_data_args_namespace()
+        args.train_source_text_file = "nonexistent_file_path"
+        self.assertRaises(ValueError, options.validate_preprocessing_args, args)

--- a/pytorch_translate/test/test_preprocess.py
+++ b/pytorch_translate/test/test_preprocess.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import unittest
+
+from pytorch_translate import preprocess
+from pytorch_translate.test import utils as test_utils
+
+
+class TestPreprocess(unittest.TestCase):
+    def get_common_data_args_namespace(self):
+        args = argparse.Namespace()
+        source_text_file, target_text_file = test_utils.create_test_text_files()
+        args.train_source_text_file = source_text_file
+        args.train_target_text_file = target_text_file
+        args.eval_source_text_file = source_text_file
+        args.eval_target_text_file = target_text_file
+
+        # The idea is to have these filled in during preprocessing
+        args.train_source_binary_path = ""
+        args.train_target_binary_path = ""
+        args.eval_source_binary_path = ""
+        args.eval_target_binary_path = ""
+
+        # Required data preprocessing args
+        args.append_eos_to_source = False
+        args.reverse_source = True
+
+        args.multiling_source_lang = None  # Indicates no multilingual data
+        args.penalized_target_tokens_file = ""
+
+        args.source_vocab_file = test_utils.make_temp_file()
+        args.source_max_vocab_size = None
+        args.target_vocab_file = test_utils.make_temp_file()
+        args.target_max_vocab_size = None
+        args.char_source_vocab_file = ""
+        return args
+
+    def test_preprocess(self):
+        """
+        This is just a correctness test to make sure no errors are thrown when
+        all the required args are passed. Actual parsing code is tested by
+        test_data.py
+        """
+        args = self.get_common_data_args_namespace()
+        preprocess.preprocess_corpora(args)
+        for file_type in (
+            "train_source_binary_path",
+            "train_target_binary_path",
+            "eval_source_binary_path",
+            "eval_target_binary_path",
+        ):
+            file = getattr(args, file_type)
+            assert file and os.path.isfile(file)
+            assert file.endswith(".npz")


### PR DESCRIPTION
Summary: This adds a unittest to make sure that preprocess doesn't throw any errors

Reviewed By: jmp84

Differential Revision: D10227964
