### PR TITLE
use num_iterations instead of epochs for warmup

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -486,7 +486,7 @@ def train(
                 and "augment_adv" in train_step_kwargs.keys()
             ):
                 train_step_kwargs["augment_adv"] = (
-                    extra_state["epoch"] > args.warmup_epochs
+                    extra_state["num_iterations"] > args.warmup_steps
                 )
             try:
                 log_output = trainer.train_step(samples, **train_step_kwargs)


### PR DESCRIPTION
Summary: This is to allow adversarial training to start independent of training data size. For large directions, model may already converged before finishing one epoch.

Differential Revision: D13231507
