### PR TITLE
add faulthandler for segfault traceback

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -2,6 +2,7 @@
 
 import argparse
 import collections
+import faulthandler
 import math
 import multiprocessing.queues as mp_queues
 import os
@@ -643,6 +644,12 @@ def multi_process_train(
     trainer_class=None,
     train_step_kwargs=None,
 ):
+    # Enable faulthandler for better Python tracebacks upon segfaults under
+    # multiprocessing. Without this, the stack trace only shows the
+    # SpawnContext.join() call, rather than the actual line where the child
+    # process segfaulted.
+    faulthandler.enable(all_threads=True)
+
     if init_fn:
         init_fn()
     args.device_id = device_id


### PR DESCRIPTION
Summary:
See https://docs.python.org/3/library/faulthandler.html

Pieter Noordhuis - could this be something that'd make sense to incorporate into PyTorch [SpawnContext](https://github.com/pytorch/pytorch/blob/master/torch/multiprocessing/spawn.py)?

Without this, the traceback is like:
```
Traceback (most recent call last):
  File "/mnt/xarfuse/uid-144043/1b9e2d40-ns-4026531840/__run_xar_main__.py", line 151, in <module>
    __invoke_main()
  File "/mnt/xarfuse/uid-144043/1b9e2d40-ns-4026531840/__run_xar_main__.py", line 148, in __invoke_main
    runpy._run_module_as_main(module, False)
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/mnt/xarfuse/uid-144043/1b9e2d40-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 742, in <module>
    main(args)
  File "/mnt/xarfuse/uid-144043/1b9e2d40-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 724, in main
    while not spawn_context.join(timeout=30):
  File "/mnt/xarfuse/uid-144043/1b9e2d40-ns-4026531840/torch/multiprocessing/spawn.py", line 103, in join
    (error_index, name)
Exception: process 1 terminated with signal SIGSEGV
```

With `all_threads=False`, the traceback becomes:
```
Fatal Python error: Segmentation fault

Stack (most recent call first):
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/fairseq/trainer.py", line 308 in valid_step
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/pytorch_translate/evals.py", line 121 in eval_tune_loss
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/pytorch_translate/evals.py", line 314 in save_and_eval
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 480 in train
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 677 in multi_process_train
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/torch/multiprocessing/spawn.py", line 19 in _wrap
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/process.py", line 93 in run
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/process.py", line 258 in _bootstrap
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/spawn.py", line 118 in _main
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/spawn.py", line 105 in spawn_main
  File "<string>", line 1 in <module>
Traceback (most recent call last):
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/__run_xar_main__.py", line 151, in <module>
    __invoke_main()
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/__run_xar_main__.py", line 148, in __invoke_main
    runpy._run_module_as_main(module, False)
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 738, in <module>
    main(args)
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 720, in main
    while not spawn_context.join(timeout=30):
  File "/mnt/xarfuse/uid-144043/9dcc70f8-ns-4026531840/torch/multiprocessing/spawn.py", line 103, in join
    (error_index, name)
Exception: process 1 terminated with signal SIGSEGV
```

(With `all_threads=True`, it becomes like:
```
Fatal Python error: Segmentation fault

Thread 0x00007f3ceca0b700 (most recent call first):

Thread 0x00007f3ced20c700 (most recent call first):

Thread 0x00007f3cedffb700 (most recent call first):

Current thread 0x00007f3df0c4d700 (most recent call first):
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/fairseq/trainer.py", line 308 in valid_step
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/pytorch_translate/evals.py", line 121 in eval_tune_loss
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/pytorch_translate/evals.py", line 314 in save_and_eval
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 480 in train
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 677 in multi_process_train
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/torch/multiprocessing/spawn.py", line 19 in _wrap
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/process.py", line 93 in run
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/process.py", line 258 in _bootstrap
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/spawn.py", line 118 in _main
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/multiprocessing/spawn.py", line 105 in spawn_main
  File "<string>", line 1 in <module>
Traceback (most recent call last):
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/__run_xar_main__.py", line 151, in <module>
    __invoke_main()
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/__run_xar_main__.py", line 148, in __invoke_main
    runpy._run_module_as_main(module, False)
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/fbcode/gcc-5-glibc-2.23/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 738, in <module>
    main(args)
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/language_technology/neural_mt/os/pytorch_translate/train.py", line 720, in main
    while not spawn_context.join(timeout=30):
  File "/mnt/xarfuse/uid-144043/1c5bdcd2-ns-4026531840/torch/multiprocessing/spawn.py", line 103, in join
    (error_index, name)
Exception: process 1 terminated with signal SIGSEGV
```
)

Reviewed By: akinh

Differential Revision: D13627797
