### PR TITLE
Fix extended load_checkpoint tests

### DIFF
--- a/pytorch_translate/test/test_checkpoint.py
+++ b/pytorch_translate/test/test_checkpoint.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+
+import torch
+from pytorch_translate import checkpoint
+from pytorch_translate.test import utils as test_utils
+
+
+class TestCheckpoint(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
+    def test_load_checkpoint(self):
+        """Train for one step, save a checkpoint, and make sure it is loaded
+        properly."""
+        test_save_file = test_utils.make_temp_file()
+        test_args = test_utils.ModelParamsDict()
+        test_args.distributed_rank = 0
+        extra_state = test_utils.create_dummy_extra_state(epoch=2)
+        trainer, _ = test_utils.gpu_train_step(test_args)
+        trainer.save_checkpoint(test_save_file, extra_state)
+        loaded, extra_state = checkpoint.load_existing_checkpoint(
+            test_save_file, trainer, restore_state=True
+        )
+        # Loading checkpoint without restore state should reset extra state
+        assert loaded and extra_state["epoch"] == 2
+        os.remove(test_save_file)
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
+    def test_load_checkpoint_no_restore_state(self):
+        """Train for one step, save a checkpoint, and make sure it is loaded
+        properly WITHOUT loading the extra state from the checkpoint."""
+        test_save_file = test_utils.make_temp_file()
+        test_args = test_utils.ModelParamsDict()
+        test_args.distributed_rank = 0
+        extra_state = test_utils.create_dummy_extra_state(epoch=2)
+        trainer, _ = test_utils.gpu_train_step(test_args)
+        trainer.save_checkpoint(test_save_file, extra_state)
+        loaded, extra_state = checkpoint.load_existing_checkpoint(
+            test_save_file, trainer, restore_state=False
+        )
+        # Loading checkpoint without restore state should reset extra state
+        assert loaded and extra_state is None
+        os.remove(test_save_file)

--- a/pytorch_translate/test/test_train.py
+++ b/pytorch_translate/test/test_train.py
@@ -5,7 +5,6 @@ import unittest
 
 import numpy as np
 import torch
-from fairseq.trainer import Trainer
 from pytorch_translate import rnn  # noqa
 from pytorch_translate import train
 from pytorch_translate.tasks import pytorch_translate_task as tasks
@@ -13,20 +12,10 @@ from pytorch_translate.test import utils as test_utils
 
 
 class TestRNNModel(unittest.TestCase):
-    def _gpu_train_step(self, test_args):
-        samples, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
-        task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
-        model = task.build_model(test_args)
-        criterion = task.build_criterion(test_args)
-        sample = next(samples)
-        trainer = Trainer(test_args, task, model, criterion, dummy_batch=sample)
-        logging_dict = trainer.train_step([sample])
-        return trainer, logging_dict
-
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_gpu_train_step(self):
         test_args = test_utils.ModelParamsDict()
-        trainer, _ = self._gpu_train_step(test_args)
+        trainer, _ = test_utils.gpu_train_step(test_args)
         assert trainer.get_meter("gnorm").avg > 0
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
@@ -34,7 +23,7 @@ class TestRNNModel(unittest.TestCase):
         test_args = test_utils.ModelParamsDict(
             encoder_freeze_embed=True, decoder_freeze_embed=True
         )
-        self._gpu_train_step(test_args)
+        test_utils.gpu_train_step(test_args)
 
     def test_load_pretrained_embedding(self):
         test_args = test_utils.ModelParamsDict()
@@ -53,7 +42,7 @@ class TestRNNModel(unittest.TestCase):
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_milstm_cell(self):
         test_args = test_utils.ModelParamsDict(cell_type="milstm")
-        trainer, _ = self._gpu_train_step(test_args)
+        trainer, _ = test_utils.gpu_train_step(test_args)
         assert trainer.get_meter("gnorm").avg > 0
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
@@ -61,49 +50,19 @@ class TestRNNModel(unittest.TestCase):
         test_args = test_utils.ModelParamsDict(
             encoder_bidirectional=True, sequence_lstm=True
         )
-        trainer, _ = self._gpu_train_step(test_args)
+        trainer, _ = test_utils.gpu_train_step(test_args)
         assert trainer.get_meter("gnorm").avg > 0
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_layer_norm_lstm_cell(self):
         test_args = test_utils.ModelParamsDict(cell_type="layer_norm_lstm")
-        trainer, _ = self._gpu_train_step(test_args)
+        trainer, _ = test_utils.gpu_train_step(test_args)
         assert trainer.get_meter("gnorm").avg > 0
-
-    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
-    def test_load_checkpoint(self):
-        test_save_file = test_utils.make_temp_file()
-        test_args = test_utils.ModelParamsDict()
-        test_args.distributed_rank = 0
-        extra_state = test_utils.create_dummy_extra_state(epoch=2)
-        trainer, _ = self._gpu_train_step(test_args)
-        trainer.save_checkpoint(test_save_file, extra_state)
-        loaded, extra_state = train.load_existing_checkpoint(
-            test_save_file, trainer, restore_state=True
-        )
-        # Loading checkpoint without restore state should reset extra state
-        assert loaded and extra_state["epoch"] == 2
-        os.remove(test_save_file)
-
-    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
-    def test_load_checkpoint_no_restore_state(self):
-        test_save_file = test_utils.make_temp_file()
-        test_args = test_utils.ModelParamsDict()
-        test_args.distributed_rank = 0
-        extra_state = test_utils.create_dummy_extra_state(epoch=2)
-        trainer, _ = self._gpu_train_step(test_args)
-        trainer.save_checkpoint(test_save_file, extra_state)
-        loaded, extra_state = train.load_existing_checkpoint(
-            test_save_file, trainer, restore_state=False
-        )
-        # Loading checkpoint without restore state should reset extra state
-        assert loaded and extra_state is None
-        os.remove(test_save_file)
 
     @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_first_layer_multihead_attention_(self):
         test_args = test_utils.ModelParamsDict(
             attention_type="multihead", attention_heads=2, first_layer_attention=True
         )
-        trainer, _ = self._gpu_train_step(test_args)
+        trainer, _ = test_utils.gpu_train_step(test_args)
         assert trainer.get_meter("gnorm").avg > 0


### PR DESCRIPTION
Summary:
Extended tests were broken because pytorch_translate.train didn't have the load_checkpoint function (it was moved to pytorch_translate.checkpoint). This fixes the tests.

While I'm here, I added input and output typehints + simple docstrings

Differential Revision: D13577679
