### PR TITLE
add enforce_sorted as a parameter in BiLSTM forward

### DIFF
--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -1360,14 +1360,18 @@ class BiLSTM(nn.Module):
                 )
             )
 
-    def forward(self, embeddings, lengths):
+    def forward(self, embeddings, lengths, enforce_sorted=True):
+        # enforce_sorted is set to True by default to force input lengths
+        # are sorted in a descending order when pack padded sequence.
         bsz = embeddings.size()[1]
 
         # Generate packed seq to deal with varying source seq length
         # packed_input is of type PackedSequence, which consists of:
         # element [0]: a tensor, the packed data, and
         # element [1]: a list of integers, the batch size for each step
-        packed_input = pack_padded_sequence(embeddings, lengths)
+        packed_input = pack_padded_sequence(
+            embeddings, lengths, enforce_sorted=enforce_sorted
+        )
 
         final_hiddens, final_cells = [], []
         for i, rnn_layer in enumerate(self.layers):


### PR DESCRIPTION
Summary: In NLG scenarios, we would like to build context-aware Fairseq model on top of current RNN-based fairseq model. To reuse the BiLSTM class defined in pytorch_translate/rnn.py, we need tweak its forward function a bit by adding an additional parameter called enforce_sorted. This should not break existing LATTE code as enforce_sorted is set to True by default in pack_padded_sequence.

Differential Revision: D14678830
