### PR TITLE
Fix failure in generation in case of empty iterator

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -126,6 +126,9 @@ class SequenceGenerator(object):
             maxlen_b = self.maxlen
 
         for sample in data_itr:
+            if 'net_input' not in sample:
+                continue
+
             if cuda:
                 s = utils.move_to_cuda(sample)
             else:


### PR DESCRIPTION
Summary: Our generate binary fails in case of empty input in iterator. This happens when use sharded iterator, samples are not guaranteed to have inputs. Early exiting iterator similar to fairseq solution.

Differential Revision: D14571815
