### PR TITLE
Refactor redundant generate caller

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -154,12 +154,8 @@ class SequenceGenerator(object):
                 ref = utils.strip_pad(s["target"][i, :], self.pad)
                 yield id, src, ref, hypos[i]
 
+    @torch.no_grad()
     def generate(self, encoder_input, beam_size=None, maxlen=None, prefix_tokens=None):
-        """Generate a batch of translations."""
-        with torch.no_grad():
-            return self._generate(encoder_input, beam_size, maxlen, prefix_tokens)
-
-    def _generate(self, encoder_input, beam_size=None, maxlen=None, prefix_tokens=None):
 
         src_tokens = encoder_input["src_tokens"]
 


### PR DESCRIPTION
Summary: Seems, the whole purpose of ```generate``` function is wrapping _generate with torch.no_grad(). Decorator is better for this kind of purpose and this is already supported in Pytorch.

Differential Revision: D14210235
