### PR TITLE
move GPU unit tests to CPU

### DIFF
--- a/pytorch_translate/test/test_beam_decode.py
+++ b/pytorch_translate/test/test_beam_decode.py
@@ -13,7 +13,6 @@ from pytorch_translate.test import utils as test_utils
 
 
 class TestBeamDecode(unittest.TestCase):
-    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_basic_generate(self):
         test_args = test_utils.ModelParamsDict()
         _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
@@ -25,7 +24,6 @@ class TestBeamDecode(unittest.TestCase):
         encoder_input = {"src_tokens": src_tokens, "src_lengths": src_lengths}
         translator.generate(encoder_input, maxlen=7)
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_char_rnn_generate(self):
         test_args = test_utils.ModelParamsDict(sequence_lstm=True)
         test_args.arch = "char_source"
@@ -52,7 +50,6 @@ class TestBeamDecode(unittest.TestCase):
         }
         translator.generate(encoder_input, maxlen=7)
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_gather_probs_with_vr(self):
         """ Tests gather_probs when there is vocab reduction """
         all_translation_tokens: List[Any] = [
@@ -60,10 +57,8 @@ class TestBeamDecode(unittest.TestCase):
             torch.LongTensor([0, 3, 5]),
         ]
         all_probs: List[Any] = [
-            torch.FloatTensor(
-                [[0.25, 0.25, 0.25, 0.25], [0.25, 0.25, 0.25, 0.25]]
-            ).cuda(),
-            torch.FloatTensor([[0.4, 0.5, 0.1], [0.4, 0.5, 0.1]]).cuda(),
+            torch.FloatTensor([[0.25, 0.25, 0.25, 0.25], [0.25, 0.25, 0.25, 0.25]]),
+            torch.FloatTensor([[0.4, 0.5, 0.1], [0.4, 0.5, 0.1]]),
         ]
         avg_probs, possible_translation_tokens = beam_decode.SequenceGenerator.gather_probs(
             all_translation_tokens=all_translation_tokens, all_probs=all_probs
@@ -86,7 +81,6 @@ class TestBeamDecode(unittest.TestCase):
             desired=np.array(possible_translation_tokens_ref),
         )
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "No GPU available for test.")
     def test_gather_probs_without_vr(self):
         """ Tests gather_probs when there is no vocab reduction """
         all_probs: List[Any] = [

--- a/pytorch_translate/test/test_integration.py
+++ b/pytorch_translate/test/test_integration.py
@@ -17,7 +17,6 @@ from pytorch_translate.test.utils import (
 
 
 class TestTranslation(unittest.TestCase):
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_rnn(self):
         with contextlib.redirect_stdout(StringIO()):
             with tempfile.TemporaryDirectory("test_rnn") as data_dir:
@@ -35,17 +34,17 @@ class TestTranslation(unittest.TestCase):
                         "--encoder-layers",
                         "2",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-layers",
                         "2",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "256",
+                        "8",
                         "--attention-type",
                         "dot",
                     ],
@@ -71,24 +70,23 @@ class TestTranslation(unittest.TestCase):
                         "--encoder-layers",
                         "2",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-layers",
                         "2",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "256",
+                        "8",
                         "--attention-type",
                         "dot",
                     ],
                 )
                 generate_main(data_dir)
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_char_rnn(self):
         with contextlib.redirect_stdout(StringIO()):
             with tempfile.TemporaryDirectory("test_char_rnn") as data_dir:
@@ -99,9 +97,9 @@ class TestTranslation(unittest.TestCase):
                         "--arch",
                         "char_source",
                         "--char-embed-dim",
-                        "64",
+                        "4",
                         "--char-rnn-units",
-                        "128",
+                        "8",
                         "--char-rnn-layers",
                         "1",
                         "--char-source-max-vocab-size",
@@ -120,17 +118,17 @@ class TestTranslation(unittest.TestCase):
                         "--encoder-layers",
                         "2",
                         "--encoder-embed-dim",
-                        "64",
+                        "8",
                         "--encoder-hidden-dim",
-                        "256",
+                        "16",
                         "--decoder-layers",
                         "2",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-hidden-dim",
-                        "256",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "256",
+                        "8",
                         "--attention-type",
                         "dot",
                     ],
@@ -143,7 +141,6 @@ class TestTranslation(unittest.TestCase):
                     ],
                 )
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_pretrained_char_model(self):
         with contextlib.redirect_stdout(StringIO()):
             with tempfile.TemporaryDirectory("test_pretrained_char_model") as data_dir:
@@ -204,7 +201,6 @@ class TestTranslation(unittest.TestCase):
                     ],
                 )
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_multilingual(self):
         with contextlib.redirect_stdout(StringIO()):
             with tempfile.TemporaryDirectory("test_multilingual") as data_dir:
@@ -224,17 +220,17 @@ class TestTranslation(unittest.TestCase):
                         "--encoder-layers",
                         "2",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-layers",
                         "2",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "256",
+                        "8",
                         "--attention-type",
                         "dot",
                         "--multiling-encoder-lang",
@@ -319,7 +315,6 @@ class TestTranslation(unittest.TestCase):
                         ],
                     )
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_transformer(self):
         with contextlib.redirect_stdout(StringIO()):
             with tempfile.TemporaryDirectory("test_transformer") as data_dir:
@@ -330,17 +325,17 @@ class TestTranslation(unittest.TestCase):
                         "--arch",
                         "ptt_transformer",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-ffn-embed-dim",
-                        "512",
+                        "16",
                         "--encoder-attention-heads",
                         "4",
                         "--encoder-layers",
                         "3",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-ffn-embed-dim",
-                        "512",
+                        "16",
                         "--decoder-attention-heads",
                         "4",
                         "--decoder-layers",
@@ -383,7 +378,6 @@ class TestTranslation(unittest.TestCase):
                 )
                 generate_main(data_dir)
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_char_transformer(self):
         with contextlib.redirect_stdout(StringIO()):
             with tempfile.TemporaryDirectory("test_char_transformer") as data_dir:
@@ -394,9 +388,9 @@ class TestTranslation(unittest.TestCase):
                         "--arch",
                         "char_source_transformer",
                         "--char-embed-dim",
-                        "64",
+                        "4",
                         "--char-cnn-params",
-                        "[(50, 1), (100,2)]",
+                        "[(10, 1), (20, 2)]",
                         "--char-cnn-nonlinear-fn",
                         "relu",
                         "--char-cnn-num-highway-layers",
@@ -404,17 +398,17 @@ class TestTranslation(unittest.TestCase):
                         "--char-source-max-vocab-size",
                         "26",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-ffn-embed-dim",
-                        "512",
+                        "16",
                         "--encoder-attention-heads",
                         "4",
                         "--encoder-layers",
                         "3",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-ffn-embed-dim",
-                        "512",
+                        "16",
                         "--decoder-attention-heads",
                         "4",
                         "--decoder-layers",
@@ -429,7 +423,6 @@ class TestTranslation(unittest.TestCase):
                     ],
                 )
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_char_source_hybrid(self):
         with contextlib.redirect_stdout(StringIO()):
             with tempfile.TemporaryDirectory("test_char_rnn") as data_dir:
@@ -440,9 +433,9 @@ class TestTranslation(unittest.TestCase):
                         "--arch",
                         "char_source_hybrid",
                         "--char-embed-dim",
-                        "64",
+                        "4",
                         "--char-cnn-params",
-                        "[(50, 1), (100,2)]",
+                        "[(10, 1), (20,2)]",
                         "--char-cnn-nonlinear-fn",
                         "relu",
                         "--char-cnn-num-highway-layers",
@@ -450,23 +443,23 @@ class TestTranslation(unittest.TestCase):
                         "--char-source-max-vocab-size",
                         "26",
                         "--encoder-embed-dim",
-                        "128",
+                        "8",
                         "--encoder-ffn-embed-dim",
-                        "256",
+                        "16",
                         "--encoder-attention-heads",
                         "4",
                         "--encoder-layers",
                         "3",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-attention-heads",
                         "4",
                         "--decoder-layers",
                         "2",
                         "--decoder-lstm-units",
-                        "128",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "64",
+                        "8",
                     ],
                 )
                 generate_main(
@@ -477,7 +470,6 @@ class TestTranslation(unittest.TestCase):
                     ],
                 )
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_semisupervised(self):
         """
         Tests semi_supervised task. Important flags: `--train-mono-*-text-file`,
@@ -505,23 +497,22 @@ class TestTranslation(unittest.TestCase):
                         "--encoder-layers",
                         "2",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-layers",
                         "2",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "256",
+                        "8",
                         "--attention-type",
                         "dot",
                     ],
                 )
 
-    @unittest.skipIf(torch.cuda.device_count() < 1, "Test only supports GPU training.")
     def test_denoising_autoencoder(self):
         """
         Tests denoising autoencoder task. Important flags:
@@ -551,25 +542,22 @@ class TestTranslation(unittest.TestCase):
                         "--encoder-layers",
                         "2",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-layers",
                         "2",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "256",
+                        "8",
                         "--attention-type",
                         "dot",
                     ],
                 )
 
-    @unittest.skipIf(
-        torch.cuda.device_count() != 1, "Test only supports single-GPU training."
-    )
     def test_word_prediction(self):
         """ Tests a word prediction model, which will use a learned vocab
         reduction via the word prediction model. It uses a custom criterion
@@ -596,17 +584,17 @@ class TestTranslation(unittest.TestCase):
                         "--encoder-layers",
                         "2",
                         "--encoder-embed-dim",
-                        "256",
+                        "8",
                         "--encoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-layers",
                         "2",
                         "--decoder-embed-dim",
-                        "256",
+                        "8",
                         "--decoder-hidden-dim",
-                        "512",
+                        "16",
                         "--decoder-out-embed-dim",
-                        "256",
+                        "8",
                         "--attention-type",
                         "dot",
                     ],
@@ -666,8 +654,6 @@ def train_translation_model(data_dir, extra_flags, criterion=None):
             "1",
             "--no-progress-bar",
             "--distributed-world-size",
-            "1",
-            "--local-num-gpus",
             "1",
             "--source-lang",
             "in",

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -202,8 +202,9 @@ def validate_and_set_default_args(args):
 def setup_training_model(args):
     """Parse args, load dataset, and build model with criterion."""
     if not torch.cuda.is_available():
-        raise NotImplementedError("Training on CPU is not supported")
-    torch.cuda.set_device(args.device_id)
+        print("Warning: training without CUDA is likely to be slow!")
+    else:
+        torch.cuda.set_device(args.device_id)
     torch.manual_seed(args.seed)
 
     # Setup task and load dataset


### PR DESCRIPTION
Summary:
Where possible all pytorch_translate unit tests requiring GPUs are moved to run on CPU. Example model sizes are greatly reduced to keep run time reasonable and prevent timeouts.

The following tests remain GPU-only:

  - `test_transformer_multigpu` - specifically tests a training mode requiring GPUs
  - `test_rnn_fp16` - FP16 not currently supported on CPU

Differential Revision: D13857481
