### PR TITLE
Use a constant for semi supervised task name

### DIFF
--- a/pytorch_translate/constants.py
+++ b/pytorch_translate/constants.py
@@ -4,3 +4,5 @@ AVERAGED_CHECKPOINT_BEST_FILENAME = "averaged_checkpoint_best.pt"
 LAST_CHECKPOINT_FILENAME = "checkpoint_last.pt"
 
 MONOLINGUAL_DATA_IDENTIFIER = "mono"
+
+SEMI_SUPERVISED_TASK = "pytorch_translate_semi_supervised"

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -2,7 +2,7 @@
 
 import os
 
-from pytorch_translate import utils
+from pytorch_translate import constants, utils
 
 
 def add_dataset_args(parser, train=False, gen=False):
@@ -365,7 +365,7 @@ def validate_preprocessing_args(args):
                 f"for it to be written to."
             )
 
-    if args.task == "pytorch_translate_semisupervised" and not (
+    if args.task == constants.SEMI_SUPERVISED_TASK and not (
         getattr(args, "train_mono_source_binary_path", None)
         or getattr(args, "train_mono_target_binary_path", None)
         or getattr(args, "train_mono_source_text_file", None)

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 from pytorch_translate import (
     char_data,
+    constants,
     data as pytorch_translate_data,
     options as pytorch_translate_options,
 )
@@ -191,7 +192,7 @@ def preprocess_corpora(args):
         )
         # Binarize additional monolingual corpora for the semisupervised translation
         # task
-        if args.task == "pytorch_translate_semisupervised":
+        if args.task == constants.SEMI_SUPERVISED_TASK:
             args.train_mono_source_binary_path = maybe_generate_temp_file_path(
                 output_path=getattr(args, "train_mono_source_binary_path", None)
             )
@@ -257,7 +258,7 @@ def build_vocabs(args: argparse.Namespace):
     source_files = [args.train_source_text_file]
     target_files = [args.train_target_text_file]
 
-    if args.task == "pytorch_translate_semisupervised" and getattr(
+    if args.task == constants.SEMI_SUPERVISED_TASK and getattr(
         args, "add_monolingual_data_for_vocab_building", None
     ):
         if getattr(args, "train_mono_source_text_file", None):

--- a/pytorch_translate/tasks/semi_supervised_task.py
+++ b/pytorch_translate/tasks/semi_supervised_task.py
@@ -21,7 +21,7 @@ from pytorch_translate import (
 from pytorch_translate.tasks.pytorch_translate_task import PytorchTranslateTask
 
 
-@register_task("pytorch_translate_semi_supervised")
+@register_task(constants.SEMI_SUPERVISED_TASK)
 class PytorchTranslateSemiSupervised(PytorchTranslateTask):
     def __init__(self, args, dicts, training):
         super().__init__(args, dicts[self.source_lang], dicts[self.target_lang])

--- a/pytorch_translate/test/test_options.py
+++ b/pytorch_translate/test/test_options.py
@@ -3,7 +3,7 @@
 import argparse
 import unittest
 
-from pytorch_translate import options
+from pytorch_translate import constants, options
 from pytorch_translate.test import utils as test_utils
 
 
@@ -47,7 +47,7 @@ class TestOptions(unittest.TestCase):
         set.
         """
         args = self.get_common_data_args_namespace()
-        args.task = "pytorch_translate_semisupervised"
+        args.task = constants.SEMI_SUPERVISED_TASK
         args.train_mono_source_binary_path = test_utils.make_temp_file()
         args.train_mono_target_text_file = test_utils.make_temp_file()
         options.validate_preprocessing_args(args)
@@ -58,7 +58,7 @@ class TestOptions(unittest.TestCase):
         task when we only have monolingual source data.
         """
         args = self.get_common_data_args_namespace()
-        args.task = "pytorch_translate_semisupervised"
+        args.task = constants.SEMI_SUPERVISED_TASK
         args.train_mono_source_binary_path = test_utils.make_temp_file()
         options.validate_preprocessing_args(args)
 
@@ -68,7 +68,7 @@ class TestOptions(unittest.TestCase):
         task when we only have monolingual source data.
         """
         args = self.get_common_data_args_namespace()
-        args.task = "pytorch_translate_semisupervised"
+        args.task = constants.SEMI_SUPERVISED_TASK
         args.train_mono_target_binary_path = test_utils.make_temp_file()
         options.validate_preprocessing_args(args)
 
@@ -78,5 +78,5 @@ class TestOptions(unittest.TestCase):
         no monolingual data at all.
         """
         args = self.get_common_data_args_namespace()
-        args.task = "pytorch_translate_semisupervised"
+        args.task = constants.SEMI_SUPERVISED_TASK
         self.assertRaises(ValueError, options.validate_preprocessing_args, args)

--- a/pytorch_translate/test/test_preprocess.py
+++ b/pytorch_translate/test/test_preprocess.py
@@ -4,7 +4,7 @@ import argparse
 import os
 import unittest
 
-from pytorch_translate import preprocess
+from pytorch_translate import constants, preprocess
 from pytorch_translate.test import utils as test_utils
 
 
@@ -69,7 +69,7 @@ class TestPreprocess(unittest.TestCase):
         test_data.py
         """
         args = self.get_common_data_args_namespace()
-        args.task = "pytorch_translate_semisupervised"
+        args.task = constants.SEMI_SUPERVISED_TASK
         args.train_mono_source_text_file = self.source_text_file
         args.train_mono_target_text_file = self.target_text_file
         preprocess.preprocess_corpora(args)

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -242,7 +242,7 @@ def setup_training_model(args):
         {sum(p.numel() for p in model.parameters())}"
     )
 
-    if args.task == "pytorch_translate_semi_supervised":
+    if args.task == constants.SEMI_SUPERVISED_TASK:
         task.load_dataset(
             split=args.train_subset,
             src_bin_path=args.train_source_binary_path,


### PR DESCRIPTION
Summary: We should do this for other task names moving forward so that when a task is renamed, we don't have to change a ton of other string literals

Differential Revision: D10520140
