### PR TITLE
Scheduling for denoising autoencoder loss contribution

### DIFF
--- a/pytorch_translate/common_layers.py
+++ b/pytorch_translate/common_layers.py
@@ -178,7 +178,7 @@ class Embedding(nn.Embedding):
         num_embeddings,
         embedding_dim,
         padding_idx,
-        freeze_embed,
+        freeze_embed=False,
         normalize_embed=False,
         normalize_decay_rate=0.99,
     ):
@@ -508,3 +508,14 @@ class VariableTracker(object):
 
     def __getitem__(self, name):
         return self.tracker[name]
+
+
+def build_embedding(dictionary, embed_dim, path=None):
+    num_embeddings = len(dictionary)
+    padding_idx = dictionary.pad()
+    emb = Embedding(num_embeddings, embed_dim, padding_idx)
+    # if provided, load from preloaded dictionaries
+    if path:
+        embed_dict = utils.parse_embedding(path)
+        utils.load_embedding(embed_dict, dictionary, emb)
+    return emb

--- a/pytorch_translate/weighted_data.py
+++ b/pytorch_translate/weighted_data.py
@@ -30,6 +30,17 @@ class WeightedLanguagePairDataset(data.language_pair_dataset.LanguagePairDataset
     """
     Extension of fairseq.data.LanguagePairDataset where each example
     has a weight in [0.0, 1.0], which will be used to weigh the loss.
+
+    TODO: Refactor this class to look like WeightedBacktranslationDataset.
+    We could wrap an existing dataset object and provide additional weights
+    feature. This way, it will be more composable and can be used with arbitrary
+    datasets. See D13143051.
+
+    Args:
+        weights (list): list of per example weight values; each example
+        has a weight in [0.0, 1.0]. Alternatively, when weights consists of a
+        single value, that value is broadcast as weight to all examples. [0.0]
+        gives 0 weight to all examples.
     """
 
     def __init__(
@@ -49,7 +60,16 @@ class WeightedLanguagePairDataset(data.language_pair_dataset.LanguagePairDataset
     def __getitem__(self, i):
         example = super().__getitem__(i)
         if self.weights:
-            example["weight"] = self.weights[i]
+            """
+            If weight for example is missing, use last seen weight. Sometimes we just
+            want to assign a weight to the entire dataset with a single value but also
+            maintain the list convention of weights. This way, even if we don't care/know
+            about dataset size, we can assign same weight to all examples.
+            """
+            if len(self.weights) <= i:
+                example["weight"] = self.weights[-1]
+            else:
+                example["weight"] = self.weights[i]
         else:
             example["weight"] = 1.0
 
@@ -62,6 +82,60 @@ class WeightedLanguagePairDataset(data.language_pair_dataset.LanguagePairDataset
         if len(samples) == 0:
             return {}
         unweighted_data = super().collater(samples)
+        original_weights = torch.FloatTensor([s.get("weight", 1.0) for s in samples])
+        # sort by descending source length
+        src_lengths = torch.LongTensor([s["source"].numel() for s in samples])
+        src_lengths, sort_order = src_lengths.sort(descending=True)
+        weights = original_weights.index_select(0, sort_order)
+        unweighted_data["weights"] = weights
+        return unweighted_data
+
+
+class WeightedBacktranslationDataset(
+    data.backtranslation_dataset.BacktranslationDataset
+):
+    """
+    Extension of fairseq.data.BacktranslationDataset where each example
+    has a weight in [0.0, 1.0], which will be used to weigh the loss.
+
+    Args:
+        weights (list): list of per example weight values; each example
+        has a weight in [0.0, 1.0]. Alternatively, when weights consists of a
+        single value, that value is broadcast as weight to all examples. [0.0]
+        gives 0 weight to all examples.
+    """
+
+    def __init__(self, dataset, weights=None, **kwargs):
+        self.weights = weights
+        self.dataset = dataset
+
+    def __getattr__(self, attr):
+        if attr in self.__dict__:
+            return getattr(self, attr)
+        return getattr(self.dataset, attr)
+
+    def __getitem__(self, i):
+        example = self.dataset.__getitem__(i)
+        if self.weights:
+            """
+            If weight for example is missing, use last seen weight. Sometimes we just
+            want to assign a weight to the entire dataset with a single value but also
+            maintain the list convention of weights. This way, even if we don't care or
+            don't know about dataset size, we can assign same weight to all examples.
+            """
+            if len(self.weights) <= i:
+                example["weight"] = self.weights[-1]
+            else:
+                example["weight"] = self.weights[i]
+        else:
+            example["weight"] = 1.0
+
+        return example
+
+    def collater(self, samples):
+        if len(samples) == 0:
+            return {}
+        unweighted_data = self.dataset.collater(samples)
         original_weights = torch.FloatTensor([s.get("weight", 1.0) for s in samples])
         # sort by descending source length
         src_lengths = torch.LongTensor([s["source"].numel() for s in samples])


### PR DESCRIPTION
Summary:
This adds 2 new training options: grow loss contribution of denoising autoencoder by increasing DAE dataset weight, decay loss contribution of denoising autoencoder by decreasing DAE dataset weight. In both cases, we leave the translation objective weight constant with weight of 1.

For simplicity and reproducibility I'm adding only a few options for scheduling loss weights. I will update the default options once I experiment with the params to figure out what works best

Differential Revision: D13208083
