### PR TITLE
fix argument passing in testing EM for morphology

### DIFF
--- a/pytorch_translate/research/test/test_unsupervised_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_morphology.py
@@ -225,7 +225,7 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
                 "no_exist_file.txt", smoothing_const=0.0
             )
-            unsupervised_model.expectation_maximization(10, 10)
+            unsupervised_model.expectation_maximization("no_exist_file.txt", 10, 10)
 
         # Running with Viterbi-EM.
         with patch("builtins.open") as mock_open:
@@ -234,7 +234,7 @@ class TestUnsupervisedMorphology(unittest.TestCase):
             unsupervised_model = unsupervised_morphology.UnsupervisedMorphology(
                 "no_exist_file.txt", smoothing_const=0.0, use_hardEM=True
             )
-            unsupervised_model.expectation_maximization(10, 10)
+            unsupervised_model.expectation_maximization("no_exist_file.txt", 10, 10)
 
     def test_get_expectations_from_viterbi(self):
         with patch("builtins.open") as mock_open:

--- a/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
+++ b/pytorch_translate/research/unsupervised_morphology/unsupervised_morphology.py
@@ -328,7 +328,11 @@ class UnsupervisedMorphology(object):
                 self.params.morph_emit_probs[morpheme] = 1.0 / num_morphs
 
     def expectation_maximization(
-        self, input_file_path, num_iters, num_cpus=10, model_path=None
+        self,
+        input_file_path: str,
+        num_iters: int,
+        num_cpus: int = 10,
+        model_path: str = None,
     ):
         """
         Runs the EM algorithm.


### PR DESCRIPTION
Summary: A simple fix in the testing: it used to be a wrong passing of morphology.

Differential Revision: D14431773
