### PR TITLE
Add semisupervised PyTorch Translate integration test

### DIFF
--- a/pytorch_translate/tasks/semi_supervised_task.py
+++ b/pytorch_translate/tasks/semi_supervised_task.py
@@ -197,6 +197,18 @@ class PytorchTranslateSemiSupervised(PytorchTranslateTask):
             "training examples.",
         )
         parser.add_argument(
+            "--train-mono-source-text-file",
+            default="",
+            help="Path for the text file containing monolingual source "
+            "training examples.",
+        )
+        parser.add_argument(
+            "--train-mono-target-text-file",
+            default="",
+            help="Path for the text file containing monolingual target "
+            "training examples.",
+        )
+        parser.add_argument(
             "--monolingual-ratio",
             default=None,
             type=float,

--- a/pytorch_translate/test/test_integration.py
+++ b/pytorch_translate/test/test_integration.py
@@ -455,6 +455,48 @@ class TestTranslation(unittest.TestCase):
                     ],
                 )
 
+    @unittest.skipIf(
+        torch.cuda.device_count() != 1, "Test only supports single-GPU training."
+    )
+    def test_semisupervised(self):
+        with contextlib.redirect_stdout(StringIO()):
+            with tempfile.TemporaryDirectory("test_rnn") as data_dir:
+                create_dummy_data(data_dir)
+                train_translation_model(
+                    data_dir,
+                    [
+                        "--task",
+                        "pytorch_translate_semi_supervised",
+                        "--train-mono-source-text-file",
+                        os.path.join(data_dir, "train.in"),
+                        "--train-mono-target-text-file",
+                        os.path.join(data_dir, "train.out"),
+                        "--arch",
+                        "semi_supervised",
+                        "--cell-type",
+                        "lstm",
+                        "--sequence-lstm",
+                        "--reverse-source",
+                        "--encoder-bidirectional",
+                        "--encoder-layers",
+                        "2",
+                        "--encoder-embed-dim",
+                        "256",
+                        "--encoder-hidden-dim",
+                        "512",
+                        "--decoder-layers",
+                        "2",
+                        "--decoder-embed-dim",
+                        "256",
+                        "--decoder-hidden-dim",
+                        "512",
+                        "--decoder-out-embed-dim",
+                        "256",
+                        "--attention-type",
+                        "dot",
+                    ],
+                )
+
 
 def write_dummy_file(filename, num_examples, maxlen):
     rng_state = torch.get_rng_state()


### PR DESCRIPTION
Summary: Add semisupervised integration test to PyTorch Translate. This runs as a GPU unittest so that we don't have to run a full FBTranslate flow integration test to verify that semisupervised models train properly in PyTorch Translate.

Reviewed By: akinh

Differential Revision: D13632474
