### PR TITLE
option to save translations as binary data

### DIFF
--- a/pytorch_translate/data.py
+++ b/pytorch_translate/data.py
@@ -188,6 +188,27 @@ class InMemoryNumpyDataset(data.indexed_dataset.IndexedDataset):
         del offsets
         del sizes
 
+    def load_from_sequences(self, sequences):
+        """
+        Load data set from a list of sequences, each a list or numpy array of
+        indices. Note that this method removes all sentences which have been
+        previously added to the data set.
+        """
+        array_list = []
+        offsets = [0]
+        sizes = []
+        for inds in sequences:
+            array_list.append(np.array(inds, dtype=np.int32))
+            offsets.append(offsets[-1] + len(inds))
+            sizes.append(len(inds))
+
+        self.buffer = np.concatenate(array_list)
+        self.offsets = np.array(offsets, dtype=np.int32)
+        self.sizes = np.array(sizes, dtype=np.int32)
+        del array_list
+        del offsets
+        del sizes
+
     @staticmethod
     def create_from_file(path, num_examples_limit: Optional[int] = None):
         result = InMemoryNumpyDataset()

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -637,6 +637,15 @@ def expand_generation_args(group, train=False):
             "sentences."
         ),
     )
+    group.add_argument(
+        "--output-hypos-binary-path",
+        default=None,
+        type=str,
+        help=(
+            "Optional filename to save output hypotheses (binary format "
+            "and EOS-terminated, suitable for use as training targets)"
+        ),
+    )
 
     # These arguments are only used during training
     if train:


### PR DESCRIPTION
Summary: For the Seq-KD knowledge distillation approach from Kim and Rush 2016 (https://arxiv.org/abs/1606.07947) we want to be able to train on the best outputs of an existing system. This diff adds the ability to save predicted translations directly as a binary data set suitable for training.

Differential Revision: D13909023
