### PR TITLE
Support for BPE vocabs + denoising autoencoder in PyTorch Translate

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -102,6 +102,23 @@ def add_preprocessing_args(parser):
         "flag will have no effect. A value of < 0 means no max size.",
     )
     group.add_argument(
+        "--source-bpe-cont-marker",
+        default=None,
+        type=str,
+        metavar="CONT",
+        help="Source BPE continuation marker. You should only specify this if "
+        "you are using a BPE source vocab that has an continuation marker "
+        "suffix. Note that this is the default BPE format in fairseq. Ex: '@@'",
+    )
+    group.add_argument(
+        "--source-bpe-end-marker",
+        default=None,
+        type=str,
+        metavar="END",
+        help="Source BPE end marker. You should only specify this if you are "
+        "using a BPE source vocab that has an end marker suffix. Ex: '_EOW'",
+    )
+    group.add_argument(
         "--char-source-vocab-file",
         default="",
         metavar="FILE",
@@ -131,7 +148,23 @@ def add_preprocessing_args(parser):
         "top N most common words. If we re-use an existing vocab file, this "
         "flag will have no effect. A value of < 0 means no max size.",
     )
-
+    group.add_argument(
+        "--target-bpe-cont-marker",
+        default=None,
+        type=str,
+        metavar="CONT",
+        help="Target BPE continuation marker. You should only specify this if "
+        "you are using a BPE target vocab that has an continuation marker "
+        "suffix. Note that this is the default BPE format in fairseq. Ex: '@@'",
+    )
+    group.add_argument(
+        "--target-bpe-end-marker",
+        default=None,
+        type=str,
+        metavar="END",
+        help="Target BPE end marker. You should only specify this if you are "
+        "using a BPE target vocab that has an end marker suffix. Ex: '_EOW'",
+    )
     group.add_argument(
         "--train-source-text-file",
         default="",

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -257,7 +257,7 @@ def setup_training_model(args):
             src_bin_path=args.train_source_binary_path,
             tgt_bin_path=args.train_target_binary_path,
             seed=args.seed,
-            noiser=task.noiser,
+            use_noiser=True,
         )
     else:
         task.load_dataset(


### PR DESCRIPTION
Summary: This actually uses the fairseq logic which supports BPE cont / end word marker suffixes.

Reviewed By: xianxl

Differential Revision: D12952766
