### PR TITLE
Fix base architecture for transformer

### DIFF
--- a/pytorch_translate/hybrid_transformer_rnn.py
+++ b/pytorch_translate/hybrid_transformer_rnn.py
@@ -403,8 +403,8 @@ def base_architecture(args):
     args.encoder_layers = getattr(args, "encoder_layers", 6)
     args.encoder_attention_heads = getattr(args, "encoder_attention_heads", 8)
     args.encoder_freeze_embed = getattr(args, "encoder_freeze_embed", False)
-    args.encoder_learned_pos = getattr(args, "encoder_normalize_before", False)
-    args.encoder_normalize_before = getattr(args, "encoder_learned_pos", False)
+    args.encoder_learned_pos = getattr(args, "encoder_learned_pos", False)
+    args.encoder_normalize_before = getattr(args, "encoder_normalize_before", False)
     args.decoder_pretrained_embed = getattr(args, "decoder_pretrained_embed", None)
     args.decoder_embed_dim = getattr(args, "decoder_embed_dim", args.encoder_embed_dim)
     args.decoder_ffn_embed_dim = getattr(

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -549,8 +549,8 @@ def base_architecture(args):
     args.encoder_layers = getattr(args, "encoder_layers", 3)
     args.encoder_attention_heads = getattr(args, "encoder_attention_heads", 4)
     args.encoder_freeze_embed = getattr(args, "encoder_freeze_embed", False)
-    args.encoder_learned_pos = getattr(args, "encoder_normalize_before", False)
-    args.encoder_normalize_before = getattr(args, "encoder_learned_pos", False)
+    args.encoder_learned_pos = getattr(args, "encoder_learned_pos", False)
+    args.encoder_normalize_before = getattr(args, "encoder_normalize_before", False)
     args.decoder_pretrained_embed = getattr(args, "decoder_pretrained_embed", None)
     args.decoder_embed_dim = getattr(args, "decoder_embed_dim", args.encoder_embed_dim)
     args.decoder_ffn_embed_dim = getattr(
@@ -559,8 +559,8 @@ def base_architecture(args):
     args.decoder_layers = getattr(args, "decoder_layers", 3)
     args.decoder_attention_heads = getattr(args, "decoder_attention_heads", 4)
     args.decoder_freeze_embed = getattr(args, "decoder_freeze_embed", False)
-    args.decoder_learned_pos = getattr(args, "decoder_normalize_before", False)
-    args.decoder_normalize_before = getattr(args, "decoder_learned_pos", False)
+    args.decoder_learned_pos = getattr(args, "decoder_learned_pos", False)
+    args.decoder_normalize_before = getattr(args, "decoder_normalize_before", False)
     args.share_decoder_input_output_embed = getattr(
         args, "share_decoder_input_output_embed", False
     )


### PR DESCRIPTION
Summary: There was a typo which affects experimentation when we want to set `encoder_normalize_before`, `encoder_learned_pos`, `decoder_normalize_before`, `decoder_learned_pos` to `True`. This didn't come up so far because we never changed those defaults. Without this diff, if we set `encoder_normalize_before=True`, we end up using learned positional embeddings which do not support ONNX because https://github.com/pytorch/fairseq/blob/master/fairseq/modules/learned_positional_embedding.py#L30 doesn't specify the ONNX related argument. Will send a separate change for that.

Differential Revision: D13982186
