### PR TITLE
Use int64 to store offsets in datasets

### DIFF
--- a/pytorch_translate/char_data.py
+++ b/pytorch_translate/char_data.py
@@ -131,9 +131,9 @@ class InMemoryNumpyWordCharDataset(data.indexed_dataset.IndexedDataset):
                     char_offsets.append(char_offsets[-1] + len(char_inds))
 
         self.word_buffer = np.concatenate(word_array_list)
-        self.word_offsets = np.array(word_offsets, dtype=np.int32)
+        self.word_offsets = np.array(word_offsets, dtype=np.int64)
         self.char_buffer = np.concatenate(char_array_list)
-        self.char_offsets = np.array(char_offsets, dtype=np.int32)
+        self.char_offsets = np.array(char_offsets, dtype=np.int64)
         self.sizes = np.array(sizes, dtype=np.int32)
 
         del word_array_list, word_offsets, char_array_list, char_offsets, sizes

--- a/pytorch_translate/data.py
+++ b/pytorch_translate/data.py
@@ -182,7 +182,7 @@ class InMemoryNumpyDataset(data.indexed_dataset.IndexedDataset):
                         sizes.append(len(inds))
 
         self.buffer = np.concatenate(array_list)
-        self.offsets = np.array(offsets, dtype=np.int32)
+        self.offsets = np.array(offsets, dtype=np.int64)
         self.sizes = np.array(sizes, dtype=np.int32)
         del array_list
         del offsets


### PR DESCRIPTION
Summary:
Due to overflow of numpy int32 because of large number of words in multilingual runs, `offsets` list which stores the indices of beginning of sentences became negative. The batch sampler used these negative numbers as negative indices and produced corrupted batches. As a result, training failed since the final token of (corrupted) sentences was not eos.

See example failure in f104704295

Differential Revision: D14672537
