### PR TITLE
Parameter holder for the bilingual model

### DIFF
--- a/pytorch_translate/research/test/test_unsupervised_bilingual_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_bilingual_morphology.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import shutil
+import tempfile
+import unittest
+from os import path
+
+from pytorch_translate.research.unsupervised_morphology.unsupervised_bilingual_morphology import (
+    BilingualMorphologyHMMParams,
+)
+
+
+src_txt_content = ["123 124 234 345", "112 122 123 345", "123456789", "123456 456789"]
+dst_txt_content = ["123 124 234 345", "112 122 123 345", "123456789", "123456 456789"]
+
+
+def get_two_tmp_files(content1, content2):
+    tmp_dir = tempfile.mkdtemp()
+    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
+    f1 = open(file1, "w")
+    f1.write(content1)
+    f1.close()
+
+    f2 = open(file2, "w")
+    f2.write(content2)
+    f2.close()
+
+    return tmp_dir, file1, file2
+
+
+class TestUnsupervisedMorphology(unittest.TestCase):
+    def test_morph_init(self):
+        morph_hmm_model = BilingualMorphologyHMMParams()
+
+        tmp_dir, f1, f2 = get_two_tmp_files(
+            "\n".join(src_txt_content), "\n".join(dst_txt_content)
+        )
+        morph_hmm_model.init_params_from_data(f1, f2)
+        print(len(morph_hmm_model.morph_emit_probs))
+        assert len(morph_hmm_model.morph_emit_probs) == 200
+        assert round(morph_hmm_model.morph_emit_probs["1234"], 3) == round(
+            0.0062799043062200955, 3
+        )
+        assert round(morph_hmm_model.translation_probs["1234"]["1234"], 3) == 1.0 / 200
+        shutil.rmtree(tmp_dir)
+
+    def test_zero_out_params(self):
+        morph_hmm_model = BilingualMorphologyHMMParams()
+
+        tmp_dir, f1, f2 = get_two_tmp_files(
+            "\n".join(src_txt_content), "\n".join(dst_txt_content)
+        )
+        morph_hmm_model.init_params_from_data(f1, f2)
+        for morph in morph_hmm_model.translation_probs.keys():
+            assert morph_hmm_model.morph_emit_probs[morph] > 0
+            for target_morph in morph_hmm_model.translation_probs.keys():
+                assert morph_hmm_model.translation_probs[morph][target_morph] > 0
+
+        morph_hmm_model.zero_out_parmas()
+        for morph in morph_hmm_model.morph_emit_probs.keys():
+            assert morph_hmm_model.morph_emit_probs[morph] == 0
+            for target_morph in morph_hmm_model.translation_probs.keys():
+                assert morph_hmm_model.translation_probs[morph][target_morph] == 0
+        shutil.rmtree(tmp_dir)
+
+    def test_save_load(self):
+        morph_hmm_model = BilingualMorphologyHMMParams()
+
+        tmp_dir, f1, f2 = get_two_tmp_files(
+            "\n".join(src_txt_content), "\n".join(dst_txt_content)
+        )
+        morph_hmm_model.init_params_from_data(f1, f2)
+        morph_hmm_model.save(path.join(tmp_dir, "test.pickle"))
+        loaded_params = BilingualMorphologyHMMParams.load(
+            path.join(tmp_dir, "test.pickle")
+        )
+
+        assert morph_hmm_model.morph_emit_probs == loaded_params.morph_emit_probs
+        assert morph_hmm_model.smoothing_const == loaded_params.smoothing_const
+        assert morph_hmm_model.SMALL_CONST == loaded_params.SMALL_CONST
+        assert morph_hmm_model.len_cost_pow == loaded_params.len_cost_pow
+        assert morph_hmm_model.max_morph_len == loaded_params.max_morph_len
+        assert morph_hmm_model.translation_probs == loaded_params.translation_probs
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/unsupervised_morphology/unsupervised_bilingual_morphology.py
+++ b/pytorch_translate/research/unsupervised_morphology/unsupervised_bilingual_morphology.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import copy
+import pickle
+from collections import defaultdict
+from typing import Dict
+
+from pytorch_translate.research.unsupervised_morphology import unsupervised_morphology
+
+
+class BilingualMorphologyHMMParams(unsupervised_morphology.MorphologyHMMParams):
+    def __init__(
+        self,
+        smoothing_const: float = 0.1,
+        max_morph_len: int = 8,
+        len_cost_pow: float = 2,
+    ):
+        """
+        This class contains unigram HMM probabilities plus translation to the
+            target language morphology.
+        Args:
+            * smoothing_const: For smoothing the categorical distribution. This is
+            mostly useful for unseen observations outside training.
+            * max_morph_len: maximum allowed size of a morpheme.
+            * len_cost_pow: used for penalizing long char sequences. Here we use
+                it in emission as exp(- math.pow(len(str)-1, len_cost_pow))
+        """
+        super().__init__(smoothing_const, max_morph_len, len_cost_pow)
+
+        # Probability of translating morpheme x in source to different possible
+        # values y in target: t(y|x)
+        self.translation_probs: Dict[str, Dict] = defaultdict()
+
+    def init_params_from_data(self, source_txt_file, target_txt_file):
+        """
+        We should obtain a list of all possible morphemes from parallel data.
+        Args:
+            source_txt_file: Source text file with the same number of line as
+                target_txt_file.
+            target_txt_file: Target text file of the parallel data.
+        """
+        super().init_params_from_data(input_file_path=source_txt_file)
+
+        target_morphs = set()
+        with open(target_txt_file, "r", encoding="utf-8") as input_stream:
+            for line in input_stream:
+                sen = line.strip()
+                for i in range(0, len(sen)):
+                    for j in range(i, min(i + self.max_morph_len, len(sen))):
+                        target_morphs.add(sen[i : j + 1])
+
+        # We just initialize the translation probabilities uniformly.
+        self.translation_probs: Dict[str, Dict] = defaultdict()
+        uniform_target_proabibility = {
+            morph: 1.0 / len(self.morph_emit_probs) for morph in target_morphs
+        }
+        for source_morph in self.morph_emit_probs.keys():
+            self.translation_probs[source_morph] = copy.deepcopy(
+                uniform_target_proabibility
+            )
+
+    def zero_out_parmas(self):
+        """
+        Resets parameter values for all parameters.
+        """
+        super().zero_out_parmas()
+        for morpheme in self.translation_probs.keys():
+            for target_morpheme in self.translation_probs[morpheme].keys():
+                self.translation_probs[morpheme][target_morpheme] = 0.0
+
+    @staticmethod
+    def load(file_path):
+        with open(file_path, "rb") as f:
+            e, s, lc, mml, tp = pickle.load(f)
+        m = BilingualMorphologyHMMParams(s)
+        m.morph_emit_probs = e
+        m.len_cost_pow = lc
+        m.max_morph_len = mml
+        m.translation_probs = tp
+        return m
+
+    def save(self, file_path):
+        e, s, lc, mml, tp = (
+            self.morph_emit_probs,
+            self.smoothing_const,
+            self.len_cost_pow,
+            self.max_morph_len,
+            self.translation_probs,
+        )
+        with open(file_path, "wb") as f:
+            pickle.dump((e, s, lc, mml, tp), f)


### PR DESCRIPTION
Summary:
In this commit, I added a parameter holder with its corresponding unit tests for bilingual morphology.

In standard morphology, the probability of a word is equal to probability of its corresponding morphemes:
$$p(w=[m_1,...,m_k]) = \prod_{i=1}^{k} p(m_i)$$

Here we add an alignment link to the target language (similar to IBM model 1):
$$p(w=[m_1,...,m_k]) = \prod_{i=1}^{k} p(m_i) \sum_{j=1}^{n} t(f_j | m_i)$$

where f_j is the jth morpheme in the target sentence.

Some info on IBM model 1 (note that the vanilla IBM model 1 is word-based but here we are going to deal with morphemes):
http://www.cs.columbia.edu/~mcollins/courses/nlp2011/notes/ibm12.pdf

Differential Revision: D14333029
