### PR TITLE
Support multiple token level features along with source_tokens in translate

### DIFF
--- a/pytorch_translate/common_layers.py
+++ b/pytorch_translate/common_layers.py
@@ -9,9 +9,8 @@ import torch.nn.functional as F
 from fairseq import utils
 from fairseq.models import FairseqIncrementalDecoder, transformer as fairseq_transformer
 from pytorch_translate import rnn_cell  # noqa
-from pytorch_translate import vocab_reduction
+from pytorch_translate import utils as pytorch_translate_utils, vocab_reduction
 from pytorch_translate.research.lexical_choice import lexical_translation
-
 
 class ContextEmbedding(nn.Module):
     """
@@ -598,9 +597,10 @@ class TransformerEmbedding(nn.Module):
     def forward(self, src_tokens, src_lengths):
         # Embed tokens
         x = self.embed_tokens(src_tokens)
+        src_tokens_tensor = pytorch_translate_utils.get_source_tokens_tensor(src_tokens)
         # Add position embeddings and dropout
         x = self.embed_scale * x
-        positions = self.embed_positions(src_tokens)
+        positions = self.embed_positions(src_tokens_tensor)
         x += positions
         x = F.dropout(x, p=self.dropout, training=self.training)
 
@@ -608,7 +608,7 @@ class TransformerEmbedding(nn.Module):
         x = x.transpose(0, 1)
 
         # compute padding mask (B x T)
-        encoder_padding_mask = src_tokens.eq(self.padding_idx)
+        encoder_padding_mask = src_tokens_tensor.eq(self.padding_idx)
         if not encoder_padding_mask.any():
             encoder_padding_mask = None
 

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -50,7 +50,9 @@ def reorder_encoder_output(encoder_out, new_order):
     final_hiddens = final_hiddens.index_select(1, new_order)
     final_cells = final_cells.index_select(1, new_order)
     src_lengths = src_lengths.index_select(0, new_order)
-    src_tokens = src_tokens.index_select(0, new_order)
+    src_tokens = pytorch_translate_utils.get_source_tokens_tensor(
+        src_tokens
+    ).index_select(0, new_order)
     src_embeddings = src_embeddings.index_select(1, new_order)
     return (
         unpacked_output,
@@ -801,7 +803,9 @@ class LSTMSequenceEncoder(FairseqEncoder):
         # some internal variables
         self.tracker.reset()
 
-        bsz, seqlen = src_tokens.size()
+        bsz, seqlen = pytorch_translate_utils.get_source_tokens_tensor(
+            src_tokens
+        ).size()
 
         # embed tokens
         x = self.embed_tokens(src_tokens)
@@ -939,7 +943,9 @@ class RNNEncoder(FairseqEncoder):
             src_tokens = utils.convert_padding_direction(
                 src_tokens, self.padding_idx, left_to_right=True
             )
-        bsz, seqlen = src_tokens.size()
+        bsz, seqlen = pytorch_translate_utils.get_source_tokens_tensor(
+            src_tokens
+        ).size()
 
         # embed tokens
         x = self.embed_tokens(src_tokens)

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -15,7 +15,7 @@ from fairseq.models import (
     transformer as fairseq_transformer,
 )
 from fairseq.modules import AdaptiveSoftmax, SinusoidalPositionalEmbedding
-from pytorch_translate import vocab_reduction
+from pytorch_translate import utils as pytorch_translate_utils, vocab_reduction
 from pytorch_translate.common_layers import (
     TransformerEmbedding,
     TransformerEncoderGivenEmbeddings,
@@ -294,13 +294,14 @@ class TransformerEncoder(FairseqEncoder):
 
     def reorder_encoder_out(self, encoder_out, new_order):
         (x, src_tokens, encoder_padding_mask) = encoder_out
+        src_tokens_tensor = pytorch_translate_utils.get_source_tokens_tensor(src_tokens)
         if x is not None:
             x = x.index_select(1, new_order)
-        if src_tokens is not None:
-            src_tokens = src_tokens.index_select(0, new_order)
+        if src_tokens_tensor is not None:
+            src_tokens_tensor = src_tokens_tensor.index_select(0, new_order)
         if encoder_padding_mask is not None:
             encoder_padding_mask = encoder_padding_mask.index_select(0, new_order)
-        return (x, src_tokens, encoder_padding_mask)
+        return (x, src_tokens_tensor, encoder_padding_mask)
 
     def max_positions(self):
         """Maximum input length supported by the encoder."""

--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -280,3 +280,20 @@ def all_gather_from_master(args, data: List) -> List:
                 )
         output_data.append(master_data)
     return output_data
+
+
+def get_source_tokens_tensor(src_tokens):
+    """
+    To enable integration with PyText, src_tokens should be able to support
+    more features than just token embeddings. Hence when dictionary features are
+    passed from PyText it will be passed as a tuple
+    (token_embeddings, dict_feat, ..). Thus, in this case where we need the source
+    tokens tensor (eg to calculate batch size = source_tokens_tensor.size(0)),
+    we get the first element on the tuple which is always guaranteed
+    to be source tokens and do the necessary operation.
+    eg : bsz, _ = get_source_tokens_tensor(source_tokens)[0].size(0)
+    """
+    if type(src_tokens) is tuple:
+        return src_tokens[0]
+    else:
+        return src_tokens


### PR DESCRIPTION
Summary:
To enable integration with PyText, src_tokens should be able to support more features than just token embeddings. Hence when dictionary features arepassed from PyText it will be passed as a tuple (token_embeddings, dict_feat, ..).

Thus, in this case where we need the source tokens tensor (eg to calculate batch size = source_tokens_tensor.size(0)), we get the first element on the tuple which is always guaranteed to be source tokens and do the necessary operation.

eg : bsz, _ = get_source_tokens_tensor(source_tokens)[0].size(0)

Let us know what you think.

Differential Revision: D14310571
