### PR TITLE
bilingual morphology (word-level) part 4 -> [ibm model1 -- part 3]

### DIFF
--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -76,3 +76,18 @@ class TestIBMModel1(unittest.TestCase):
         )
 
         shutil.rmtree(tmp_dir)
+
+    def test_ibm_train(self):
+        ibm_model = IBMModel1()
+
+        tmp_dir, f1, f2 = get_two_tmp_files()
+        ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
+
+        assert ibm_model.translation_prob["456789"]["345"] == 0
+        assert ibm_model.translation_prob["456789"]["456789"] == 0.5
+        assert (
+            ibm_model.translation_prob[ibm_model.null_str]["124"]
+            < ibm_model.translation_prob[ibm_model.null_str]["456789"]
+        )
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -32,6 +32,17 @@ class IBMModel1(object):
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
 
+    def learn_ibm_parameters(self, src_path: str, dst_path: str, num_iters: int):
+        """
+        Runs the EM algorithm for IBM model 1.
+        Args:
+            num_iters: Number of EM iterations.
+        """
+        self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
+        for iter in range(num_iters):
+            print("Iteration of IBM model(1):", str(iter + 1))
+            self.em_step(src_path=src_path, dst_path=dst_path)
+
     def em_step(self, src_path: str, dst_path: str):
         translation_expectations = defaultdict()
 

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from collections import defaultdict
+from typing import Dict, List
 
 
 class IBMModel1(object):
@@ -12,7 +13,7 @@ class IBMModel1(object):
         self.translation_prob = defaultdict()
         self.null_str = "<null>"
 
-    def initialize_translation_probs(self, src_path, dst_path):
+    def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
         """
@@ -30,3 +31,47 @@ class IBMModel1(object):
             denom = len(self.translation_prob[src_word])
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
+
+    def em_step(self, src_path: str, dst_path: str):
+        translation_expectations = defaultdict()
+
+        with open(src_path) as src_file, open(dst_path) as dst_file:
+            for src_line, dst_line in zip(src_file, dst_file):
+                src_words = src_line.strip().split() + [self.null_str]
+                dst_words = dst_line.strip().split()
+                self.e_step(src_words, dst_words, translation_expectations)
+        self.m_step(translation_expectations)
+
+    def e_step(self, src_words: List, dst_words: List, translation_expectations: Dict):
+        """
+        Args:
+            translation_expectations: holder of expectations until now. This method
+                should update this
+        """
+        denom = defaultdict(float)
+        nominator = defaultdict(float)
+
+        for src_word in src_words:
+            if src_word not in nominator:
+                nominator[src_word] = defaultdict(float)
+
+            for dst_word in dst_words:
+                denom[src_word] += self.translation_prob[src_word][dst_word]
+                nominator[src_word][dst_word] += self.translation_prob[src_word][
+                    dst_word
+                ]
+
+        for src_word in nominator.keys():
+            if src_word not in translation_expectations:
+                translation_expectations[src_word] = defaultdict(float)
+            for dst_word in nominator[src_word].keys():
+                delta = nominator[src_word][dst_word] / denom[src_word]
+                translation_expectations[src_word][dst_word] += delta
+
+    def m_step(self, translation_expectations):
+        for src_word in translation_expectations.keys():
+            denom = sum(translation_expectations[src_word].values())
+            for dst_word in translation_expectations[src_word].keys():
+                self.translation_prob[src_word][dst_word] = (
+                    translation_expectations[src_word][dst_word] / denom
+                )


### PR DESCRIPTION
Summary:
Training for IBM model 1.

An important note: this implementation is single-process. We could make it multi-process (for the E step) to make it more efficient. This is mostly a proof-of-concept code.

Differential Revision: D14656358
