### PR TITLE
Read task-specific args for generation directly from model args in the saved checkpoint

### DIFF
--- a/pytorch_translate/benchmark.py
+++ b/pytorch_translate/benchmark.py
@@ -114,9 +114,8 @@ def benchmark(args):
     args.source_lang = "src"
     args.target_lang = "tgt"
 
-    task = tasks.setup_task(args)
-    models, model_args = pytorch_translate_utils.load_diverse_ensemble_for_inference(
-        args.path.split(":"), task
+    models, model_args, task = pytorch_translate_utils.load_diverse_ensemble_for_inference(
+        args.path.split(":")
     )
 
     append_eos_to_source = model_args[0].append_eos_to_source
@@ -155,13 +154,13 @@ def benchmark(args):
         os.remove(target_text_file)
 
         # priming
-        scorer, num_sentences, gen_timer, _ = pytorch_translate_generate._generate_score(
+        scorer, num_sentences, gen_timer, _ = pytorch_translate_generate.generate_score(
             models=models, args=args, task=task, dataset=task.dataset(args.gen_subset)
         )
 
         total_time = 0.0
         for _ in range(args.runs_per_length):
-            scorer, num_sentences, gen_timer, _ = pytorch_translate_generate._generate_score(
+            scorer, num_sentences, gen_timer, _ = pytorch_translate_generate.generate_score(
                 models=models,
                 args=args,
                 task=task,

--- a/pytorch_translate/research/adversarial/whitebox.py
+++ b/pytorch_translate/research/adversarial/whitebox.py
@@ -116,12 +116,9 @@ def validate_args(args):
 def setup_attack(args):
     """Load model, data and create the AdversarialTrainer object"""
 
-    # Setup task
-    task = tasks.setup_task(args)
-
     # Load model
-    models, models_args = pytorch_translate_utils.load_diverse_ensemble_for_inference(
-        args.path.split(":"), task
+    models, models_args, task = pytorch_translate_utils.load_diverse_ensemble_for_inference(
+        args.path.split(":")
     )
 
     # Only one model is supported as of now

--- a/pytorch_translate/research/knowledge_distillation/knowledge_distillation_loss.py
+++ b/pytorch_translate/research/knowledge_distillation/knowledge_distillation_loss.py
@@ -19,7 +19,7 @@ class KnowledgeDistillationCriterion(FairseqCriterion):
         use_cuda = torch.cuda.is_available() and not self.args.cpu
 
         # Load model ensemble from checkpoints
-        self.teacher_models, self.teacher_model_args = pytorch_translate_utils.load_diverse_ensemble_for_inference(
+        self.teacher_models, self.teacher_model_args, _ = pytorch_translate_utils.load_diverse_ensemble_for_inference(
             args.teacher_path.split(":"), task
         )
 

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -930,10 +930,15 @@ def calculate_bleu_on_subset(args, task, epoch_str: str, offset, dataset_split):
         task.score_aggregator if hasattr(task, "score_aggregator") else sum
     )
     scores = []
+    ensemble_models, _ = utils.load_ensemble_for_inference(args.path.split(":"), task)
     for dataset, lang_pair in zip(datasets, lang_pairs):
         # Generate score
         scorer, num_sentences, gen_timer, translation_samples = generate.generate_score(
-            args=args, task=task, dataset=dataset, lang_pair=lang_pair
+            args=args,
+            task=task,
+            dataset=dataset,
+            models=ensemble_models,
+            lang_pair=lang_pair,
         )
         scores.append(scorer.score())
         print(


### PR DESCRIPTION
Summary:
Generation should use the same args as training, so it is better to load the task-specific args from the model args when we load the checkpoint.

Task specific args I need to unblock denoising autoencoding generation + weight sweeping:  --denoising-source-, --denoising-target-, and --append-eos-to-source

I've updated the documentation for load_diverse_ensemble_for_inference and updated all the callsites. It isn't trivial to update KnowledgeDistillation so I've kept the optional task argument in load_diverse_ensemble_for_inference to maintain backwards compatibility.

Differential Revision: D13056323
