### PR TITLE
dual-decoder KD: support ONNX export

### DIFF
--- a/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_model.py
+++ b/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_model.py
@@ -10,7 +10,7 @@ from pytorch_translate.utils import torch_find
 
 @register_model("dual_decoder_kd")
 class DualDecoderKDModel(FairseqModel):
-    def __init__(self, task, encoder, student_decoder, teacher_decoder):
+    def __init__(self, task, encoder, teacher_decoder, student_decoder):
         super().__init__(encoder, student_decoder)
         self.teacher_decoder = teacher_decoder
         self.student_decoder = student_decoder
@@ -106,7 +106,12 @@ class DualDecoderKDModel(FairseqModel):
             args, src_dict, tgt_dict, student_decoder_embed_tokens
         )
 
-        return DualDecoderKDModel(task, encoder, teacher_decoder, student_decoder)
+        return DualDecoderKDModel(
+            task=task,
+            encoder=encoder,
+            teacher_decoder=teacher_decoder,
+            student_decoder=student_decoder,
+        )
 
     def get_targets(self, sample, net_output):
         targets = sample["target"].view(-1)

--- a/pytorch_translate/test/test_onnx.py
+++ b/pytorch_translate/test/test_onnx.py
@@ -23,6 +23,9 @@ from pytorch_translate.ensemble_export import (
     ForcedDecoder,
     merge_transpose_and_batchmatmul,
 )
+from pytorch_translate.research.knowledge_distillation import (  # noqa
+    dual_decoder_kd_model,
+)
 from pytorch_translate.tasks import pytorch_translate_task as tasks
 from pytorch_translate.test import utils as test_utils
 
@@ -551,3 +554,17 @@ class TestONNX(unittest.TestCase):
             test_args, return_caffe2_rep=True
         )
         merge_transpose_and_batchmatmul(caffe2_rep)
+
+    def test_ensemble_encoder_export_dual_decoder(self):
+        test_args = test_utils.ModelParamsDict(arch="dual_decoder_kd")
+        self._test_ensemble_encoder_export(test_args)
+
+    def test_batched_beam_decoder_dual_decoder_vocab_reduction(self):
+        test_args = test_utils.ModelParamsDict(arch="dual_decoder_kd")
+        lexical_dictionaries = test_utils.create_lexical_dictionaries()
+        test_args.vocab_reduction_params = {
+            "lexical_dictionaries": lexical_dictionaries,
+            "num_top_words": 5,
+            "max_translation_candidates_per_word": 1,
+        }
+        self._test_batched_beam_decoder_step(test_args)


### PR DESCRIPTION
Summary: Adds support ONNX export for `DualDecoderKDModel` and adds unit tests for same.. Also fixes discrepancy between constructor argument order and call site, which now uses named arguments.

Differential Revision: D14356750
