### PR TITLE
Enable Diverse Beam Search

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -118,6 +118,8 @@ def build_sequence_generator(args, task, models):
         word_reward=args.word_reward,
         model_weights=model_weights,
         use_char_source=use_char_source,
+        diverse_beam_groups=args.diverse_beam_groups,
+        diverse_beam_strength=args.diverse_beam_strength,
     )
     if use_cuda:
         translator.cuda()


### PR DESCRIPTION
Summary: Enable diverse beam search (from Fairseq) to produce a set of diverse hypotheses. This is not implemented in stagger structure, will speed up later. Will enable sampling in the next diff (due to padding issue)

Differential Revision: D13940293
