### PR TITLE
Adding explicit word segmentation based on the Viterbi algorithm

### DIFF
--- a/pytorch_translate/research/test/test_unsupervised_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_morphology.py
@@ -153,3 +153,28 @@ class TestUnsupervisedMorphology(unittest.TestCase):
 
             segmentor = unsupervised_morphology.MorphologySegmentor(morph_hmm_model)
             assert segmentor.segment_viterbi("123123789") == (["stem"], [0, 9])
+
+    def test_segment_word_no_smoothing(self):
+        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
+            smoothing_const=0.0
+        )
+        with patch("builtins.open") as mock_open:
+            txt_content = [
+                "123 124 234 345",
+                "112 122 123 345",
+                "123456789",
+                "123456 456789",
+            ]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
+
+            segmentor = unsupervised_morphology.MorphologySegmentor(morph_hmm_model)
+            assert segmentor.segment_word("123123789789") == "123 123 789 789"
+            assert (
+                segmentor.segment_word("123123789789", add_affix_symbols=True)
+                == "123+ 123+ 789 +789"
+            )
+            assert segmentor.segment_word("123") == segmentor.segment_word(
+                "123", add_affix_symbols=True
+            )

--- a/pytorch_translate/research/test/test_unsupervised_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_morphology.py
@@ -116,3 +116,40 @@ class TestUnsupervisedMorphology(unittest.TestCase):
                 morph_hmm_model.transition_log_prob("suffix", "START")
                 == morph_hmm_model.SMALL_CONST
             )
+
+    def test_segment_viterbi_no_smoothing(self):
+        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
+            smoothing_const=0.0
+        )
+        with patch("builtins.open") as mock_open:
+            txt_content = [
+                "123 124 234 345",
+                "112 122 123 345",
+                "123456789",
+                "123456 456789",
+            ]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
+
+            segmentor = unsupervised_morphology.MorphologySegmentor(morph_hmm_model)
+            assert segmentor.segment_viterbi("123123789") == (
+                ["prefix", "prefix", "stem"],
+                [0, 3, 6, 9],
+            )
+
+    def test_segment_viterbi_w_smoothing(self):
+        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams()
+        with patch("builtins.open") as mock_open:
+            txt_content = [
+                "123 124 234 345",
+                "112 122 123 345",
+                "123456789",
+                "123456 456789",
+            ]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
+
+            segmentor = unsupervised_morphology.MorphologySegmentor(morph_hmm_model)
+            assert segmentor.segment_viterbi("123123789") == (["stem"], [0, 9])

--- a/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
+++ b/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
@@ -127,4 +127,89 @@ class MorphologyHMMParams(object):
     def emission_log_probs(self, affix, morpheme):
         if affix in {"START", "END"}:
             return self.SMALL_CONST
+        if self.emission_prob(affix, morpheme) == 0:
+            return self.SMALL_CONST
         return math.log(self.emission_prob(affix, morpheme))
+
+
+class MorphologySegmentor(object):
+    def __init__(self, morphology_hmm_params):
+        self.params = morphology_hmm_params
+
+    def initialize_prob_values(self, n):
+        pi = [{} for _ in range(n + 1)]
+        pi[0]["START"] = 0
+        pi[0]["prefix"] = self.params.SMALL_CONST
+        pi[0]["stem"] = self.params.SMALL_CONST
+        pi[0]["suffix"] = self.params.SMALL_CONST
+        pi[0]["END"] = self.params.SMALL_CONST
+        for i in range(1, n + 1):
+            for affix in self.params.affix_trans_probs.keys():
+                pi[i][affix] = (i + 1) * self.params.SMALL_CONST
+        return pi
+
+    def segment_viterbi(self, word):
+        """
+        This is a dynamic programming algorithm for segmenting a word by using a
+        modified version of the Viterbi algorithm. The main difference here is that
+        the segment-Viterbi algorithm is based on segment-HMM where a state can
+        emit more than one output. In our case, a state is an affix such as prefix,
+        and an output is a substring of a word. Because of searching for a substring
+        the segment-Viterbi algorithm has a slower run-time. In this case (bigram HMM),
+        the runtime complexity of a vanilla Viterbi algorithm is O(nT^2) where n
+        is the number of characters in word and T is the number of possible affixes
+        (in our case 3). The segment-Viterbi has a complexity O(n^2 T^2).
+        A pseudo-code for the vanilla Viterbi algorithm:
+        http://www.cs.columbia.edu/~mcollins/hmms-spring2013.pdf#page=18
+        """
+        n = len(word)
+        pi = self.initialize_prob_values(n)
+        back_pointer = [{} for _ in range(n + 1)]
+
+        for i in range(n):  # loop over starting indices of morphemes
+            for j in range(i + 1, n + 1):  # loop over end indices of morphemes
+                for v in {"prefix", "stem", "suffix"}:  # loop over possible tags
+                    for w in {"START", "prefix", "stem", "suffix"}:
+                        # loop over possible previous tags
+                        t = self.params.transition_log_prob(w, v)
+                        e = self.params.emission_log_probs(v, word[i:j])
+                        log_prob = pi[i][w] + t + e
+                        if log_prob > pi[j][v]:
+                            pi[j][v] = log_prob
+                            # Saving backpointer for previous tag and index.
+                            back_pointer[j][v] = w, i
+
+        # finalizing the best segmentation.
+        best_score = n * self.params.SMALL_CONST
+        best_bp = None
+        indices = [n]  # backtracking indices for segmentation.
+        labels = []  # backtracking labels for segmentation.
+        for v in {"prefix", "stem", "suffix"}:
+            t = self.params.transition_log_prob(v, "END")
+            log_prob = pi[n][v] + t
+            if log_prob > best_score:
+                best_score = log_prob
+                best_bp = back_pointer[n][v][1], v, back_pointer[n][v][0]
+
+        indices.append(best_bp[0])
+        labels.append(best_bp[1])
+        if best_bp[0] > 0:
+            # In cases where the last index is zero, we don't want to backtrack
+            # anymore.
+            labels.append(best_bp[2])
+
+        while True:
+            last_index = indices[-1]
+            last_label = labels[-1]
+            if last_index == 0:
+                break
+            w, i = back_pointer[last_index][last_label]
+            indices.append(i)
+            if i == 0:
+                break
+            labels.append(w)
+
+        # We should now reverse the backtracked list.
+        indices.reverse()
+        labels.reverse()
+        return labels, indices


### PR DESCRIPTION
Summary: This diff tries to segment words based on morphology HMM. For example, given "preorder", output "pre order".

Differential Revision: D13774217
