### PR TITLE
Unsupervised morphology without morpheme tags and with length penalty cost in emission probability

### DIFF
--- a/pytorch_translate/research/test/test_unsupervised_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_morphology.py
@@ -30,41 +30,12 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
 
-            assert len(morph_hmm_model.morph_emit_probs["prefix"]) == 28
-            assert "9" not in morph_hmm_model.morph_emit_probs["prefix"]
-            assert len(morph_hmm_model.morph_emit_probs["stem"]) == 42
-            assert "689" not in morph_hmm_model.morph_emit_probs["stem"]
-            assert len(morph_hmm_model.morph_emit_probs["suffix"]) == 29
-            assert "1" not in morph_hmm_model.morph_emit_probs["suffix"]
-            assert morph_hmm_model.morph_emit_probs["stem"]["1234"] == 1.1 / (42 * 1.1)
-
-            assert morph_hmm_model.affix_trans_probs["START"]["START"] == 0
-            assert morph_hmm_model.affix_trans_probs["START"]["prefix"] == 0.5
-            assert morph_hmm_model.affix_trans_probs["START"]["stem"] == 0.5
-            assert morph_hmm_model.affix_trans_probs["START"]["suffix"] == 0
-            assert morph_hmm_model.affix_trans_probs["START"]["END"] == 0
-            assert morph_hmm_model.affix_trans_probs["prefix"]["START"] == 0
-            assert morph_hmm_model.affix_trans_probs["prefix"]["prefix"] == 0.5
-            assert morph_hmm_model.affix_trans_probs["prefix"]["stem"] == 0.5
-            assert morph_hmm_model.affix_trans_probs["prefix"]["suffix"] == 0
-            assert morph_hmm_model.affix_trans_probs["prefix"]["END"] == 0
-            assert morph_hmm_model.affix_trans_probs["stem"]["START"] == 0
-            assert morph_hmm_model.affix_trans_probs["stem"]["prefix"] == 0
-            assert morph_hmm_model.affix_trans_probs["stem"]["stem"] == 1.0 / 3
-            assert morph_hmm_model.affix_trans_probs["stem"]["suffix"] == 1.0 / 3
-            assert morph_hmm_model.affix_trans_probs["stem"]["END"] == 1.0 / 3
-            assert morph_hmm_model.affix_trans_probs["suffix"]["START"] == 0
-            assert morph_hmm_model.affix_trans_probs["suffix"]["prefix"] == 0
-            assert morph_hmm_model.affix_trans_probs["suffix"]["stem"] == 0
-            assert morph_hmm_model.affix_trans_probs["suffix"]["suffix"] == 0.5
-            assert morph_hmm_model.affix_trans_probs["suffix"]["END"] == 0.5
-            assert morph_hmm_model.affix_trans_probs["END"]["START"] == 0
-            assert morph_hmm_model.affix_trans_probs["END"]["prefix"] == 0
-            assert morph_hmm_model.affix_trans_probs["END"]["stem"] == 0
-            assert morph_hmm_model.affix_trans_probs["END"]["suffix"] == 0
-            assert morph_hmm_model.affix_trans_probs["END"]["END"] == 0
+            assert len(morph_hmm_model.morph_emit_probs) == 51
+            assert round(morph_hmm_model.morph_emit_probs["1234"], 3) == round(
+                0.014141414141414142, 3
+            )
 
     def test_zero_out_params(self):
         morph_hmm_model = unsupervised_morphology.MorphologyHMMParams()
@@ -77,141 +48,15 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
-            for tag in morph_hmm_model.morph_emit_probs.keys():
-                for morph in morph_hmm_model.morph_emit_probs[tag].keys():
-                    assert morph_hmm_model.morph_emit_probs[tag][morph] > 0
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
+            for morph in morph_hmm_model.morph_emit_probs.keys():
+                assert morph_hmm_model.morph_emit_probs[morph] > 0
 
             morph_hmm_model.zero_out_parmas()
-            for tag in morph_hmm_model.morph_emit_probs.keys():
-                for morph in morph_hmm_model.morph_emit_probs[tag].keys():
-                    assert morph_hmm_model.morph_emit_probs[tag][morph] == 0
-
-            for prev_tag in morph_hmm_model.affix_trans_probs.keys():
-                for tag in morph_hmm_model.affix_trans_probs[prev_tag].keys():
-                    assert morph_hmm_model.affix_trans_probs[prev_tag][tag] == 0
-
-    def test_morph_normal_init(self):
-        """
-        Check if normal initilization does not break.
-        """
-        stems = ["jump", "say", "work", "play"]
-        prefixes = ["re"]
-        suffixes = ["ing", "s", "ed"]
-
-        txt_content = []
-        for _ in range(1000):
-            p, stem, s = "", "", ""
-            if random.randint(1, 5) > 2:
-                p_i = random.randint(0, len(prefixes) - 1)
-                p = prefixes[p_i]
-            if random.randint(1, 5) > 2:
-                s_i = random.randint(0, len(suffixes) - 1)
-                s = suffixes[s_i]
-            stem_i = random.randint(0, len(stems) - 1)
-            stem = stems[stem_i]
-            txt_content.append(p + stem + s)
-
-        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
-            use_morph_likeness=False
-        )
-        with patch("builtins.open") as mock_open:
-            mock_open.return_value.__enter__ = mock_open
-            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_params_with_normal_distribution("no_exist_file.txt")
-
-        assert morph_hmm_model.affix_trans_probs["END"]["START"] == 0
-        assert morph_hmm_model.affix_trans_probs["END"]["prefix"] == 0
-        assert morph_hmm_model.affix_trans_probs["END"]["stem"] == 0
-        assert morph_hmm_model.affix_trans_probs["END"]["suffix"] == 0
-        assert morph_hmm_model.affix_trans_probs["END"]["END"] == 0
-
-        assert morph_hmm_model.affix_trans_probs["START"]["START"] == 0
-        assert morph_hmm_model.affix_trans_probs["START"]["suffix"] == 0
-        assert morph_hmm_model.affix_trans_probs["START"]["END"] == 0
+            for morph in morph_hmm_model.morph_emit_probs.keys():
+                assert morph_hmm_model.morph_emit_probs[morph] == 0
 
     def test_emission_probs(self):
-        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
-            use_morph_likeness=False
-        )
-        with patch("builtins.open") as mock_open:
-            txt_content = [
-                "123 124 234 345",
-                "112 122 123 345",
-                "123456789",
-                "123456 456789",
-            ]
-            mock_open.return_value.__enter__ = mock_open
-            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
-
-            assert morph_hmm_model.emission_prob("stem", "1234") == 1.1 / (42 * 1.1)
-            assert morph_hmm_model.emission_prob("suffix", "1") == 0.1 / (29 * 1.1)
-            assert morph_hmm_model.emission_prob("END", "1") == 0
-
-    def test_emission_log_probs(self):
-        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
-            use_morph_likeness=False
-        )
-        with patch("builtins.open") as mock_open:
-            txt_content = [
-                "123 124 234 345",
-                "112 122 123 345",
-                "123456789",
-                "123456 456789",
-            ]
-            mock_open.return_value.__enter__ = mock_open
-            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
-
-            assert morph_hmm_model.emission_log_probs("stem", "1234") == math.log(
-                1.1 / (42 * 1.1)
-            )
-            assert morph_hmm_model.emission_log_probs("suffix", "1") == math.log(
-                0.1 / (29 * 1.1)
-            )
-            assert (
-                morph_hmm_model.emission_log_probs("END", "1")
-                == morph_hmm_model.SMALL_CONST
-            )
-
-    def test_likeness_probs(self):
-        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
-            use_morph_likeness=True
-        )
-        with patch("builtins.open") as mock_open:
-            txt_content = [
-                "123 124 234 345",
-                "112 122 123 345",
-                "123456789",
-                "123456 456789",
-            ]
-            mock_open.return_value.__enter__ = mock_open
-            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
-
-            float_precision = 3
-            assert round(morph_hmm_model.morph_likeness["prefix"]["23"], 3) == round(
-                0.016515200181119086, float_precision
-            )
-            assert round(morph_hmm_model.morph_likeness["stem"]["23"], 3) == round(
-                0.9824677845172917, float_precision
-            )
-            assert round(morph_hmm_model.morph_likeness["suffix"]["23"], 3) == round(
-                0.0010170153015892497, float_precision
-            )
-
-            assert round(morph_hmm_model.morph_likeness["prefix"]["789"], 3) == round(
-                0.00024574366719647703, float_precision
-            )
-            assert round(morph_hmm_model.morph_likeness["stem"]["789"], 3) == round(
-                0.9957636518152019, float_precision
-            )
-            assert round(morph_hmm_model.morph_likeness["suffix"]["789"], 3) == round(
-                0.003990604517601711, float_precision
-            )
-
-    def test_transition_log_probs(self):
         morph_hmm_model = unsupervised_morphology.MorphologyHMMParams()
         with patch("builtins.open") as mock_open:
             txt_content = [
@@ -222,19 +67,36 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
 
-            assert morph_hmm_model.transition_log_prob("stem", "END") == math.log(
-                1.0 / 3
-            )
-            assert (
-                morph_hmm_model.transition_log_prob("suffix", "START")
-                == morph_hmm_model.SMALL_CONST
+            # todo add more tests
+            e = 0.014141414141414142
+            e_r = e * math.exp(-9)
+            assert round(morph_hmm_model.emission_prob("1234"), 3) == round(e_r, 3)
+
+    def test_emission_log_prob(self):
+        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams()
+        with patch("builtins.open") as mock_open:
+            txt_content = [
+                "123 124 234 345",
+                "112 122 123 345",
+                "123456789",
+                "123456 456789",
+            ]
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
+
+            # todo add more tests
+            e = 0.014141414141414142
+            e_r = e * math.exp(-9)
+            assert round(morph_hmm_model.emission_log_prob("1234"), 3) == round(
+                math.log(e_r), 3
             )
 
     def test_segment_viterbi_no_smoothing(self):
         morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
-            smoothing_const=0.0, use_morph_likeness=False
+            smoothing_const=0.0
         )
         with patch("builtins.open") as mock_open:
             txt_content = [
@@ -245,18 +107,13 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
 
             segmentor = unsupervised_morphology.MorphologySegmentor(morph_hmm_model)
-            assert segmentor.segment_viterbi("123123789") == (
-                ["prefix", "prefix", "stem"],
-                [0, 3, 6, 9],
-            )
+            assert segmentor.segment_viterbi("123123789") == [0, 2, 3, 5, 6, 9]
 
     def test_segment_viterbi_w_smoothing(self):
-        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
-            use_morph_likeness=False
-        )
+        morph_hmm_model = unsupervised_morphology.MorphologyHMMParams()
         with patch("builtins.open") as mock_open:
             txt_content = [
                 "123 124 234 345",
@@ -266,14 +123,14 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
 
             segmentor = unsupervised_morphology.MorphologySegmentor(morph_hmm_model)
-            assert segmentor.segment_viterbi("123123789") == (["stem"], [0, 9])
+            assert segmentor.segment_viterbi("123123789") == [0, 2, 3, 5, 6, 9]
 
     def test_segment_word_no_smoothing(self):
         morph_hmm_model = unsupervised_morphology.MorphologyHMMParams(
-            smoothing_const=0.0, use_morph_likeness=False
+            smoothing_const=0.0
         )
         with patch("builtins.open") as mock_open:
             txt_content = [
@@ -284,39 +141,17 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_uniform_params_from_data("no_exist_file.txt")
+            morph_hmm_model.init_params_from_data("no_exist_file.txt")
 
             segmentor = unsupervised_morphology.MorphologySegmentor(morph_hmm_model)
-            assert segmentor.segment_word("123123789789") == "123 123 789 789"
-            assert (
-                segmentor.segment_word("123123789789", add_affix_symbols=True)
-                == "123+ 123+ 789 +789"
-            )
-            assert segmentor.segment_word("123") == segmentor.segment_word(
-                "123", add_affix_symbols=True
-            )
+            assert segmentor.segment_word("123123789789") == "12 3 12 3 789 789"
 
-    def check_emission_after_forward_backward(
-        self, str, e, expected_prefixes, expected_stems, expected_suffixes
-    ):
+    def check_emission_after_forward_backward(self, str, e, expected_morphemes):
         for str in get_all_substrings(str):
-            if str in expected_prefixes:
-                assert e[("prefix", str)] > 0
+            if str in expected_morphemes:
+                assert e[str] > 0
             else:
-                assert e[("prefix", str)] == 0
-
-            if str in expected_stems:
-                assert e[("stem", str)] > 0
-            else:
-                assert e[("stem", str)] == 0
-
-            if str in expected_suffixes:
-                assert e[("suffix", str)] > 0
-            else:
-                assert e[("suffix", str)] == 0
-
-            assert e[("START", str)] == 0
-            assert e[("END", str)] == 0
+                assert e[str] == 0
 
     def test_forward_backward(self):
         with patch("builtins.open") as mock_open:
@@ -326,54 +161,12 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
                 "no_exist_file.txt", smoothing_const=0.0
             )
-            e, t = unsupervised_model.forward_backward("123")
+            e = unsupervised_model.forward_backward("123")
 
             # checking emission parameters
-            expected_prefixes = {"1"}
-            expected_stems = {"12", "123", "23"}
-            expected_suffixes = {"3"}
             self.check_emission_after_forward_backward(
-                "123", e, expected_prefixes, expected_stems, expected_suffixes
+                "123", e, get_all_substrings("123")
             )
-
-            assert t[("START", "START")] == 0
-            assert t[("START", "END")] == 0
-            assert t[("START", "prefix")] > 0
-            assert t[("START", "stem")] > 0
-            assert t[("START", "suffix")] == 0
-            assert t[("END", "START")] == 0
-            assert t[("END", "END")] == 0
-            assert t[("END", "prefix")] == 0
-            assert t[("END", "stem")] == 0
-            assert t[("END", "suffix")] == 0
-            assert t[("prefix", "START")] == 0
-            assert t[("prefix", "END")] == 0
-            assert t[("prefix", "prefix")] == 0
-            assert t[("prefix", "stem")] > 0
-            assert t[("prefix", "suffix")] == 0
-            assert t[("stem", "START")] == 0
-            assert t[("stem", "END")] > 0
-            assert t[("stem", "prefix")] == 0
-            assert t[("stem", "stem")] == 0
-            assert t[("stem", "suffix")] > 0
-            assert t[("suffix", "START")] == 0
-            assert t[("suffix", "END")] > 0
-            assert t[("suffix", "prefix")] == 0
-            assert t[("suffix", "stem")] == 0
-            assert t[("suffix", "suffix")] == 0
-
-    def test_forward_backward_with_smoothing(self):
-        """
-        Making sure that the algorithm works end-to-end.
-        """
-        with patch("builtins.open") as mock_open:
-            txt_content = ["123 12123"]
-            mock_open.return_value.__enter__ = mock_open
-            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                "no_exist_file.txt", smoothing_const=0.1
-            )
-            e, t = unsupervised_model.forward_backward("123")
 
     def test_forward_backward_long_str(self):
         with patch("builtins.open") as mock_open:
@@ -388,74 +181,58 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
                 "no_exist_file.txt", smoothing_const=0.0
             )
-            e, t = unsupervised_model.forward_backward("1232345")
-            expected_prefixes = {"1", "12", "123", "2", "23", "3"}
-            expected_stems = {"12", "123", "23", "234", "2345", "345", "45", "34"}
-            expected_suffixes = {"2", "3", "4", "5", "34", "45", "345"}
-            self.check_emission_after_forward_backward(
-                "1232345", e, expected_prefixes, expected_stems, expected_suffixes
-            )
+            e = unsupervised_model.forward_backward("1232345")
+            expected_morphs = {
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "12",
+                "23",
+                "34",
+                "45",
+                "123",
+                "234",
+                "345",
+                "2345",
+            }
+            self.check_emission_after_forward_backward("1232345", e, expected_morphs)
 
-            assert t[("START", "START")] == 0
-            assert t[("START", "END")] == 0
-            assert t[("START", "prefix")] > 0
-            assert t[("START", "stem")] > 0
-            assert t[("START", "suffix")] == 0
-            assert t[("END", "START")] == 0
-            assert t[("END", "END")] == 0
-            assert t[("END", "prefix")] == 0
-            assert t[("END", "stem")] == 0
-            assert t[("END", "suffix")] == 0
-            assert t[("prefix", "START")] == 0
-            assert t[("prefix", "END")] == 0
-            assert t[("prefix", "prefix")] > 0
-            assert t[("prefix", "stem")] > 0
-            assert t[("prefix", "suffix")] == 0
-            assert t[("stem", "START")] == 0
-            assert t[("stem", "END")] > 0
-            assert t[("stem", "prefix")] == 0
-            assert t[("stem", "stem")] > 0
-            assert t[("stem", "suffix")] > 0
-            assert t[("suffix", "START")] == 0
-            assert t[("suffix", "END")] > 0
-            assert t[("suffix", "prefix")] == 0
-            assert t[("suffix", "stem")] == 0
-            assert t[("suffix", "suffix")] > 0
-
-    def test_EM(self):
+    def test_EM_alg(self):
+        txt_content = [
+            "work",
+            "works",
+            "worked",
+            "working",
+            "go",
+            "goes",
+            "gone",
+            "going",
+            "do",
+            "does",
+            "did",
+            "doing",
+            "see",
+            "saw",
+            "seen",
+            "seeing",
+        ]
+        # Running with forward-backward.
         with patch("builtins.open") as mock_open:
-            txt_content = [
-                "work",
-                "works",
-                "worked",
-                "working",
-                "go",
-                "goes",
-                "gone",
-                "going",
-                "do",
-                "does",
-                "did",
-                "doing",
-                "see",
-                "saw",
-                "seen",
-                "seeing",
-            ]
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            # Running with forward-backward.
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                "no_exist_file.txt", smoothing_const=0.0, use_morph_likeness=False
+                "no_exist_file.txt", smoothing_const=0.0
             )
             unsupervised_model.expectation_maximization(10, 10)
 
-            # Running with Viterbi-EM.
+        # Running with Viterbi-EM.
+        with patch("builtins.open") as mock_open:
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                "no_exist_file.txt",
-                smoothing_const=0.0,
-                use_hardEM=True,
-                use_morph_likeness=False,
+                "no_exist_file.txt", smoothing_const=0.0, use_hardEM=True
             )
             unsupervised_model.expectation_maximization(10, 10)
 
@@ -470,24 +247,14 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
 
-            unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
-                "no_exist_file.txt",
-                smoothing_const=0.0,
-                use_hardEM=True,
-                use_morph_likeness=False,
+            um = unsupervised_morphology.UnsupervisedMorphology(
+                "no_exist_file.txt", smoothing_const=0.0, use_hardEM=True
             )
-            assert unsupervised_model.segmentor.segment_viterbi("123123789") == (
-                ["prefix", "prefix", "stem"],
-                [0, 3, 6, 9],
-            )
-            e, t = unsupervised_model.get_expectations_from_viterbi("123123789")
-            assert e[("prefix", "123")] == 2
-            assert e[("stem", "789")] == 1
-            assert e[("suffix", "789")] == 0
-            assert t[("START", "prefix")] == 1
-            assert t[("prefix", "prefix")] == 1
-            assert t[("prefix", "stem")] == 1
-            assert t[("stem", "END")] == 1
+            assert um.segmentor.segment_viterbi("123123789") == [0, 2, 3, 5, 6, 9]
+            e = um.get_expectations_from_viterbi("123123789")
+            assert e["12"] == 2
+            assert e["789"] == 1
+            assert e["89"] == 0
 
     def test_save_load(self):
         with patch("builtins.open") as mock_open:
@@ -526,13 +293,10 @@ class TestUnsupervisedMorphology(unittest.TestCase):
         assert (
             unsupervised_model.params.morph_emit_probs == loaded_params.morph_emit_probs
         )
-        assert (
-            unsupervised_model.params.affix_trans_probs
-            == loaded_params.affix_trans_probs
-        )
         assert unsupervised_model.params.word_counts == loaded_params.word_counts
         assert (
             unsupervised_model.params.smoothing_const == loaded_params.smoothing_const
         )
         assert unsupervised_model.params.SMALL_CONST == loaded_params.SMALL_CONST
+        assert unsupervised_model.params.len_cost_pow == loaded_params.len_cost_pow
         shutil.rmtree(test_dir)

--- a/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
+++ b/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
@@ -14,523 +14,148 @@ from pytorch_translate.research.unsupervised_morphology.morphology_context impor
 
 
 class MorphologyHMMParams(object):
-    def __init__(
-        self,
-        smoothing_const: float = 0.1,
-        use_morph_likeness: bool = True,
-        perplexity_threshold: float = 10,
-        perplexity_slope: float = 1,
-        length_threshold: float = 3,
-        length_slope: float = 2,
-    ):
+    def __init__(self, smoothing_const: float = 0.1, len_cost_pow: float = 2):
         """
-        This class contains HMM probabilities for the morphological model.
-        The model has transition probabilities of affix classes, and
-        emission probabilities of morphemes.
-        Types of affixes: prefix, stem, suffix (we ignore infixes).
-        Example of transition probabilities: q(suffix | stem).
-        Example of emission probabilities: e(ing | suffix).
-        We also have two registered affixes for showing the START and END of
-        words.
+        This class contains unigram HMM probabilities for the morphological model.
         Args:
             * smoothing_const: For smoothing the categorical distribution. This is
             mostly useful for unseen observations outside training.
-            * use_morph_likeness: If true, use the equations 16 and 17 in the
-            following paper:
-            https://users.ics.aalto.fi/krista/papers/Creutz07.pdf
-            * perplexity_threshold and perplexity_slope: Used for thresholding
-            and slope the perplexity value. This come from equation 16 of the
-            above paper:
-            > prefix_like(m) =
-            1/(1 + exp(-perplexity_slope *(right_perplexity(m)-perplexity_threshold)))
-            * length_threshold and length_slope: This comes from equation 17 of
-            the above paper:
-            > stem_like(m) = 1/(1+ exp(-length_slope*(length(m)-length_threshold)))
+            * len_cost_pow: used for penalizing long char sequences. Here we use
+                it in emission as exp(- math.pow(len(str)-1, len_cost_pow))
         """
-        self.morph_emit_probs: Dict[str, dict] = {
-            "prefix": {},
-            "stem": {},
-            "suffix": {},
-        }
-        self.affix_trans_probs: Dict[str, dict] = {
-            "prefix": {},
-            "stem": {},
-            "suffix": {},
-            "START": {},
-            "END": {},
-        }
+        self.emit_probs: Dict[str, float] = defaultdict(float)
         self.word_counts: Dict[str, int] = Counter()
         self.smoothing_const = smoothing_const
         self.SMALL_CONST = -10000
-        self.use_morph_likeness = use_morph_likeness
-        self.perplexity_threshold = perplexity_threshold
-        self.perplexity_slope = perplexity_slope
-        self.length_threshold = length_threshold
-        self.length_slope = length_slope
+        self.len_cost_pow = len_cost_pow
 
-        # This gets values after calling init_uniform_params_from_data if
-        # use_morph_likeness is True.
-        self.morph_likeness = None
-
-    def init_uniform_params_from_data(self, input_file_path):
+    def init_params_from_data(self, input_file_path):
         """
         We should obtain a list of all possible morphemes from a data file.
         """
-        self.morph_emit_probs = {"prefix": {}, "stem": {}, "suffix": {}}
-        self.affix_trans_probs = {
-            "prefix": {},
-            "stem": {},
-            "suffix": {},
-            "START": {},
-            "END": {},
-        }
+        self.morph_emit_probs: Dict[str, dict] = defaultdict(float)
 
         with open(input_file_path, "r", encoding="utf-8") as input_stream:
             for line in input_stream:
                 for word in line.strip().split():
                     self.word_counts[word] += 1
 
-        context_dics: Dict[str, MorphologyContext] = {}
         for word in self.word_counts:
             word_count = self.word_counts[word]
-            if len(word) <= 2:
-                # If a word is very short, it is definitely an
-                # independent stem.
-                self.morph_emit_probs["stem"][word] = 1.0
-                if self.use_morph_likeness:
-                    # We don't allow context with length lower than 3.
-                    if word not in context_dics:
-                        context_dics[word] = MorphologyContext()
-
             for i in range(0, len(word)):
                 for j in range(i, len(word)):
                     substr = word[i : j + 1]
-                    if j < len(word) - 2:
-                        self.morph_emit_probs["prefix"][substr] = 1.0
-                    if j - i >= 1:
-                        self.morph_emit_probs["stem"][substr] = 1.0
-                    if i >= 2:
-                        self.morph_emit_probs["suffix"][substr] = 1.0
+                    self.morph_emit_probs[substr] += word_count
 
-                    if self.use_morph_likeness:
-                        if substr not in context_dics:
-                            context_dics[substr] = MorphologyContext()
-
-                        # Updating left and right context vectors.
-                        for k in range(0, i - 2):
-                            # Get context values of length at least 3.
-                            left_context_str = word[k:i]
-                            context_dics[substr].add_to_left_context(
-                                left_context_str, word_count
-                            )
-                        for k in range(j + 4, len(word) + 1):
-                            # Get context values of length at least 3.
-                            right_context_str = word[j + 1 : k]
-                            context_dics[substr].add_to_right_context(
-                                right_context_str, word_count
-                            )
-
-        # Normalizing the initial probabilities uniformly.
-        for affix in self.morph_emit_probs.keys():
-            num_morphs = len(self.morph_emit_probs[affix])
-            for morph in self.morph_emit_probs[affix].keys():
-                self.morph_emit_probs[affix][morph] = (1.0 + self.smoothing_const) / (
-                    num_morphs * (1 + self.smoothing_const)
-                )
-
-        # Initializing the transition probabilities. Here we force some trivial
-        # rules such as not having a suffix right after a prefix.
-        self.affix_trans_probs["START"]["START"] = 0
-        self.affix_trans_probs["START"]["prefix"] = 0.5
-        self.affix_trans_probs["START"]["stem"] = 0.5
-        self.affix_trans_probs["START"]["suffix"] = 0
-        self.affix_trans_probs["START"]["END"] = 0
-        self.affix_trans_probs["prefix"]["START"] = 0
-        self.affix_trans_probs["prefix"]["prefix"] = 0.5
-        self.affix_trans_probs["prefix"]["stem"] = 0.5
-        self.affix_trans_probs["prefix"]["suffix"] = 0
-        self.affix_trans_probs["prefix"]["END"] = 0
-        self.affix_trans_probs["stem"]["START"] = 0
-        self.affix_trans_probs["stem"]["prefix"] = 0
-        self.affix_trans_probs["stem"]["stem"] = 1.0 / 3
-        self.affix_trans_probs["stem"]["suffix"] = 1.0 / 3
-        self.affix_trans_probs["stem"]["END"] = 1.0 / 3
-        self.affix_trans_probs["suffix"]["START"] = 0
-        self.affix_trans_probs["suffix"]["prefix"] = 0
-        self.affix_trans_probs["suffix"]["stem"] = 0
-        self.affix_trans_probs["suffix"]["suffix"] = 0.5
-        self.affix_trans_probs["suffix"]["END"] = 0.5
-        self.affix_trans_probs["END"]["START"] = 0
-        self.affix_trans_probs["END"]["prefix"] = 0
-        self.affix_trans_probs["END"]["stem"] = 0
-        self.affix_trans_probs["END"]["suffix"] = 0
-        self.affix_trans_probs["END"]["END"] = 0
-
-        if self.use_morph_likeness:
-            self.build_morph_likeness_values(context_dics)
-
-        # Deleting this to free memory just in case GC does not work efficiently.
-        del context_dics
-
-    def build_morph_likeness_values(self, context_dics):
-        self.morph_likeness = {
-            "prefix": defaultdict(float),
-            "stem": defaultdict(float),
-            "suffix": defaultdict(float),
-        }
-        for substr in context_dics.keys():
-            left_perplexity = context_dics[substr].left_perplexity()
-            right_perplexity = context_dics[substr].right_perplexity()
-
-            # Following https://users.ics.aalto.fi/krista/papers/Creutz07.pdf
-            # As in eq. 16.
-            prefix_like = 1.0 / (
-                1
-                + math.exp(
-                    -self.perplexity_slope
-                    * (right_perplexity - self.perplexity_threshold)
-                )
-            )
-            suffix_like = 1.0 / (
-                1
-                + math.exp(
-                    -self.perplexity_slope
-                    * (left_perplexity - self.perplexity_threshold)
-                )
-            )
-
-            # As in eq. 17.
-            stem_like = 1.0 / (
-                1 + math.exp(-self.length_slope * (len(substr) - self.length_threshold))
-            )
-
-            # Similar to eq. 19, but we ignore non-morpheme type and normalization
-            # exponent q.
-            denom = prefix_like + stem_like + suffix_like
-            self.morph_likeness["stem"][substr] = stem_like / denom
-            self.morph_likeness["prefix"][substr] = prefix_like / denom
-            self.morph_likeness["suffix"][substr] = suffix_like / denom
+        # Normalizing the initial probabilities.
+        denom = sum(self.morph_emit_probs.values())
+        for morph in self.morph_emit_probs.keys():
+            self.morph_emit_probs[morph] = (
+                self.morph_emit_probs[morph] + self.smoothing_const
+            ) / (denom * (1 + self.smoothing_const))
 
     def zero_out_parmas(self):
         """
         Resets parameter values for all parameters.
         """
-        for morpheme_class1 in self.affix_trans_probs.keys():
-            for morpheme_class2 in self.affix_trans_probs[morpheme_class1].keys():
-                self.affix_trans_probs[morpheme_class1][morpheme_class2] = 0.0
+        for morpheme in self.morph_emit_probs.keys():
+            self.morph_emit_probs[morpheme] = 0.0
 
-        for morpheme_class in self.morph_emit_probs.keys():
-            for morpheme in self.morph_emit_probs[morpheme_class].keys():
-                self.morph_emit_probs[morpheme_class][morpheme] = 0.0
-
-    def sample_segmentation(self, word, affix_len_mean, affix_len_std_dev):
-        """
-        Sample until the first plausible segmentation shows up. Here the
-        constraint is to have a stem with at least length of two.
-        """
-        wlen = len(word)
-        # At most try 5 times to sample segmentations. Otherwise
-        for _ in range(5):
-            # If a word is short, the real mean value show decrease. For example,
-            # if wlen=3, real_min is 1.
-            real_mean = min(affix_len_mean, wlen - 2)
-
-            prefix_lens = []
-            for _ in range(2):
-                # Sample at most two prefixes.
-                pl = int(
-                    max(
-                        math.ceil(random.normalvariate(real_mean, affix_len_std_dev)), 0
-                    )
-                )
-                if pl > 0:
-                    prefix_lens.append(pl)
-
-            suffix_lens = []
-            for _ in range(2):
-                # Sample at most two prefixes.
-                sl = int(
-                    max(
-                        math.ceil(random.normalvariate(real_mean, affix_len_std_dev)), 0
-                    )
-                )
-                if sl > 0:
-                    suffix_lens.append(sl)
-
-            stem_len = int(wlen - sum(prefix_lens + suffix_lens))
-            num_of_stems = 1 if random.randint(1, 10) < 10 else 2
-            if stem_len > 4 and num_of_stems > 1:
-                # Generate two stems by breaking it from the middle.
-                m = int(stem_len / 2)
-                stem_lens = [m, stem_len - m]
-            elif stem_len >= 2:
-                # Generate one stem.
-                stem_lens = [stem_len]
-            else:
-                # Just in case the model was not able to sample any segmentation.
-                morphemes = [word]
-                tags = ["START", "stem", "END"]
-                continue
-
-            tags = (
-                ["START"]
-                + ["prefix"] * len(prefix_lens)
-                + ["stem"] * len(stem_lens)
-                + ["suffix"] * len(suffix_lens)
-                + ["END"]
-            )
-
-            lens = chain(prefix_lens, stem_lens, suffix_lens)
-
-            morphemes = []
-            offset = 0
-            for ml in lens:
-                morpheme = word[offset : ml + offset]
-                morphemes.append(morpheme)
-                offset += ml
-
-            # Making sure that we reached the end of word.
-            assert offset == wlen
-            assert len(morphemes) + 2 == len(tags)
-
-            # Successful attempt, break the loop.
-            break
-
-        return morphemes, tags
-
-    def init_params_with_normal_distribution(
-        self, input_file_path: str, affix_len_mean=2.0, affix_len_std_dev=1.0
-    ):
-        """
-        Instead of uniformly enumerating all possible affixes, we initialize
-        parameters by sampling.
-        Args:
-            input_file_path: input file path.
-            affix_len_mean: mean value for affix (prefix or suffix) length.
-            affix_len_std_dev: standard deviation value for affix length.
-        """
-        assert self.smoothing_const > 0
-        self.init_uniform_params_from_data(input_file_path)
-        self.zero_out_parmas()
-
-        self.affix_trans_denoms = {
-            morpheme: 0.0 for morpheme in self.affix_trans_probs.keys()
-        }
-        self.morph_emit_denoms = {
-            morpheme: 0.0 for morpheme in self.morph_emit_probs.keys()
-        }
-
-        for word in self.word_counts:
-            wlen, freq = len(word), self.word_counts[word]
-            if wlen <= 2:
-                # If a word is very short, it is definitely an
-                # independent stem.
-                self.morph_emit_probs["stem"][word] += freq
-                self.morph_emit_denoms["stem"] += freq
-                self.affix_trans_probs["START"]["stem"] += freq
-                self.affix_trans_denoms["START"] += freq
-                self.affix_trans_probs["stem"]["END"] += freq
-                self.affix_trans_denoms["stem"] += freq
-
-            morphemes, tags = self.sample_segmentation(
-                word, affix_len_mean, affix_len_std_dev
-            )
-            for i in range(len(morphemes)):
-                prev_tag, tag = tags[i], tags[i + 1]
-                self.morph_emit_probs[tag][morphemes[i]] += freq
-                self.morph_emit_denoms[tag] += freq
-                self.affix_trans_probs[prev_tag][tag] += freq
-                self.affix_trans_denoms[prev_tag] += freq
-            self.affix_trans_probs[tags[-2]][tags[-1]] += freq
-            self.affix_trans_denoms[tags[-2]] += freq
-
-        for prev_tag in self.affix_trans_probs.keys():
-            if prev_tag == "END":
-                continue
-            num_morphs = len(self.affix_trans_probs[prev_tag])
-            for cur_tag in self.affix_trans_probs[prev_tag].keys():
-                self.affix_trans_probs[prev_tag][cur_tag] /= self.affix_trans_denoms[
-                    prev_tag
-                ]
-
-        for tag in self.morph_emit_probs.keys():
-            num_morphs = len(self.morph_emit_probs[tag])
-            for word in self.morph_emit_probs[tag].keys():
-                self.morph_emit_probs[tag][word] = (
-                    self.morph_emit_probs[tag][word] + self.smoothing_const
-                ) / (self.morph_emit_denoms[tag] + num_morphs * self.smoothing_const)
-
-    def transition_log_prob(self, prev_tag, current_tag):
-        """
-        For parameter estimation of the forward-backward algorithm, we still need
-        the actual probability values. However, in decoding, working in log-scale
-        is more efficient.
-        """
-        if self.affix_trans_probs[prev_tag][current_tag] == 0:
-            return self.SMALL_CONST
-        return math.log(self.affix_trans_probs[prev_tag][current_tag])
-
-    def emission_prob(self, morpheme_type, morpheme):
+    def emission_prob(self, morpheme):
         """
         If a morpheme is not seen, we return the default smoothed probability.
         Note that we assume the probabilities for the seen morphemes are already
         smoothed.
         """
-        if morpheme_type in {"START", "END"}:
-            return 0
+        e = self.morph_emit_probs[morpheme]
+        if e == 0:
+            return e
 
-        # Incorporating likeness count.
-        likeness_const = (
-            1
-            if self.morph_likeness is None
-            else self.morph_likeness[morpheme_type][morpheme]
-        )
+        # panalty term for length
+        ln = math.pow(len(morpheme) - 1, self.len_cost_pow)
+        return e * math.exp(-ln)
 
-        if morpheme in self.morph_emit_probs[morpheme_type]:
-            return likeness_const * self.morph_emit_probs[morpheme_type][morpheme]
-        else:
-            num_morphs = len(self.morph_emit_probs[morpheme_type])
-            return (
-                likeness_const
-                * self.smoothing_const
-                / (num_morphs * (1 + self.smoothing_const))
-            )
-
-    def emission_log_probs(self, morpheme_type, morpheme):
-        if morpheme_type in {"START", "END"}:
+    def emission_log_prob(self, morpheme):
+        if self.emission_prob(morpheme) == 0:
             return self.SMALL_CONST
-        if self.emission_prob(morpheme_type, morpheme) == 0:
-            return self.SMALL_CONST
-        return math.log(self.emission_prob(morpheme_type, morpheme))
+        return math.log(self.emission_prob(morpheme))
 
     @staticmethod
     def load(file_path):
         with open(file_path, "rb") as f:
-            e, t, s, c, morph_likeness = pickle.load(f)
+            e, s, c, lc = pickle.load(f)
         m = MorphologyHMMParams(s)
         m.morph_emit_probs = e
-        m.affix_trans_probs = t
         m.word_counts = c
-        m.morph_likeness = morph_likeness
+        m.len_cost_pow = lc
         return m
 
     def save(self, file_path):
-        e, t, s, c, morph_likeness = (
+        e, s, c, lc = (
             self.morph_emit_probs,
-            self.affix_trans_probs,
             self.smoothing_const,
             self.word_counts,
-            self.morph_likeness,
+            self.len_cost_pow,
         )
         with open(file_path, "wb") as f:
-            pickle.dump((e, t, s, c, morph_likeness), f)
+            pickle.dump((e, s, c, lc), f)
 
 
 class MorphologySegmentor(object):
     def __init__(self, morphology_hmm_params):
         self.params = morphology_hmm_params
 
-    def initialize_prob_values(self, n):
-        pi = [{} for _ in range(n + 1)]
-        pi[0]["START"] = 0
-        pi[0]["prefix"] = self.params.SMALL_CONST
-        pi[0]["stem"] = self.params.SMALL_CONST
-        pi[0]["suffix"] = self.params.SMALL_CONST
-        pi[0]["END"] = self.params.SMALL_CONST
-        for i in range(1, n + 1):
-            for affix in self.params.affix_trans_probs.keys():
-                pi[i][affix] = (i + 1) * self.params.SMALL_CONST
-        return pi
-
     def segment_viterbi(self, word):
         """
         This is a dynamic programming algorithm for segmenting a word by using a
         modified version of the Viterbi algorithm. The main difference here is that
         the segment-Viterbi algorithm is based on segment-HMM where a state can
-        emit more than one output. In our case, a state is an affix such as prefix,
-        and an output is a substring of a word. Because of searching for a substring
-        the segment-Viterbi algorithm has a slower run-time. In this case (bigram HMM),
-        the runtime complexity of a vanilla Viterbi algorithm is O(nT^2) where n
-        is the number of characters in word and T is the number of possible affixes
-        (in our case 3). The segment-Viterbi has a complexity O(n^2 T^2).
+        emit more than one output. In our case, a state is a morpheme and an output
+        is a substring of a word. Because of searching for a substring
+        the segment-Viterbi algorithm has a slower run-time. The segment-Viterbi
+        has a complexity O(n^2). In our case, the model is context-insensitive.
         A pseudo-code for the vanilla Viterbi algorithm:
         http://www.cs.columbia.edu/~mcollins/hmms-spring2013.pdf#page=18
         """
         n = len(word)
-        pi = self.initialize_prob_values(n)
-        back_pointer = [{} for _ in range(n + 1)]
+        pi = [self.params.SMALL_CONST for _ in range(n + 1)]
+        pi[0] = 0
+        back_pointer = [0 for _ in range(n + 1)]
 
         for start in range(n):  # loop over starting indices of morphemes.
             for end in range(start + 1, n + 1):  # loop over end indices of morphemes.
-                for cur_tag in ["prefix", "stem", "suffix"]:  # loop over possible tags.
-                    for prev_tag in ["START", "prefix", "stem", "suffix"]:
-                        # loop over possible previous tags
-                        t = self.params.transition_log_prob(prev_tag, cur_tag)
-                        e = self.params.emission_log_probs(cur_tag, word[start:end])
-                        log_prob = pi[start][prev_tag] + t + e
-                        if log_prob > pi[end][cur_tag]:
-                            pi[end][cur_tag] = log_prob
-                            # Saving backpointer for previous tag and index.
-                            back_pointer[end][cur_tag] = prev_tag, start
+                e = self.params.emission_log_prob(word[start:end])
+                log_prob = pi[start] + e
+                if log_prob > pi[end]:
+                    pi[end] = log_prob
+                    # Saving backpointer for previous tag and index.
+                    back_pointer[end] = start
 
         # finalizing the best segmentation.
-        best_score = n * self.params.SMALL_CONST
-        best_bp = None
         indices = [n]  # backtracking indices for segmentation.
-        labels = []  # backtracking labels for segmentation.
-        for last_tag in {"prefix", "stem", "suffix"}:
-            t = self.params.transition_log_prob(last_tag, "END")
-            log_prob = pi[n][last_tag] + t
-            if log_prob > best_score:
-                best_score = log_prob
-                best_bp = (
-                    back_pointer[n][last_tag][1],
-                    last_tag,
-                    back_pointer[n][last_tag][0],
-                )
-
-        indices.append(best_bp[0])
-        labels.append(best_bp[1])
-        if best_bp[0] > 0:
-            # In cases where the last index is zero, we don't want to backtrack
-            # anymore.
-            labels.append(best_bp[2])
-
+        indices.append(back_pointer[-1])
         while True:
             last_index = indices[-1]
-            last_label = labels[-1]
             if last_index == 0:
                 break
-            prev_tag, start_index = back_pointer[last_index][last_label]
+            start_index = back_pointer[last_index]
             indices.append(start_index)
             if start_index == 0:
                 break
-            labels.append(prev_tag)
 
         # We should now reverse the backtracked list.
         indices.reverse()
-        labels.reverse()
-        return labels, indices
+        return indices
 
-    def segment_word(self, word, add_affix_symbols=False):
+    def segment_word(self, word):
         """
         This method segments words based on the Viterbi algorithm. Given an input
         string, the algorithm segments that word to one or more substrings.
-
-        Args:
-            add_affix_symbols: if True, put a + after prefixes, and before affixes.
-            Example: pretokenize --> pre+ token +ize
         """
-        labels, indices = self.segment_viterbi(word)
+        indices = self.segment_viterbi(word)
         outputs = []
-        for i in range(len(labels)):
+        for i in range(len(indices) - 1):
             substr = word[indices[i] : indices[i + 1]]
-            label = labels[i]
-            if add_affix_symbols:
-                if label == "prefix":
-                    substr = substr + "+"
-                elif label == "suffix":
-                    substr = "+" + substr
             outputs.append(substr)
 
         return " ".join(outputs)
@@ -541,72 +166,30 @@ class UnsupervisedMorphology(object):
         self,
         input_file: str,
         smoothing_const: float = 0.1,
-        use_normal_init: bool = False,
-        normal_mean: float = 2.0,
-        normal_stddev: float = 1.0,
         use_hardEM: bool = False,
-        use_morph_likeness: bool = True,
-        perplexity_threshold: float = 10,
-        perplexity_slope: float = 1,
-        length_threshold: float = 3,
-        length_slope: float = 2,
+        len_cost_pow: float = 2.0,
     ):
         """
         Args:
-            use_normal_init: Use normal distribution for initializing the
-                probabilities. Default model uses a uniform value for all.
-            normal_mean: Mean value for prefix/suffix length when sampling with
-                the normal distribution.
-            normal_stddev: Standard deviation for prefix/suffix length when sampling
-                with the normal distribution.
             use_hardEM: Choosing between soft EM or Viterbi EM (hard EM) algorithm.
-            use_morph_likeness: Used by MorphologyHMMParams constructor.
-            perplexity_threshold: Used by MorphologyHMMParams constructor.
-            perplexity_slope: Used by MorphologyHMMParams constructor.
-            length_threshold: Used by MorphologyHMMParams constructor.
-            length_slope: Used by MorphologyHMMParams constructor.
         """
         self.params = MorphologyHMMParams(
-            smoothing_const=smoothing_const,
-            use_morph_likeness=use_morph_likeness,
-            perplexity_threshold=perplexity_threshold,
-            perplexity_slope=perplexity_slope,
-            length_threshold=length_threshold,
-            length_slope=length_slope,
+            smoothing_const=smoothing_const, len_cost_pow=len_cost_pow
         )
         self.use_hardEM = use_hardEM
-
-        if use_normal_init:
-            self.params.init_params_with_normal_distribution(
-                input_file, normal_mean, normal_stddev
-            )
-        else:
-            self.params.init_uniform_params_from_data(input_file)
-
+        self.params.init_params_from_data(input_file)
         self.segmentor = MorphologySegmentor(self.params) if self.use_hardEM else None
 
     @staticmethod
     def init_forward_values(n):
-        forward_values = [{} for _ in range(n + 1)]
-        forward_values[0]["START"] = 1.0
-        forward_values[0]["prefix"] = 0
-        forward_values[0]["stem"] = 0
-        forward_values[0]["suffix"] = 0
-        forward_values[0]["END"] = 0
-        for i in range(1, len(forward_values)):
-            for cur_tag in ["START", "prefix", "stem", "suffix", "END"]:
-                forward_values[i][cur_tag] = 0
+        forward_values = [0 for _ in range(n + 1)]
+        forward_values[0] = 1.0
         return forward_values
 
     @staticmethod
     def init_backward_values(n):
-        backward_values = [{} for _ in range(n + 1)]
-
-        backward_values[n]["END"] = 1.0
-
-        for i in range(0, len(backward_values)):
-            for cur_tag in ["START", "prefix", "stem", "suffix", "END"]:
-                backward_values[i][cur_tag] = 0
+        backward_values = [0 for _ in range(n + 1)]
+        backward_values[n] = 1.0
         return backward_values
 
     def forward(self, word):
@@ -619,13 +202,8 @@ class UnsupervisedMorphology(object):
         forward_values = UnsupervisedMorphology.init_forward_values(n)
         for start in range(n):
             for end in range(start + 1, n + 1):
-                for cur_tag in ["prefix", "stem", "suffix"]:
-                    for prev_tag in ["START", "prefix", "stem", "suffix"]:
-                        t = self.params.affix_trans_probs[prev_tag][cur_tag]
-                        e = self.params.emission_prob(cur_tag, word[start:end])
-                        forward_values[end][cur_tag] += (
-                            forward_values[start][prev_tag] * t * e
-                        )
+                e = self.params.emission_prob(word[start:end])
+                forward_values[end] += forward_values[start] * e
         return forward_values
 
     def backward(self, word):
@@ -635,23 +213,10 @@ class UnsupervisedMorphology(object):
         n = len(word)
         backward_values = UnsupervisedMorphology.init_backward_values(n)
 
-        # Here we initialize the backward pass of the valid morpheme classes equal
-        # to their transition to the END state.
-        for cur_tag in ["prefix", "stem", "suffix"]:
-            t = self.params.affix_trans_probs[cur_tag]["END"]
-            backward_values[n][cur_tag] = t
-
-        # Here we do regular summation over all possible paths leading to a specific
-        # morpheme class.
         for start in range(n - 1, -1, -1):
             for end in range(start + 1, n + 1):
-                for cur_tag in ["prefix", "stem", "suffix"]:
-                    for next_tag in ["prefix", "stem", "suffix"]:
-                        t = self.params.affix_trans_probs[cur_tag][next_tag]
-                        e = self.params.emission_prob(next_tag, word[start:end])
-                        backward_values[start][cur_tag] += (
-                            backward_values[end][next_tag] * t * e
-                        )
+                e = self.params.emission_prob(word[start:end])
+                backward_values[start] += backward_values[end] * e
         return backward_values
 
     def forward_backward(self, word):
@@ -674,41 +239,16 @@ class UnsupervisedMorphology(object):
         backward_values = self.backward(word)
 
         emission_expectations = defaultdict(float)
-        transition_expectations = defaultdict(float)
-
-        for prev_tag in ["prefix", "stem", "suffix"]:
-            transition_expectations[(prev_tag, "END")] += (
-                forward_values[n][prev_tag]
-                * self.params.affix_trans_probs[prev_tag]["END"]
-            )
-        denominator = sum(
-            transition_expectations[(prev_tag, "END")]
-            for prev_tag in ["prefix", "stem", "suffix"]
-        )
-        for prev_tag in ["prefix", "stem", "suffix"]:
-            transition_expectations[(prev_tag, "END")] /= denominator
 
         for start in range(n):
             for end in range(start + 1, n + 1):
                 substr = word[start:end]
-                for prev_tag in ["START", "prefix", "stem", "suffix"]:
-                    for cur_tag in ["prefix", "stem", "suffix"]:
-                        t = self.params.affix_trans_probs[prev_tag][cur_tag]
-                        e = self.params.emission_prob(cur_tag, substr)
-                        emission_expectations[(cur_tag, substr)] += (
-                            forward_values[start][prev_tag]
-                            * t
-                            * e
-                            * backward_values[end][cur_tag]
-                        ) / denominator
-                        transition_expectations[(prev_tag, cur_tag)] += (
-                            forward_values[start][prev_tag]
-                            * t
-                            * e
-                            * backward_values[end][cur_tag]
-                        ) / denominator
+                e = self.params.emission_prob(substr)
+                emission_expectations[substr] += (
+                    forward_values[start] * e * backward_values[end]
+                )
 
-        return emission_expectations, transition_expectations
+        return emission_expectations
 
     @staticmethod
     def group_to(max_size, iterable):
@@ -723,44 +263,34 @@ class UnsupervisedMorphology(object):
         account.
         """
         emission_expectations = defaultdict(float)
-        transition_expectations = defaultdict(float)
 
-        labels, indices = self.segmentor.segment_viterbi(word)
+        indices = self.segmentor.segment_viterbi(word)
 
-        transition_expectations[("START", labels[0])] += 1
-        for i in range(len(labels)):
+        for i in range(len(indices) - 1):
             substr = word[indices[i] : indices[i + 1]]
-            emission_expectations[(labels[i], substr)] += 1
-            if i > 0:
-                transition_expectations[(labels[i - 1], labels[i])] += 1
-        transition_expectations[(labels[-1], "END")] += 1
+            emission_expectations[substr] += 1
 
-        return emission_expectations, transition_expectations
+        return emission_expectations
 
     def expectation_substep(self, words):
         """
         This method is subprocess for the expectation method.
         """
         emission_expectations = defaultdict(float)
-        transition_expectations = defaultdict(float)
         for wf in words:
             if wf is None:
                 continue
             (word, freq) = wf
 
             if self.use_hardEM:
-                e, t = self.get_expectations_from_viterbi(word)
+                e = self.get_expectations_from_viterbi(word)
             else:
-                e, t = self.forward_backward(word)
+                e = self.forward_backward(word)
 
             for e_key in e.keys():
                 emission_expectations[e_key] += e[e_key] * freq
-            for t_key in t.keys():
-                transition_expectations[t_key] += t[t_key] * freq
-            del e
-            del t
 
-        return emission_expectations, transition_expectations
+        return emission_expectations
 
     def expectation(self, pool, train_words_chunks):
         """
@@ -771,92 +301,28 @@ class UnsupervisedMorphology(object):
                                 (chunked for multi-threading).
         """
         expectations = pool.map(self.expectation_substep, train_words_chunks)
+        emission_expectations = defaultdict(float)
+        for e_key in set(chain(*[list(e.keys()) for e in expectations])):
+            emission_expectations[e_key] = sum(e[e_key] for e in expectations)
+        return emission_expectations
 
-        emission_expectations = {"prefix": {}, "stem": {}, "suffix": {}}
-        transition_expectations = {
-            "prefix": {},
-            "stem": {},
-            "suffix": {},
-            "START": {},
-            "END": {},
-        }
-
-        for e_key in set(chain(*[list(e[0].keys()) for e in expectations])):
-            emission_expectations[e_key[0]][e_key[1]] = sum(
-                e[0][e_key] for e in expectations
-            )
-        for t_key in set(chain(*[list(t[1].keys()) for t in expectations])):
-            transition_expectations[t_key[0]][t_key[1]] = sum(
-                t[1][t_key] for t in expectations
-            )
-
-        emission_denoms = {
-            e: sum(v for v in emission_expectations[e].values())
-            for e in emission_expectations.keys()
-        }
-        transition_denoms = {
-            t: sum(v for v in transition_expectations[t].values())
-            for t in transition_expectations.keys()
-        }
-        return (
-            emission_expectations,
-            emission_denoms,
-            transition_expectations,
-            transition_denoms,
-        )
-
-    def maximization(
-        self,
-        emission_expectations,
-        emission_denoms,
-        transition_expectations,
-        transition_denoms,
-    ):
+    def maximization(self, emission_expectations):
         """
         Runs the maximization algorithm.
         Args:
-            emission_expectations: the expected counts for each affix-morpheme pair.
-            emission_denoms: the sum-expected count of each morpheme class.
-            transition_expectations: the expected counts for each affix-affix pair
-                                     for transition.
-            transition_denoms: the sum-expected count of each morpheme class as
-                               conditional in transition.
+            emission_expectations: the expected counts for each morpheme.
         """
         smoothing_const = self.params.smoothing_const
-        for morpheme_class in self.params.morph_emit_probs.keys():
-            num_morphs = len(self.params.morph_emit_probs[morpheme_class])
-            d = emission_denoms[morpheme_class]
-            for morpheme in self.params.morph_emit_probs[morpheme_class].keys():
-                e = 0
-                if morpheme in emission_expectations[morpheme_class]:
-                    e = emission_expectations[morpheme_class][morpheme]
-                if d > 0 or smoothing_const > 0:
-                    self.params.morph_emit_probs[morpheme_class][morpheme] = (
-                        e + smoothing_const
-                    ) / ((num_morphs * smoothing_const) + d)
-                else:  # for cases of underflowing
-                    self.params.morph_emit_probs[morpheme_class][morpheme] = (
-                        1.0 / num_morphs
-                    )
-
-        for m1 in self.params.affix_trans_probs.keys():
-            if m1 == "END":
-                continue  # "END" has zero probs for all.
-            for m2 in self.params.affix_trans_probs[m1].keys():
-                if m2 in transition_expectations[m1]:
-                    if transition_denoms[m1] > 0:
-                        t = 0
-                        if m2 in transition_expectations[m1]:
-                            t = transition_expectations[m1][m2]
-                        self.params.affix_trans_probs[m1][m2] = (
-                            t / transition_denoms[m1]
-                        )
-                    else:  # for cases of underflow.
-                        self.params.affix_trans_probs[m1][m2] = 1.0 / len(
-                            self.params.affix_trans_probs[m1]
-                        )
-                else:
-                    self.params.affix_trans_probs[m1][m2] = 0.0
+        num_morphs = len(self.params.morph_emit_probs)
+        d = sum(emission_expectations.values())
+        for morpheme in self.params.morph_emit_probs.keys():
+            e = emission_expectations[morpheme]
+            if d > 0 or smoothing_const > 0:
+                self.params.morph_emit_probs[morpheme] = (e + smoothing_const) / (
+                    (num_morphs * smoothing_const) + d
+                )
+            else:  # for cases of underflowing
+                self.params.morph_emit_probs[morpheme] = 1.0 / num_morphs
 
     def expectation_maximization(self, num_iters, num_cpus=10, model_path=None):
         """
@@ -881,9 +347,9 @@ class UnsupervisedMorphology(object):
         One EM step of the EM algorithm.
         """
         print("starting expectation step")
-        ee, ed, te, td = self.expectation(pool, train_words_chunks)
+        ee = self.expectation(pool, train_words_chunks)
         print("starting maximization step")
-        self.maximization(ee, ed, te, td)
+        self.maximization(ee)
         print("updated parameters after maximization")
         if model_path is not None:
             self.save(model_path)


### PR DESCRIPTION
Summary:
I noticed that the EM algorithm by essence  maximizes the likelihood of data by undersegmenting every word. In order to fix that, I defined a codebook cost regularizer that penalizes character sequences proportional to their length (preferring shorter sequences translates to smaller codebooks). In other words, if a sequence s has length l, p(s) is multiplied by exp(-(l-1)^c) where c is a configurable constant. I ran experiments with c=2. I removed the morphology classes (prefix/stem/suffix) from HMM because I did not find them super helpful but they slowed down the experiments. Our preliminary results show improvements over baseline but our results lag behind BPE and Morfessor.

Summary of main differences:
* Removed all functions for morpheme tags such as transition probabilities and their corresponding tests.
* Added cost term for length in the emission probabilities.

Differential Revision: D14137022
