### PR TITLE
Generalize PyTorch Translate semi-supervised model to support any model class

### DIFF
--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -31,6 +31,7 @@ from pytorch_translate.common_layers import (
 from pytorch_translate.multi_model import MultiDecoder, MultiEncoder
 from pytorch_translate.multilingual import MultilingualDecoder, MultilingualEncoder
 from pytorch_translate.ngram import NGramDecoder
+from pytorch_translate.semi_supervised import SemiSupervisedModel
 from pytorch_translate.utils import maybe_cat, maybe_cuda, torch_find
 from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_packed_sequence
 
@@ -1382,6 +1383,16 @@ class BiLSTM(nn.Module):
         return (unpacked_output, final_hiddens, final_cells)
 
 
+@register_model("semi_supervised_rnn")
+class SemisupervisedRNNModel(SemiSupervisedModel):
+    single_model_cls = RNNModel
+
+    @staticmethod
+    def add_args(parser):
+        RNNModel.add_args(parser)
+        SemiSupervisedModel.add_args(parser)
+
+
 @register_model_architecture("rnn", "rnn")
 def base_architecture(args):
     # default architecture
@@ -1448,3 +1459,9 @@ def rnn_big_test(args):
     args.decoder_layers = 6
     args.decoder_hidden_dim = 1024
     args.decoder_out_embed_dim = 1024
+
+
+@register_model_architecture("semi_supervised_rnn", "semi_supervised_rnn")
+def semi_supervised_rnn(args):
+    base_architecture(args)
+    SemiSupervisedModel.set_semi_supervised_arch_args(args)

--- a/pytorch_translate/test/test_integration.py
+++ b/pytorch_translate/test/test_integration.py
@@ -472,7 +472,7 @@ class TestTranslation(unittest.TestCase):
                     ],
                 )
 
-    def test_semisupervised(self):
+    def test_semi_supervised_rnn(self):
         """
         Tests semi_supervised task. Important flags: `--train-mono-*-text-file`,
         `--task`, and `--arch`.
@@ -490,7 +490,7 @@ class TestTranslation(unittest.TestCase):
                         "--train-mono-target-text-file",
                         os.path.join(data_dir, "train.out"),
                         "--arch",
-                        "semi_supervised",
+                        "semi_supervised_rnn",
                         "--cell-type",
                         "lstm",
                         "--sequence-lstm",
@@ -534,7 +534,7 @@ class TestTranslation(unittest.TestCase):
                         "--train-mono-target-text-file",
                         os.path.join(data_dir, "train.out"),
                         "--arch",
-                        "semi_supervised",
+                        "semi_supervised_rnn",
                         "--denoising-target-mono",
                         "--cell-type",
                         "lstm",


### PR DESCRIPTION
Summary:
To add semi-supervised support to any model architecture, simply create a new class which specifies single_model_cls as a class variable. Any model-specific args for single_model_cls should be set in that new class's static add_args method.

The single_model_cls must define a constructor, build_encoder, and build_decoder.

Differential Revision: D13952136
