### PR TITLE
Remove sudo in continuous integration for pytorch translate

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -2,7 +2,7 @@
 # Builds PyTorch Translate and runs basic tests.
 
 pip uninstall -y pytorch-translate
-sudo python3 setup.py build develop
+python3 setup.py build develop
 pushd pytorch_translate/cpp || exit
 
 mkdir build && pushd build || exit


### PR DESCRIPTION
Summary: There is no need to call sudo and python3 is not available in sudo path.

Differential Revision: D13686174
