### PR TITLE
Random morphology initialization with random sampling from a normal distribution

### DIFF
--- a/pytorch_translate/research/test/test_unsupervised_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_morphology.py
@@ -318,19 +318,16 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             assert t[("suffix", "stem")] == 0
             assert t[("suffix", "suffix")] == 0
 
-        def test_forward_backward_with_smoothing(self):
-            """
-            Making sure that the algorithm works end-to-end.
-            """
-            with patch("builtins.open") as mock_open:
-                txt_content = ["123 12123"]
-                mock_open.return_value.__enter__ = mock_open
-                mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-                unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                    "no_exist_file.txt", smoothing_const=0.0
-                )
+    def test_forward_backward_with_smoothing(self):
+        """
+        Making sure that the algorithm works end-to-end.
+        """
+        with patch("builtins.open") as mock_open:
+            txt_content = ["123 12123"]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                "no_exist_file.txt", smoothing_const=0.1
+                "no_exist_file.txt", smoothing_const=0.0
             )
             e, t = unsupervised_model.forward_backward("123")
 
@@ -403,10 +400,44 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            # Running with forward-backward.
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
                 "no_exist_file.txt", smoothing_const=0.0
             )
-            unsupervised_model.expectation_maximization(100, 10)
+            unsupervised_model.expectation_maximization(10, 10)
+
+            # Running with Viterbi-EM.
+            unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
+                "no_exist_file.txt", smoothing_const=0.0, use_hardEM=True
+            )
+            unsupervised_model.expectation_maximization(10, 10)
+
+    def test_get_expectations_from_viterbi(self):
+        with patch("builtins.open") as mock_open:
+            txt_content = [
+                "123 124 234 345",
+                "112 122 123 345",
+                "123456789",
+                "123456 456789",
+            ]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+
+            unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
+                "no_exist_file.txt", smoothing_const=0.0, use_hardEM=True
+            )
+            assert unsupervised_model.segmentor.segment_viterbi("123123789") == (
+                ["prefix", "prefix", "stem"],
+                [0, 3, 6, 9],
+            )
+            e, t = unsupervised_model.get_expectations_from_viterbi("123123789")
+            assert e[("prefix", "123")] == 2
+            assert e[("stem", "789")] == 1
+            assert e[("suffix", "789")] == 0
+            assert t[("START", "prefix")] == 1
+            assert t[("prefix", "prefix")] == 1
+            assert t[("prefix", "stem")] == 1
+            assert t[("stem", "END")] == 1
 
     def test_save_load(self):
         with patch("builtins.open") as mock_open:

--- a/pytorch_translate/research/unsupervised_morphology/morphology_runner.py
+++ b/pytorch_translate/research/unsupervised_morphology/morphology_runner.py
@@ -58,6 +58,34 @@ def get_arg_parser():
     parser.add_option(
         "--save-checkpoint", action="store_true", dest="save_checkpoint", default=False
     )
+    parser.add_option(
+        "--smooth-const",
+        type="float",
+        help="Constant float value for smoothing probabilities.",
+        dest="smooth_const",
+        default=2,
+    )
+    parser.add_option(
+        "--normal-init",
+        action="store_true",
+        help="Initialize parameters with samples from normal distribution.",
+        dest="normal_init",
+        default=False,
+    )
+    parser.add_option(
+        "--normal-mean",
+        type="float",
+        help="Mean for the normal distribution in initialization.",
+        dest="normal_mean",
+        default=2,
+    )
+    parser.add_option(
+        "--normal-stddev",
+        type="float",
+        help="Standard deviation for the normal distribution in initialization.",
+        dest="normal_stddev",
+        default=1,
+    )
     return parser
 
 
@@ -65,7 +93,13 @@ if __name__ == "__main__":
     arg_parser = get_arg_parser()
     options, args = arg_parser.parse_args()
     if options.train_file is not None and options.model_path is not None:
-        model = unsupervised_morphology.UnsupervisedMorphology(options.train_file)
+        model = unsupervised_morphology.UnsupervisedMorphology(
+            input_file=options.train_file,
+            smoothing_const=options.smooth_const,
+            use_normal_init=options.normal_init,
+            normal_mean=options.normal_mean,
+            normal_stddev=options.normal_stddev,
+        )
         print("Number of training words", len(model.params.word_counts))
         model.expectation_maximization(
             options.em_iter,

--- a/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
+++ b/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
@@ -434,8 +434,8 @@ class UnsupervisedMorphology(object):
             normal_stddev: Standard deviation for prefix/suffix length when sampling
                 with the normal distribution.
             use_hardEM: Choosing between soft EM or Viterbi EM (hard EM) algorithm.
+    ):
         """
-        self.params = MorphologyHMMParams(smoothing_const)
         self.use_hardEM = use_hardEM
 
         if use_normal_init:


### PR DESCRIPTION
Summary: We are trying to test if random initialization of morpheme distributions are better for unsupervised morphology. This can also be helpful for cases such as the Viterbi-EM (aka hard EM) algorithm (not implemented yet). Here we initialize a segmentation per word by assuming that a prefix/suffix length follows a normal distribution (default: mean: 2 characters, std_dev: 1 character). For initialization we let a word to have at most two prefixes and two suffixes. We also let a word to have two stems as initialization (we break one stem into two parts evenly).

Differential Revision: D14017270
