### PR TITLE
Remove unnecessary(!) and confusing vocab requirement from generate.par

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -585,12 +585,6 @@ def validate_args(args):
     pytorch_translate_options.validate_generation_args(args)
 
     assert args.path is not None, "--path required for generation!"
-    assert args.source_vocab_file and os.path.isfile(
-        args.source_vocab_file
-    ), "Please specify a valid file for --source-vocab-file"
-    assert args.target_vocab_file and os.path.isfile(
-        args.target_vocab_file
-    ), "Please specify a valid file for --target-vocab_file"
     if args.source_binary_file != "":
         assert args.target_binary_file != ""
         assert os.path.isfile(args.source_binary_file)


### PR DESCRIPTION
Summary: These assertions seem unnecessary (tracked but couldn't find a usage, works fine without), but more importantly they are confusing for the user. Users are not supposed to provide vocab during generation, they provide a checkpoint which contains a vocab. These forced vocab parameter creates the false illusion of doing something, but its quite the contrary.

Reviewed By: jhcross

Differential Revision: D14554127
