### PR TITLE
clean up word_dropout_params

### DIFF
--- a/pytorch_translate/char_source_model.py
+++ b/pytorch_translate/char_source_model.py
@@ -71,7 +71,6 @@ class CharSourceModel(rnn.RNNModel):
                 dropout_out=args.encoder_dropout_out,
                 residual_level=args.residual_level,
                 bidirectional=bool(args.encoder_bidirectional),
-                word_dropout_params=args.word_dropout_params,
                 use_pretrained_weights=getattr(args, "use_pretrained_weights", False),
                 finetune_pretrained_weights=getattr(
                     args, "finetune_pretrained_weights", False
@@ -260,7 +259,6 @@ class CharCNNEncoder(FairseqEncoder):
         dropout_out=0.1,
         residual_level=None,
         bidirectional=False,
-        word_dropout_params=None,
         use_pretrained_weights=False,
         finetune_pretrained_weights=False,
         weights_file=None,

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -86,7 +86,6 @@ class ModelParamsDict:
         self.clip_norm = 5.0
         self.batch_size = 4
         self.vocab_reduction_params = None
-        self.word_dropout_params = None
         self.distributed_world_size = 1
         self.seed = 1
         self.left_pad_source = "True"


### PR DESCRIPTION
Summary: We removed the WordDropout model (D13830640) but left a few unused parameters.

Differential Revision: D13830640
