### PR TITLE
Make padding right by default for pytorch_translate

### DIFF
--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -604,7 +604,7 @@ class RNNModel(FairseqModel):
         """Build a new model instance."""
         base_architecture(args)
         # set default value for old checkpoints
-        args.left_pad_source = getattr(args, "left_pad_source", True)
+        args.left_pad_source = getattr(args, "left_pad_source", False)
         if pytorch_translate_data.is_multilingual(args):
             return RNNModel.build_model_multilingual(args, task)
         src_dict, dst_dict = task.source_dictionary, task.target_dictionary

--- a/pytorch_translate/tasks/pytorch_translate_task.py
+++ b/pytorch_translate/tasks/pytorch_translate_task.py
@@ -33,10 +33,10 @@ class PytorchTranslateTask(FairseqTask):
         )
         parser.add_argument(
             "--left-pad-source",
-            default="True",
-            type=str,
+            default=False,
+            type=bool,
             metavar="BOOL",
-            help="pad the source on the left (default: True)",
+            help="pad the source on the left (default: False)",
         )
         parser.add_argument(
             "--max-source-positions",
@@ -61,7 +61,7 @@ class PytorchTranslateTask(FairseqTask):
 
     def build_model(self, args):
         # set defaults for old model checkpoints
-        args.left_pad_source = getattr(args, "left_pad_source", True)
+        args.left_pad_source = getattr(args, "left_pad_source", False)
         return super().build_model(args)
 
     @classmethod
@@ -151,6 +151,7 @@ class PytorchTranslateTask(FairseqTask):
                 tgt_sizes=dst_dataset.sizes,
                 tgt_dict=self.target_dictionary,
                 weights=weights_dataset,
+                left_pad_source=False,
             )
 
         if self.args.log_verbose:
@@ -212,6 +213,7 @@ class PytorchTranslateTask(FairseqTask):
                 dst_dataset,
                 dst_dataset.sizes,
                 self.target_dictionary,
+                left_pad_source=False,
             )
 
         print(f"| {split} {len(self.datasets[split])} examples")

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -88,7 +88,7 @@ class ModelParamsDict:
         self.vocab_reduction_params = None
         self.distributed_world_size = 1
         self.seed = 1
-        self.left_pad_source = "True"
+        self.left_pad_source = "False"
         self.fp16 = False
         self.cpu = None
         # Modified params

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -246,7 +246,7 @@ class TransformerEncoder(FairseqEncoder):
     """Transformer encoder."""
 
     def __init__(
-        self, args, dictionary, embed_tokens, left_pad=True, proj_to_decoder=True
+        self, args, dictionary, embed_tokens, left_pad=False, proj_to_decoder=True
     ):
         super().__init__(dictionary)
         self.transformer_embedding = TransformerEmbedding(


### PR DESCRIPTION
Summary:
In pytorch_translate codebase, we work with right padding by default. However, in fairseq the default had been set to left, causing issues in our generate function.

Currently, batching diverse length sentences creates padding, which causes BLEU score to be computed wrong for generation code. This diff fixes the issue.

However, we have other causes of variance in BLEU estimations yet, so will add unit tests later after fixing those.

Differential Revision: D13890623
