### PR TITLE
adding context perplexity for morphology

### DIFF
--- a/pytorch_translate/research/test/test_morphology_context.py
+++ b/pytorch_translate/research/test/test_morphology_context.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from pytorch_translate.research.unsupervised_morphology import morphology_context
+
+
+class TestMorphologyContext(unittest.TestCase):
+    def test_context_calculations(self):
+        contexts = morphology_context.MorphologyContext()
+        contexts.add_to_left_context("yeah", 3)
+        contexts.add_to_left_context("yeh", 2)
+        contexts.add_to_left_context("yeah", 5)
+        contexts.add_to_left_context("yeh", 3)
+
+        contexts.add_to_right_context("yeah", 4)
+        contexts.add_to_right_context("yeh", 3)
+        contexts.add_to_right_context("yeah", 2)
+        contexts.add_to_right_context("yeh", 1)
+
+        assert contexts.left_context_count("yeah") == 8
+        assert contexts.left_context_count("yeh") == 5
+        assert contexts.right_context_count("yeah") == 6
+        assert contexts.right_context_count("yeh") == 4
+
+        assert contexts.left_context_sum_count() == 13
+        assert contexts.right_context_sum_count() == 10
+
+        assert contexts.left_perplexity() == 1.9469780302238757
+        assert contexts.right_perplexity() == 1.9601317042077895

--- a/pytorch_translate/research/test/test_unsupervised_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_morphology.py
@@ -318,19 +318,16 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             assert t[("suffix", "stem")] == 0
             assert t[("suffix", "suffix")] == 0
 
-        def test_forward_backward_with_smoothing(self):
-            """
-            Making sure that the algorithm works end-to-end.
-            """
-            with patch("builtins.open") as mock_open:
-                txt_content = ["123 12123"]
-                mock_open.return_value.__enter__ = mock_open
-                mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-                unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                    "no_exist_file.txt", smoothing_const=0.0
-                )
+    def test_forward_backward_with_smoothing(self):
+        """
+        Making sure that the algorithm works end-to-end.
+        """
+        with patch("builtins.open") as mock_open:
+            txt_content = ["123 12123"]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                "no_exist_file.txt", smoothing_const=0.1
+                "no_exist_file.txt", smoothing_const=0.0
             )
             e, t = unsupervised_model.forward_backward("123")
 
@@ -403,10 +400,44 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            # Running with forward-backward.
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
                 "no_exist_file.txt", smoothing_const=0.0
             )
-            unsupervised_model.expectation_maximization(100, 10)
+            unsupervised_model.expectation_maximization(10, 10)
+
+            # Running with Viterbi-EM.
+            unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
+                "no_exist_file.txt", smoothing_const=0.0, use_hardEM=True
+            )
+            unsupervised_model.expectation_maximization(10, 10)
+
+    def test_get_expectations_from_viterbi(self):
+        with patch("builtins.open") as mock_open:
+            txt_content = [
+                "123 124 234 345",
+                "112 122 123 345",
+                "123456789",
+                "123456 456789",
+            ]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+
+            unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
+                "no_exist_file.txt", smoothing_const=0.0, use_hardEM=True
+            )
+            assert unsupervised_model.segmentor.segment_viterbi("123123789") == (
+                ["prefix", "prefix", "stem"],
+                [0, 3, 6, 9],
+            )
+            e, t = unsupervised_model.get_expectations_from_viterbi("123123789")
+            assert e[("prefix", "123")] == 2
+            assert e[("stem", "789")] == 1
+            assert e[("suffix", "789")] == 0
+            assert t[("START", "prefix")] == 1
+            assert t[("prefix", "prefix")] == 1
+            assert t[("prefix", "stem")] == 1
+            assert t[("stem", "END")] == 1
 
     def test_save_load(self):
         with patch("builtins.open") as mock_open:

--- a/pytorch_translate/research/unsupervised_morphology/morphology_context.py
+++ b/pytorch_translate/research/unsupervised_morphology/morphology_context.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import math
+from collections import Counter
+
+
+class MorphologyContext:
+    """
+    This class is a data holder for keeping left and right context counts for
+    morphology. This is inspired from the following paper:
+    https://users.ics.aalto.fi/krista/papers/Creutz07.pdf
+    """
+
+    def __init__(self):
+        self.left_context = Counter()
+        self.right_context = Counter()
+
+    def add_to_left_context(self, substr, count):
+        self.left_context[substr] += count
+
+    def add_to_right_context(self, substr, count):
+        self.right_context[substr] += count
+
+    def left_context_count(self, substr):
+        return self.left_context[substr]
+
+    def right_context_count(self, substr):
+        return self.right_context[substr]
+
+    def left_context_sum_count(self):
+        return sum(self.left_context.values())
+
+    def right_context_sum_count(self):
+        return sum(self.right_context.values())
+
+    def perplexity(self, direction: str):
+        contexts = self.left_context if direction == "left" else self.right_context
+        context_count = (
+            self.left_context_sum_count()
+            if direction == "left"
+            else self.right_context_sum_count()
+        )
+        entropy = 0
+        for context in contexts:
+            prob = float(contexts[context]) / context_count
+            entropy -= prob * math.log(prob)
+        return math.exp(entropy)
+
+    def left_perplexity(self):
+        return self.perplexity("left")
+
+    def right_perplexity(self):
+        return self.perplexity("right")

--- a/pytorch_translate/research/unsupervised_morphology/morphology_runner.py
+++ b/pytorch_translate/research/unsupervised_morphology/morphology_runner.py
@@ -58,6 +58,34 @@ def get_arg_parser():
     parser.add_option(
         "--save-checkpoint", action="store_true", dest="save_checkpoint", default=False
     )
+    parser.add_option(
+        "--smooth-const",
+        type="float",
+        help="Constant float value for smoothing probabilities.",
+        dest="smooth_const",
+        default=2,
+    )
+    parser.add_option(
+        "--normal-init",
+        action="store_true",
+        help="Initialize parameters with samples from normal distribution.",
+        dest="normal_init",
+        default=False,
+    )
+    parser.add_option(
+        "--normal-mean",
+        type="float",
+        help="Mean for the normal distribution in initialization.",
+        dest="normal_mean",
+        default=2,
+    )
+    parser.add_option(
+        "--normal-stddev",
+        type="float",
+        help="Standard deviation for the normal distribution in initialization.",
+        dest="normal_stddev",
+        default=1,
+    )
     return parser
 
 
@@ -65,7 +93,13 @@ if __name__ == "__main__":
     arg_parser = get_arg_parser()
     options, args = arg_parser.parse_args()
     if options.train_file is not None and options.model_path is not None:
-        model = unsupervised_morphology.UnsupervisedMorphology(options.train_file)
+        model = unsupervised_morphology.UnsupervisedMorphology(
+            input_file=options.train_file,
+            smoothing_const=options.smooth_const,
+            use_normal_init=options.normal_init,
+            normal_mean=options.normal_mean,
+            normal_stddev=options.normal_stddev,
+        )
         print("Number of training words", len(model.params.word_counts))
         model.expectation_maximization(
             options.em_iter,

--- a/pytorch_translate/research/unsupervised_morphology/morphology_runner.py
+++ b/pytorch_translate/research/unsupervised_morphology/morphology_runner.py
@@ -80,11 +80,49 @@ def get_arg_parser():
         default=2,
     )
     parser.add_option(
+        "--hard-em", action="store_true", dest="use_hardEM", default=False
+    )
+    parser.add_option(
         "--normal-stddev",
         type="float",
         help="Standard deviation for the normal distribution in initialization.",
         dest="normal_stddev",
         default=1,
+    )
+    parser.add_option(
+        "--no-morph-likeness",
+        action="store_false",
+        help="Turn off morph likeness based on perplexity.",
+        dest="use_morph_likeness",
+        default=True,
+    )
+    parser.add_option(
+        "--perplexity-threshold",
+        type="float",
+        help="Perplexity threshold in affix likeness equation.",
+        dest="perplexity_threshold",
+        default=10,
+    )
+    parser.add_option(
+        "--length-threshold",
+        type="float",
+        help="Length threshold in stem likeness equation.",
+        dest="length_threshold",
+        default=3,
+    )
+    parser.add_option(
+        "--perplexity-slope",
+        type="float",
+        help="Perplexity slope in affix likeness equation.",
+        dest="perplexity_slope",
+        default=1,
+    )
+    parser.add_option(
+        "--length-slope",
+        type="float",
+        help="Length slope in stem likeness equation.",
+        dest="length_slope",
+        default=2,
     )
     return parser
 
@@ -99,6 +137,12 @@ if __name__ == "__main__":
             use_normal_init=options.normal_init,
             normal_mean=options.normal_mean,
             normal_stddev=options.normal_stddev,
+            use_hardEM=options.use_hardEM,
+            use_morph_likeness=options.use_morph_likeness,
+            perplexity_threshold=options.perplexity_threshold,
+            perplexity_slope=options.perplexity_slope,
+            length_threshold=options.length_threshold,
+            length_slope=options.length_slope,
         )
         print("Number of training words", len(model.params.word_counts))
         model.expectation_maximization(

--- a/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
+++ b/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
@@ -122,8 +122,9 @@ class MorphologyHMMParams(object):
         constraint is to have a stem with at least length of two.
         """
         wlen = len(word)
-        while True:
-            # if a word is short, the real mean value show decrease. For example,
+        # At most try 5 times to sample segmentations. Otherwise
+        for _ in range(5):
+            # If a word is short, the real mean value show decrease. For example,
             # if wlen=3, real_min is 1.
             real_mean = min(affix_len_mean, wlen - 2)
 
@@ -159,6 +160,9 @@ class MorphologyHMMParams(object):
                 # Generate one stem.
                 stem_lens = [stem_len]
             else:
+                # Just in case the model was not able to sample any segmentation.
+                morphemes = [word]
+                tags = ["START", "stem", "END"]
                 continue
 
             tags = (
@@ -414,11 +418,12 @@ class MorphologySegmentor(object):
 class UnsupervisedMorphology(object):
     def __init__(
         self,
-        input_file: str,
-        smoothing_const: float = 0.1,
-        use_normal_init: bool = False,
-        normal_mean: float = 2.0,
-        normal_stddev: float = 1.0,
+        input_file,
+        smoothing_const=0.1,
+        use_normal_init=False,
+        normal_mean=2.0,
+        normal_stddev=1.0,
+        use_hardEM=False,
     ):
         """
         Args:
@@ -428,14 +433,19 @@ class UnsupervisedMorphology(object):
                 the normal distribution.
             normal_stddev: Standard deviation for prefix/suffix length when sampling
                 with the normal distribution.
+            use_hardEM: Choosing between soft EM or Viterbi EM (hard EM) algorithm.
         """
         self.params = MorphologyHMMParams(smoothing_const)
+        self.use_hardEM = use_hardEM
+
         if use_normal_init:
             self.params.init_params_with_normal_distribution(
                 input_file, normal_mean, normal_stddev
             )
         else:
             self.params.init_uniform_params_from_data(input_file)
+
+        self.segmentor = MorphologySegmentor(self.params) if self.use_hardEM else None
 
     @staticmethod
     def init_forward_values(n):
@@ -566,6 +576,29 @@ class UnsupervisedMorphology(object):
     def group_to(max_size, iterable):
         return list(zip_longest(*[iter(iterable)] * max_size, fillvalue=None))
 
+    def get_expectations_from_viterbi(self, word):
+        """
+        This method segments a word with the Viterbi algorithm, and assumes that
+        the output of the Viterbi algorithm has an expected count of one, and others
+        will have an expected count of zero. This is in contrast with the
+        forward-backward algorithm where every possible segmentation is taken into
+        account.
+        """
+        emission_expectations = defaultdict(float)
+        transition_expectations = defaultdict(float)
+
+        labels, indices = self.segmentor.segment_viterbi(word)
+
+        transition_expectations[("START", labels[0])] += 1
+        for i in range(len(labels)):
+            substr = word[indices[i] : indices[i + 1]]
+            emission_expectations[(labels[i], substr)] += 1
+            if i > 0:
+                transition_expectations[(labels[i - 1], labels[i])] += 1
+        transition_expectations[(labels[-1], "END")] += 1
+
+        return emission_expectations, transition_expectations
+
     def expectation_substep(self, words):
         """
         This method is subprocess for the expectation method.
@@ -576,7 +609,12 @@ class UnsupervisedMorphology(object):
             if wf is None:
                 continue
             (word, freq) = wf
-            e, t = self.forward_backward(word)
+
+            if self.use_hardEM:
+                e, t = self.get_expectations_from_viterbi(word)
+            else:
+                e, t = self.forward_backward(word)
+
             for e_key in e.keys():
                 emission_expectations[e_key] += e[e_key] * freq
             for t_key in t.keys():
@@ -651,7 +689,9 @@ class UnsupervisedMorphology(object):
             num_morphs = len(self.params.morph_emit_probs[morpheme_class])
             d = emission_denoms[morpheme_class]
             for morpheme in self.params.morph_emit_probs[morpheme_class].keys():
-                e = emission_expectations[morpheme_class][morpheme]
+                e = 0
+                if morpheme in emission_expectations[morpheme_class]:
+                    e = emission_expectations[morpheme_class][morpheme]
                 if d > 0 or smoothing_const > 0:
                     self.params.morph_emit_probs[morpheme_class][morpheme] = (
                         e + smoothing_const
@@ -667,8 +707,11 @@ class UnsupervisedMorphology(object):
             for m2 in self.params.affix_trans_probs[m1].keys():
                 if m2 in transition_expectations[m1]:
                     if transition_denoms[m1] > 0:
+                        t = 0
+                        if m2 in transition_expectations[m1]:
+                            t = transition_expectations[m1][m2]
                         self.params.affix_trans_probs[m1][m2] = (
-                            transition_expectations[m1][m2] / transition_denoms[m1]
+                            t / transition_denoms[m1]
                         )
                     else:  # for cases of underflow.
                         self.params.affix_trans_probs[m1][m2] = 1.0 / len(
@@ -693,10 +736,16 @@ class UnsupervisedMorphology(object):
         train_words_chunks = UnsupervisedMorphology.group_to(chunk_size, train_words)
         for epoch in range(num_iters):
             print("starting epoch %i" % epoch)
-            print("starting expectation step")
-            ee, ed, te, td = self.expectation(pool, train_words_chunks)
-            print("starting maximization step")
-            self.maximization(ee, ed, te, td)
-            print("updated parameters after maximization")
-            if model_path is not None:
-                self.save(model_path)
+            self.em_step(pool, train_words_chunks, model_path)
+
+    def em_step(self, pool, train_words_chunks, model_path):
+        """
+        One EM step of the EM algorithm.
+        """
+        print("starting expectation step")
+        ee, ed, te, td = self.expectation(pool, train_words_chunks)
+        print("starting maximization step")
+        self.maximization(ee, ed, te, td)
+        print("updated parameters after maximization")
+        if model_path is not None:
+            self.save(model_path)


### PR DESCRIPTION
Summary: Following the idea behind using perplexity of context around affixes in the Morfessor paper, we add this as an option to out model. For more info, go to pages 14-16 of its paper:  https://users.ics.aalto.fi/krista/papers/Creutz07.pdf or read inline comments.

Differential Revision: D14066583
