### PR TITLE
option to evaluate oracle BLEU

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -76,10 +76,10 @@ def generate_score(
 
 
 class TranslationInfo(NamedTuple):
-    sample_id: int
-    src_tokens: str
-    target_tokens: str
-    hypo_tokens: str
+    sample_id: torch.Tensor
+    src_tokens: torch.Tensor
+    target_tokens: torch.Tensor
+    hypo_tokens: torch.Tensor
     src_str: str
     target_str: str
     hypo_str: str

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -623,6 +623,20 @@ def expand_generation_args(group, train=False):
             "floats with length equal to the number of models in the ensemble."
         ),
     )
+    group.add_argument(
+        "--report-oracle-bleu",
+        type=utils.bool_flag,
+        nargs="?",
+        const=True,
+        default=False,
+        help=(
+            "During evaluation, determine best among top-k outputs (where k "
+            "is controlled by --nbest) for each sentence by smoothed "
+            "sentence-level BLEU and report overall BLEU score for these "
+            "sentences."
+        ),
+    )
+
     # These arguments are only used during training
     if train:
         group.add_argument(


### PR DESCRIPTION
Summary: Adds an option (initially command-online only pending refactor) to evaluate the best BLEU achievable when choosing among top-K beam search outputs with an oracle. For the purpose of comparing individual sentences (where counts may often be zero), we use smoothing (method 3 from Chen and Cherry 2014, linked in function docstring).

Differential Revision: D13794925
