### PR TITLE
Add optional monolingual ratio limit when loading binarized data files for semisupervised tasks

### DIFF
--- a/pytorch_translate/data_utils.py
+++ b/pytorch_translate/data_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+from typing import Optional
 
 from pytorch_translate import char_data, data as pytorch_translate_data, weighted_data
 
@@ -57,7 +58,11 @@ def load_parallel_dataset(
 
 
 def load_monolingual_dataset(
-    bin_path, is_source=False, char_source_dict=None, log_verbose=True
+    bin_path,
+    is_source=False,
+    char_source_dict=None,
+    log_verbose=True,
+    num_examples_limit: Optional[int] = None,
 ):
     if log_verbose:
         print("Starting to load binarized monolingual data file.", flush=True)
@@ -70,7 +75,7 @@ def load_monolingual_dataset(
 
     else:
         dataset = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
-            path=bin_path
+            path=bin_path, num_examples_limit=num_examples_limit
         )
 
     if log_verbose:

--- a/pytorch_translate/tasks/denoising_autoencoder_task.py
+++ b/pytorch_translate/tasks/denoising_autoencoder_task.py
@@ -190,7 +190,7 @@ class PytorchTranslateDenoisingAutoencoder(PytorchTranslateSemiSupervised):
 
             if getattr(self.args, "denoising_source_mono", False):
                 source_mono_dataset = self.load_monolingual_dataset(
-                    self.args.train_mono_source_binary_path
+                    bin_path=self.args.train_mono_source_binary_path, is_source=True
                 )
                 dataset_map[
                     (
@@ -212,7 +212,7 @@ class PytorchTranslateDenoisingAutoencoder(PytorchTranslateSemiSupervised):
                 )
             if getattr(self.args, "denoising_target_mono", False):
                 target_mono_dataset = self.load_monolingual_dataset(
-                    self.args.train_mono_target_binary_path
+                    bin_path=self.args.train_mono_target_binary_path, is_source=False
                 )
                 dataset_map[
                     (
@@ -233,7 +233,14 @@ class PytorchTranslateDenoisingAutoencoder(PytorchTranslateSemiSupervised):
                     append_eos_to_target=True,
                 )
 
+        # print before loading RoundRobinZipDatasets to help catch any bugs
+        for dataset_key, dataset in dataset_map.items():
+            print(f"| {split}: {dataset_key} {len(dataset)} examples in dataset")
+
         self.datasets[split] = RoundRobinZipDatasets(dataset_map)
+        print(
+            f"| {split} {len(self.datasets[split])} examples in RoundRobinZipDatasets"
+        )
 
         if self.args.log_verbose:
             print("Finished loading dataset", flush=True)


### PR DESCRIPTION
Summary:
Note in the semi supervised case, forward parallel data size is the same as backward parallel data size.

I added this option in the binarized data loading stage so that we can do quick iteration with different monolingual data sizes without having to re-binarize data.

follow-up: randomly sample examples instead of taking the top n examples

Reviewed By: dpacgopinath

Differential Revision: D13270281
