### PR TITLE
Build embeddings outside of encoder / decoder in RNN

### DIFF
--- a/pytorch_translate/dual_learning/dual_learning_models.py
+++ b/pytorch_translate/dual_learning/dual_learning_models.py
@@ -9,6 +9,7 @@ from pytorch_translate.rnn import (
     LSTMSequenceEncoder,
     RNNDecoder,
     RNNEncoder,
+    RNNModel,
     base_architecture,
 )
 from pytorch_translate.tasks.pytorch_translate_task import PytorchTranslateTask
@@ -109,10 +110,13 @@ class RNNDualLearningModel(DualLearningModel):
             encoder_class = RNNEncoder
         decoder_class = RNNDecoder
 
+        encoder_embed_tokens, decoder_embed_tokens = RNNModel.build_embed_tokens(
+            args, task.primal_src_dict, task.primal_tgt_dict
+        )
         primal_encoder = encoder_class(
             task.primal_src_dict,
             embed_dim=args.encoder_embed_dim,
-            freeze_embed=args.encoder_freeze_embed,
+            embed_tokens=encoder_embed_tokens,
             cell_type=args.cell_type,
             num_layers=args.encoder_layers,
             hidden_dim=args.encoder_hidden_dim,
@@ -124,6 +128,7 @@ class RNNDualLearningModel(DualLearningModel):
         primal_decoder = decoder_class(
             src_dict=task.primal_src_dict,
             dst_dict=task.primal_tgt_dict,
+            embed_tokens=decoder_embed_tokens,
             vocab_reduction_params=args.vocab_reduction_params,
             encoder_hidden_dim=args.encoder_hidden_dim,
             embed_dim=args.decoder_embed_dim,
@@ -143,10 +148,13 @@ class RNNDualLearningModel(DualLearningModel):
         )
         primal_model = rnn.RNNModel(primal_task, primal_encoder, primal_decoder)
 
+        encoder_embed_tokens, decoder_embed_tokens = RNNModel.build_embed_tokens(
+            args, task.dual_src_dict, task.dual_tgt_dict
+        )
         dual_encoder = encoder_class(
             task.dual_src_dict,
             embed_dim=args.encoder_embed_dim,
-            freeze_embed=args.encoder_freeze_embed,
+            embed_tokens=encoder_embed_tokens,
             cell_type=args.cell_type,
             num_layers=args.encoder_layers,
             hidden_dim=args.encoder_hidden_dim,
@@ -158,10 +166,10 @@ class RNNDualLearningModel(DualLearningModel):
         dual_decoder = decoder_class(
             src_dict=task.dual_src_dict,
             dst_dict=task.dual_tgt_dict,
+            embed_tokens=decoder_embed_tokens,
             vocab_reduction_params=args.vocab_reduction_params,
             encoder_hidden_dim=args.encoder_hidden_dim,
             embed_dim=args.decoder_embed_dim,
-            freeze_embed=args.decoder_freeze_embed,
             out_embed_dim=args.decoder_out_embed_dim,
             cell_type=args.cell_type,
             num_layers=args.decoder_layers,

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -31,6 +31,7 @@ from pytorch_translate.common_layers import (
 from pytorch_translate.multi_model import MultiDecoder, MultiEncoder
 from pytorch_translate.multilingual import MultilingualDecoder, MultilingualEncoder
 from pytorch_translate.ngram import NGramDecoder
+from pytorch_translate.semi_supervised import SemiSupervisedModel
 from pytorch_translate.utils import maybe_cat, maybe_cuda, torch_find
 from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_packed_sequence
 
@@ -1382,6 +1383,16 @@ class BiLSTM(nn.Module):
         return (unpacked_output, final_hiddens, final_cells)
 
 
+@register_model("semi_supervised_rnn")
+class SemisupervisedRNNModel(SemiSupervisedModel):
+    single_model_cls = RNNModel
+
+    @staticmethod
+    def add_args(parser):
+        RNNModel.add_args(parser)
+        SemiSupervisedModel.add_args(parser)
+
+
 @register_model_architecture("rnn", "rnn")
 def base_architecture(args):
     # default architecture
@@ -1448,3 +1459,9 @@ def rnn_big_test(args):
     args.decoder_layers = 6
     args.decoder_hidden_dim = 1024
     args.decoder_out_embed_dim = 1024
+
+
+@register_model_architecture("semi_supervised_rnn", "semi_supervised_rnn")
+def semi_supervised_rnn(args):
+    base_architecture(args)
+    SemiSupervisedModel.set_semi_supervised_arch_args(args)

--- a/pytorch_translate/test/test_integration.py
+++ b/pytorch_translate/test/test_integration.py
@@ -472,7 +472,7 @@ class TestTranslation(unittest.TestCase):
                     ],
                 )
 
-    def test_semisupervised(self):
+    def test_semi_supervised_rnn(self):
         """
         Tests semi_supervised task. Important flags: `--train-mono-*-text-file`,
         `--task`, and `--arch`.
@@ -490,7 +490,7 @@ class TestTranslation(unittest.TestCase):
                         "--train-mono-target-text-file",
                         os.path.join(data_dir, "train.out"),
                         "--arch",
-                        "semi_supervised",
+                        "semi_supervised_rnn",
                         "--cell-type",
                         "lstm",
                         "--sequence-lstm",
@@ -534,7 +534,7 @@ class TestTranslation(unittest.TestCase):
                         "--train-mono-target-text-file",
                         os.path.join(data_dir, "train.out"),
                         "--arch",
-                        "semi_supervised",
+                        "semi_supervised_rnn",
                         "--denoising-target-mono",
                         "--cell-type",
                         "lstm",

--- a/pytorch_translate/word_prediction/word_prediction_model.py
+++ b/pytorch_translate/word_prediction/word_prediction_model.py
@@ -2,7 +2,7 @@
 
 from fairseq.models import FairseqModel, register_model, register_model_architecture
 from pytorch_translate import rnn
-from pytorch_translate.rnn import LSTMSequenceEncoder, RNNDecoder, RNNEncoder
+from pytorch_translate.rnn import LSTMSequenceEncoder, RNNDecoder, RNNEncoder, RNNModel
 from pytorch_translate.utils import torch_find
 from pytorch_translate.word_prediction import word_predictor
 
@@ -61,6 +61,11 @@ class RNNWordPredictionModel(WordPredictionModel):
         """Build a new model instance."""
         src_dict, dst_dict = task.source_dictionary, task.target_dictionary
         base_architecture_wp(args)
+
+        encoder_embed_tokens, decoder_embed_tokens = RNNModel.build_embed_tokens(
+            args, src_dict, dst_dict
+        )
+
         if args.sequence_lstm:
             encoder_class = LSTMSequenceEncoder
         else:
@@ -69,8 +74,8 @@ class RNNWordPredictionModel(WordPredictionModel):
 
         encoder = encoder_class(
             src_dict,
+            embed_tokens=encoder_embed_tokens,
             embed_dim=args.encoder_embed_dim,
-            freeze_embed=args.encoder_freeze_embed,
             cell_type=args.cell_type,
             num_layers=args.encoder_layers,
             hidden_dim=args.encoder_hidden_dim,
@@ -88,10 +93,10 @@ class RNNWordPredictionModel(WordPredictionModel):
         decoder = decoder_class(
             src_dict=src_dict,
             dst_dict=dst_dict,
+            embed_tokens=decoder_embed_tokens,
             vocab_reduction_params=args.vocab_reduction_params,
             encoder_hidden_dim=args.encoder_hidden_dim,
             embed_dim=args.decoder_embed_dim,
-            freeze_embed=args.decoder_freeze_embed,
             out_embed_dim=args.decoder_out_embed_dim,
             cell_type=args.cell_type,
             num_layers=args.decoder_layers,


### PR DESCRIPTION
Summary: We should build embeddings outside of the encoder / decoder because it's easier to set shared embeddings. This is more consistent with the Transformer implementation / fairseq models, which makes this refactor necessary for the 4th diff in this stack: extending semisupervised support for the transformer model.

Differential Revision: D13952209
