### PR TITLE
return empty tensor instead of None

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -256,22 +256,12 @@ class EncoderEnsemble(nn.Module):
             # evaluation mode
             model.eval()
 
-            # TODO(jamesreed): transformer encodder returns a None output, and
-            # the fork/join API doesn't handle that well. We should figure out
-            # a way to annotate outputs as Optional and record that in fork/join
-            # traces.
-            if isinstance(model.encoder, TransformerEncoder):
-                futures.append(model.encoder(src_tokens_seq_first, src_lengths))
-            else:
-                futures.append(
-                    torch.jit._fork(model.encoder, src_tokens_seq_first, src_lengths)
-                )
+            futures.append(
+                torch.jit._fork(model.encoder, src_tokens_seq_first, src_lengths)
+            )
 
         for i, (model, future) in enumerate(zip(self.models, futures)):
-            if isinstance(model.encoder, TransformerEncoder):
-                encoder_out = future
-            else:
-                encoder_out = torch.jit._wait(future)
+            encoder_out = torch.jit._wait(future)
             # "primary" encoder output (vector representations per source token)
             encoder_outputs = encoder_out[0]
             outputs.append(encoder_outputs)

--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -267,9 +267,6 @@ class EncoderEnsemble(nn.Module):
                     torch.jit._fork(model.encoder, src_tokens_seq_first, src_lengths)
                 )
 
-            # evaluation mode
-            model.eval()
-
         for i, (model, future) in enumerate(zip(self.models, futures)):
             if isinstance(model.encoder, TransformerEncoder):
                 encoder_out = future
@@ -1360,9 +1357,6 @@ class CharSourceEncoderEnsemble(nn.Module):
             encoder_out = model.encoder(
                 src_tokens_seq_first, src_lengths, char_inds, word_lengths
             )
-
-            # evaluation mode
-            model.eval()
 
             # "primary" encoder output (vector representations per source token)
             encoder_outputs = encoder_out[0]

--- a/pytorch_translate/hybrid_transformer_rnn.py
+++ b/pytorch_translate/hybrid_transformer_rnn.py
@@ -247,6 +247,9 @@ class HybridRNNDecoder(FairseqIncrementalDecoder):
     ):
         (encoder_x, src_tokens, encoder_padding_mask) = encoder_out
 
+        if encoder_padding_mask is not None and encoder_padding_mask.numel() == 0:
+            encoder_padding_mask = None
+
         bsz, seqlen = prev_output_tokens.size()
         if incremental_state is not None:
             prev_output_tokens = prev_output_tokens[:, -1:]


### PR DESCRIPTION
Summary:
To allow efficient use of fork/join annotation, we return an empty tensor instead of `None` for `encoder_padding_mask` from transformer encoder in the unmasked/inference case.

Note that this slight hack is preferable to more far-reaching changes in, e.g., Fairseq multihead_attention.

Differential Revision: D13969691
