### PR TITLE
bilingual morphology (word-level) part 5

### DIFF
--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -76,3 +76,18 @@ class TestIBMModel1(unittest.TestCase):
         )
 
         shutil.rmtree(tmp_dir)
+
+    def test_ibm_train(self):
+        ibm_model = IBMModel1()
+
+        tmp_dir, f1, f2 = get_two_tmp_files()
+        ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
+
+        assert ibm_model.translation_prob["456789"]["345"] == 0
+        assert ibm_model.translation_prob["456789"]["456789"] == 0.5
+        assert (
+            ibm_model.translation_prob[ibm_model.null_str]["124"]
+            < ibm_model.translation_prob[ibm_model.null_str]["456789"]
+        )
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import shutil
+import tempfile
+import unittest
+from os import path
+
+from pytorch_translate.research.unsupervised_morphology.ibm_model1 import IBMModel1
+
+
+def get_two_tmp_files():
+    src_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    dst_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
+    tmp_dir = tempfile.mkdtemp()
+    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
+    with open(file1, "w") as f1:
+        f1.write(content1)
+    with open(file2, "w") as f2:
+        f2.write(content2)
+
+    return tmp_dir, file1, file2
+
+
+class TestIBMModel1(unittest.TestCase):
+    def test_morph_init(self):
+        ibm_model = IBMModel1()
+
+        tmp_dir, f1, f2 = get_two_tmp_files()
+        ibm_model.initialize_translation_probs(f1, f2)
+        assert len(ibm_model.translation_prob) == 10
+        assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
+        assert len(ibm_model.translation_prob["345"]) == 6
+        assert ibm_model.translation_prob["122"]["123"] == 1.0 / 4
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -39,8 +39,7 @@ class TestIBMModel1(unittest.TestCase):
 
         tmp_dir, f1, f2 = get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
-        assert len(ibm_model.translation_prob) == 10
-        assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
+        assert len(ibm_model.translation_prob) == 9
         assert len(ibm_model.translation_prob["345"]) == 6
         assert ibm_model.translation_prob["122"]["123"] == 1.0 / 4
         shutil.rmtree(tmp_dir)
@@ -53,7 +52,7 @@ class TestIBMModel1(unittest.TestCase):
         translation_counts = defaultdict()
 
         ibm_model.e_step(
-            ["123", "124", "234", "345", ibm_model.null_str],
+            ["123", "124", "234", "345"],
             ["123", "124", "234", "345"],
             translation_counts,
         )
@@ -70,10 +69,6 @@ class TestIBMModel1(unittest.TestCase):
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
-        assert (
-            ibm_model.translation_prob[ibm_model.null_str]["124"]
-            < ibm_model.translation_prob[ibm_model.null_str]["456789"]
-        )
 
         shutil.rmtree(tmp_dir)
 
@@ -85,9 +80,4 @@ class TestIBMModel1(unittest.TestCase):
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
-        assert (
-            ibm_model.translation_prob[ibm_model.null_str]["124"]
-            < ibm_model.translation_prob[ibm_model.null_str]["456789"]
-        )
-
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_unsupervised_bilingual_morphology.py
+++ b/pytorch_translate/research/test/test_unsupervised_bilingual_morphology.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
+import shutil
+import tempfile
 import unittest
+from os import path
 from unittest.mock import Mock, patch
 
 from pytorch_translate.research.unsupervised_morphology import (
@@ -8,23 +11,46 @@ from pytorch_translate.research.unsupervised_morphology import (
 )
 
 
+def get_two_tmp_files():
+    src_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    dst_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
+    tmp_dir = tempfile.mkdtemp()
+    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
+    with open(file1, "w") as f1:
+        f1.write(content1)
+    with open(file2, "w") as f2:
+        f2.write(content2)
+
+    return tmp_dir, file1, file2
+
+
 class TestUnsupervisedBilingualMorphology(unittest.TestCase):
     def test_morph_init(self):
         morph_hmm_model = (
             unsupervised_bilingual_morphology.BilingualMorphologyHMMParams()
         )
-        with patch("builtins.open") as mock_open:
-            txt_content = [
-                "123 124 234 345",
-                "112 122 123 345",
-                "123456789",
-                "123456 456789",
-            ]
-            mock_open.return_value.__enter__ = mock_open
-            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
-            morph_hmm_model.init_params_from_data("no_exist_file.txt")
+        tmp_dir, f1, f2 = get_two_tmp_files()
+        morph_hmm_model.init_params_from_data(
+            src_path=f1, dst_path=f2, num_ibm_iters=3, num_candidate_per_word=2
+        )
+        assert len(morph_hmm_model.alignment_probs) == 7
+        assert len(morph_hmm_model.alignment_probs["123456"]) == 2
+        assert len(morph_hmm_model.alignment_probs["123456789"]) == 1
 
-            assert len(morph_hmm_model.alignment_probs) == 9
-            assert round(morph_hmm_model.morph_emit_probs["1234"], 3) == round(
-                0.014141414141414142, 3
-            )
+        morph_hmm_model.init_params_from_data(
+            src_path=f1, dst_path=f2, num_ibm_iters=3, num_candidate_per_word=10
+        )
+        assert len(morph_hmm_model.alignment_probs) == 9
+        assert len(morph_hmm_model.alignment_probs["123"]) == 6
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -12,7 +12,7 @@ class IBMModel1(object):
         self.translation_prob = defaultdict()
         self.null_str = "<null>"
 
-    def initialize_translation_probs(self, src_path, dst_path):
+    def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
         """
@@ -30,3 +30,47 @@ class IBMModel1(object):
             denom = len(self.translation_prob[src_word])
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
+
+    def em_step(self, src_path: str, dst_path: str):
+        translation_expectations = defaultdict()
+
+        with open(src_path) as src_file, open(dst_path) as dst_file:
+            for src_line, dst_line in zip(src_file, dst_file):
+                src_words = src_line.strip().split() + [self.null_str]
+                dst_words = dst_line.strip().split()
+                self.e_step(src_words, dst_words, translation_expectations)
+        self.m_step(translation_expectations)
+
+    def e_step(self, src_words: list, dst_words: list, translation_expectations: dict):
+        """
+        Args:
+            translation_expectations: holder of expectations until now. This method
+                should update this
+        """
+        denom = defaultdict(float)
+        nominator = defaultdict(float)
+
+        for src_word in src_words:
+            if src_word not in nominator:
+                nominator[src_word] = defaultdict(float)
+
+            for dst_word in dst_words:
+                denom[src_word] += self.translation_prob[src_word][dst_word]
+                nominator[src_word][dst_word] += self.translation_prob[src_word][
+                    dst_word
+                ]
+
+        for src_word in nominator.keys():
+            if src_word not in translation_expectations:
+                translation_expectations[src_word] = defaultdict(float)
+            for dst_word in nominator[src_word].keys():
+                delta = nominator[src_word][dst_word] / denom[src_word]
+                translation_expectations[src_word][dst_word] += delta
+
+    def m_step(self, translation_expectations):
+        for src_word in translation_expectations.keys():
+            denom = sum(translation_expectations[src_word].values())
+            for dst_word in translation_expectations[src_word].keys():
+                self.translation_prob[src_word][dst_word] = (
+                    translation_expectations[src_word][dst_word] / denom
+                )

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -31,6 +31,17 @@ class IBMModel1(object):
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
 
+    def learn_ibm_parameters(self, src_path: str, dst_path: str, num_iters: int):
+        """
+        Runs the EM algorithm for IBM model 1.
+        Args:
+            num_iters: Number of EM iterations.
+        """
+        self.initialize_translation_probs(src_path=src_path,dst_path=dst_path)
+        for iter in range(num_iters):
+            print("Iteration of IBM model(1):", str(iter + 1))
+            self.em_step(src_path=src_path, dst_path=dst_path)
+
     def em_step(self, src_path: str, dst_path: str):
         translation_expectations = defaultdict()
 

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from collections import defaultdict
+
+
+class IBMModel1(object):
+    def __init__(self):
+        """
+        translation_prob is the translation probability in the IBM model 1.
+        the full pseudo-code is available at https://fburl.com/yvp31kuw
+        """
+        self.translation_prob = defaultdict()
+        self.null_str = "<null>"
+
+    def initialize_translation_probs(self, src_path, dst_path):
+        """
+        Direction of translation is conditioned on the source text: t(dst|src).
+        """
+        with open(src_path) as src_file, open(dst_path) as dst_file:
+            for src_line, dst_line in zip(src_file, dst_file):
+                src_words = set(src_line.strip().split() + [self.null_str])
+                dst_words = set(dst_line.strip().split())
+                for src_word in src_words:
+                    if src_word not in self.translation_prob:
+                        self.translation_prob[src_word] = defaultdict(float)
+                    for dst_word in dst_words:
+                        self.translation_prob[src_word][dst_word] = 1.0
+
+        for src_word in self.translation_prob.keys():
+            denom = len(self.translation_prob[src_word])
+            for dst_word in self.translation_prob[src_word].keys():
+                self.translation_prob[src_word][dst_word] = 1.0 / denom

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -10,7 +10,6 @@ class IBMModel1(object):
         the full pseudo-code is available at https://fburl.com/yvp31kuw
         """
         self.translation_prob = defaultdict()
-        self.null_str = "<null>"
 
     def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
@@ -18,7 +17,7 @@ class IBMModel1(object):
         """
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
-                src_words = set(src_line.strip().split() + [self.null_str])
+                src_words = set(src_line.strip().split())
                 dst_words = set(dst_line.strip().split())
                 for src_word in src_words:
                     if src_word not in self.translation_prob:
@@ -37,7 +36,7 @@ class IBMModel1(object):
         Args:
             num_iters: Number of EM iterations.
         """
-        self.initialize_translation_probs(src_path=src_path,dst_path=dst_path)
+        self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
         for iter in range(num_iters):
             print("Iteration of IBM model(1):", str(iter + 1))
             self.em_step(src_path=src_path, dst_path=dst_path)
@@ -47,7 +46,7 @@ class IBMModel1(object):
 
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
-                src_words = src_line.strip().split() + [self.null_str]
+                src_words = src_line.strip().split()
                 dst_words = dst_line.strip().split()
                 self.e_step(src_words, dst_words, translation_expectations)
         self.m_step(translation_expectations)

--- a/pytorch_translate/research/unsupervised_morphology/unsupervised_bilingual_morphology.py
+++ b/pytorch_translate/research/unsupervised_morphology/unsupervised_bilingual_morphology.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 from typing import Dict
 
+from pytorch_translate.research.unsupervised_morphology.ibm_model1 import IBMModel1
 from pytorch_translate.research.unsupervised_morphology.unsupervised_morphology import (
     MorphologyHMMParams,
 )
@@ -20,12 +21,40 @@ class BilingualMorphologyHMMParams(MorphologyHMMParams):
         """
         super().__init__(smoothing_const, len_cost_pow)
 
-        # For every word in the source language, we create a dictionary that gives
-        # us information about the target language words that could be aligned to
-        # them with their corresponding probabilities.
+        # For every word in the target language, we create a dictionary that gives
+        # us information about the source language words that could be aligned to
+        # them with their corresponding probabilities. This comes from IBM model
+        # and is fixed during training.
+        # This is actually p(target|source) but since it is easier to iterate
+        # over target words first, we save it in reverse order.
         self.alignment_probs: Dict[str, Dict] = defaultdict()
 
-    def init_params_from_data(self, src_file_path):
-        super().init_params_from_data(input_file_path=src_file_path)
-        for word in self.word_counts.keys():
-            self.alignment_probs[word] = defaultdict(float)
+    def init_params_from_data(
+        self,
+        src_path: str,
+        dst_path: str,
+        num_ibm_iters: int,
+        num_candidate_per_word: int,
+    ):
+        """
+        Args:
+            num_candidate_per_word: Number of top-k words in the target language
+                as translation candidates.
+        """
+        super().init_params_from_data(input_file_path=src_path)
+        ibm_model = IBMModel1()
+        ibm_model.learn_ibm_parameters(
+            src_path=src_path, dst_path=dst_path, num_iters=num_ibm_iters
+        )
+
+        self.alignment_probs: Dict[str, Dict] = defaultdict()
+        for src_word in ibm_model.translation_prob.keys():
+            topk_pairs = sorted(
+                ibm_model.translation_prob[src_word].items(), key=lambda x: x[1]
+            )[:num_candidate_per_word]
+            denom = sum(p[1] for p in topk_pairs)
+            for candidate in topk_pairs:
+                dst_word, prob = candidate[0], candidate[1] / denom
+                if dst_word not in self.alignment_probs:
+                    self.alignment_probs[dst_word] = defaultdict(float)
+                self.alignment_probs[dst_word][src_word] = prob


### PR DESCRIPTION
Summary:
Initializing p(target | source) in the bilingual model.

Note that I removed the null string from IBM model. In the original IBM model, NULL is a possible translation but it is not useful for us.

Differential Revision: D14656575
