### PR TITLE
dual-decoder: teacher_probs.detach()

### DIFF
--- a/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_loss.py
+++ b/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_loss.py
@@ -56,6 +56,8 @@ class DualDecoderCriterion(FairseqCriterion):
             model, teacher_output, sample, reduce=reduce
         )
 
+        # do not propagate gradient from student loss to teacher output
+        teacher_probs = teacher_probs.detach()
         student_loss, student_nll_loss = self.compute_student_loss(
             model, student_output, sample, teacher_probs, reduce=reduce
         )


### PR DESCRIPTION
Summary: We need to call `detach()` on the teacher decoder's output probabilities, which are used as targets for the student decoder (KD loss term) to prevent back-propagation of gradient from that loss term into the teacher decoder (effectively encouraging the teacher output to look like the student's).

Differential Revision: D14461148
