### PR TITLE
dual_decoder: arg typo fix

### DIFF
--- a/pytorch_translate/hybrid_transformer_rnn.py
+++ b/pytorch_translate/hybrid_transformer_rnn.py
@@ -453,9 +453,6 @@ def base_architecture(args):
     args.encoder_normalize_before = getattr(args, "encoder_normalize_before", False)
     args.decoder_pretrained_embed = getattr(args, "decoder_pretrained_embed", None)
     args.decoder_embed_dim = getattr(args, "decoder_embed_dim", args.encoder_embed_dim)
-    args.decoder_ffn_embed_dim = getattr(
-        args, "decoder_ffn_embed_dim", args.encoder_ffn_embed_dim
-    )
     args.decoder_layers = getattr(args, "decoder_layers", 2)
     args.decoder_attention_heads = getattr(args, "decoder_attention_heads", 8)
     args.decoder_lstm_units = getattr(args, "decoder_lstm_units", 512)

--- a/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_model.py
+++ b/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_model.py
@@ -142,7 +142,7 @@ class StudentHybridRNNDecoder(hybrid_transformer_rnn.HybridRNNDecoder):
         self.input_dim = self.lstm_units + self.attention_dim
 
         self.num_attention_heads = args.student_decoder_attention_heads
-        self.out_embed_dim = args.student_decoder_attention_heads
+        self.out_embed_dim = args.student_decoder_out_embed_dim
 
 
 @register_model_architecture("dual_decoder_kd", "dual_decoder_kd")

--- a/pytorch_translate/research/test/test_knowledge_distillation.py
+++ b/pytorch_translate/research/test/test_knowledge_distillation.py
@@ -117,3 +117,57 @@ class TestKnowledgeDistillation(unittest.TestCase):
             "ntokens": target_tokens.numel(),
         }
         return sample
+
+    def test_dual_decoder_args(self):
+        test_args = test_utils.ModelParamsDict(arch="dual_decoder_kd")
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        self.task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
+        model = self.task.build_model(test_args)
+
+        assert (
+            model.encoder.transformer_embedding.embed_tokens.embedding_dim
+            == test_args.encoder_embed_dim
+        )
+        assert (
+            model.encoder.transformer_encoder_given_embeddings.layers[
+                0
+            ].fc1.out_features
+            == test_args.encoder_ffn_embed_dim
+        )
+        assert (
+            len(model.encoder.transformer_encoder_given_embeddings.layers)
+            == test_args.encoder_layers
+        )
+        assert (
+            model.encoder.transformer_encoder_given_embeddings.layers[
+                0
+            ].self_attn.num_heads
+            == test_args.encoder_attention_heads
+        )
+        assert (
+            model.teacher_decoder.embed_tokens.embedding_dim
+            == test_args.decoder_embed_dim
+        )
+        assert (
+            model.teacher_decoder.layers[0].fc1.out_features
+            == test_args.decoder_ffn_embed_dim
+        )
+        assert len(model.teacher_decoder.layers) == test_args.decoder_layers
+        assert (
+            model.teacher_decoder.layers[0].self_attn.num_heads
+            == test_args.decoder_attention_heads
+        )
+        assert (
+            model.student_decoder.embed_tokens.embedding_dim
+            == test_args.student_decoder_embed_dim
+        )
+        assert model.student_decoder.num_layers == test_args.student_decoder_layers
+        assert (
+            model.student_decoder.num_attention_heads
+            == test_args.student_decoder_attention_heads
+        )
+        assert model.student_decoder.lstm_units == test_args.student_decoder_lstm_units
+        assert (
+            model.student_decoder.out_embed_dim
+            == test_args.student_decoder_out_embed_dim
+        )


### PR DESCRIPTION
Summary:
Quick fix for picking up the wrong argument in model construction.

Also removes an unused (but innocuous) default args attribute in hybrid model and adds a unit test to ensure model is properly constructed from args.

Differential Revision: D14691063
