### PR TITLE
Temporarily add back ManagedCheckpoints for backward compatibility reasons

### DIFF
--- a/pytorch_translate/checkpoint.py
+++ b/pytorch_translate/checkpoint.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import collections
+import itertools
 import os
 from collections import OrderedDict, deque
 from typing import Any, Deque, Dict, List, Optional, Tuple
@@ -398,3 +400,96 @@ class CheckpointManager:
             f"| Finished saving new best averaged checkpoint to "
             f"{best_averaged_checkpoint_filename}."
         )
+
+
+##############
+# DEPRECATED #
+#####################################################
+# DEPRECATED!!! DO NOT USE!!!
+# TEMPORARILY KEPT ONLY FOR BACKWARD COMPATIBILITY.
+#
+# SERIOUSLY - DON'T USE THIS UNLESS YOU WANT
+# TO DIE IN THE FIRE OF A THOUSAND SUNS.
+#####################################################
+# DEPRECATED #
+##############
+class ManagedCheckpoints:
+
+    # - max_num_checkpoints: Maximum number of checkpoints we need at one point.
+    # - auto_clear: Control whether or not checkpoints should get deleted when
+    #   they are not in the last max_num_checkpoints appended to the
+    #   self anymore.
+    def __init__(self, max_num_checkpoints, auto_clear):
+        self.auto_clear = auto_clear
+        assert max_num_checkpoints > 0, "Empty listing is not supported"
+        self.kept_checkpoints = collections.deque(maxlen=max_num_checkpoints)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ManagedCheckpoints)
+            and self.auto_clear == other.auto_clear
+            and self.kept_checkpoints == other.kept_checkpoints
+        )
+
+    def __repr__(self):
+        return (
+            f"ManagedCheckpoints(kept_checkpoints={self.kept_checkpoints}, "
+            f"auto_clear={self.auto_clear})"
+        )
+
+    def append(self, checkpoint_filename):
+        # If we append a filename that we already manage, we would need
+        # to remove it from its current position otherwise it may get deleted
+        # by the time we reach the use for this append.
+        # E.g., Let us assume we have a max of 2 checkpoint.
+        # We insert last_checkpoint, use it, then insert last_checkpoint,
+        # use it, then insert it again. The first file gets delete, but it
+        # is actually the same as the current one, so we actually delete
+        # the current one. Then we try to use it and we will get an error
+        # for file not found.
+        # Although this is pretty easy to support this case, given we only
+        # append the same file names with no_epoch_checkpoints, we decided
+        # not to slow every other uses case for that.
+        # Instead we rely on the fact that when this happens, we actually
+        # don't automatically delete files (auto_clear == False).
+        assert not self.auto_clear or not self.kept_checkpoints.count(
+            checkpoint_filename
+        ), "Not yet implemented"
+        if (
+            self.auto_clear
+            and len(self.kept_checkpoints) == self.kept_checkpoints.maxlen
+        ):
+            # We reach the max number of checkpoints we keep around.
+            # Delete the oldest one.
+            try:
+                os.remove(self.kept_checkpoints.popleft())
+            except FileNotFoundError:
+                pass
+        # Save the new checkpoint.
+        self.kept_checkpoints.append(checkpoint_filename)
+
+    def get_last_n(self, num_elements):
+        assert 0 < num_elements <= self.kept_checkpoints.maxlen, (
+            f"Requested number of elements {num_elements} "
+            f"must be between 0 and maxlen {self.kept_checkpoints.maxlen}, "
+            f"exclusive"
+        )
+        # If we ask for more elements than what we currently have, return all
+        # of them.
+        # Reason why we don't assert unlike for maxlen is because maxlen points
+        # out a design issue (the reserved size is too small), whereas the case
+        # where we ask more elements than what is currently in the list happens
+        # when we print the average of X checkpoints for BLEU, but we haven't
+        # yet computed that many checkpoints. We could also assert in this case
+        # and fix the caller, but handling it here was just fine!
+        start = max(len(self.kept_checkpoints) - num_elements, 0)
+        return collections.deque(itertools.islice(self.kept_checkpoints, start, None))
+
+
+##############
+# DEPRECATED #
+###############################
+# DEPRECATED!!! DO NOT USE!!! #
+###############################
+# DEPRECATED #
+##############

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -324,8 +324,12 @@ def setup_training_state(args, trainer, task, epoch_itr):
         )
         if loaded_extra_state:
             extra_state.update(loaded_extra_state)
-            # Reset the start time for the current training run.
-            extra_state["start_time"] = time.time()
+
+    # Reset the start time for the current training run.
+    extra_state["start_time"] = time.time()
+    # Removes all uses of the deprecated ManagedCheckpoints
+    if "last_checkpoints" in extra_state:
+        del extra_state["last_checkpoints"]
 
     # Skips printing all training progress to prevent log spam.
     training_progress = extra_state["training_progress"]


### PR DESCRIPTION
Summary: Temporarily add back the ManagedCheckpoints originally removed in D13510446 so Python pickling can still handle loading old checkpoints

Differential Revision: D14014444
