### PR TITLE
Refactor 2/N for char transformer

### DIFF
--- a/pytorch_translate/common_layers.py
+++ b/pytorch_translate/common_layers.py
@@ -2,7 +2,6 @@
 
 import abc
 
-import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F


### PR DESCRIPTION
Summary:
Replace the bi-lstm logic with a module that takes as input embeddings.
Some small simplifications: remove the freeze embedding, the word dropout and the padding options since these options were unused.

Reviewed By: jhcross

Differential Revision: D13113193
