### PR TITLE
Fix faulty getattr usage

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -401,9 +401,9 @@ def validate_preprocessing_args(args):
                 or getattr(args, "multiling_train_source_text_file", None)
             )
             and (
-                getattr(args, "train_target_text_file")
-                or getattr(args, "train_target_binary_path")
-                or getattr(args, "multiling_train_target_text_file")
+                getattr(args, "train_target_text_file", None)
+                or getattr(args, "train_target_binary_path", None)
+                or getattr(args, "multiling_train_target_text_file", None)
             )
             and (
                 getattr(args, "eval_source_text_file", None)

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -707,6 +707,20 @@ def expand_generation_args(group, train=False):
         type=str,
         help=("Provide a path for the reverse rescoring model"),
     )
+    group.add_argument(
+        "--enable-lm-rescoring",
+        nargs="?",
+        const=True,
+        default=False,
+        type=utils.bool_flag,
+        help=("Enable language model based rescoring of hypos"),
+    )
+    group.add_argument(
+        "--lm-model-path",
+        default=None,
+        type=str,
+        help=("Provide a path for the language model rescoring model"),
+    )
 
     # These arguments are only used during training
     if train:

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -680,6 +680,12 @@ def expand_generation_args(group, train=False):
         help=("Enable running rescoring during beam decoding"),
     )
     group.add_argument(
+        "--original-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the r2l rescoring model"),
+    )
+    group.add_argument(
         "--enable-r2l-rescoring",
         nargs="?",
         const=True,
@@ -692,6 +698,12 @@ def expand_generation_args(group, train=False):
         default=None,
         type=str,
         help=("Provide a path for the r2l rescoring model"),
+    )
+    group.add_argument(
+        "--r2l-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the r2l rescoring model"),
     )
     group.add_argument(
         "--enable-reverse-rescoring",
@@ -708,6 +720,12 @@ def expand_generation_args(group, train=False):
         help=("Provide a path for the reverse rescoring model"),
     )
     group.add_argument(
+        "--reverse-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the reverse rescoring model"),
+    )
+    group.add_argument(
         "--enable-lm-rescoring",
         nargs="?",
         const=True,
@@ -720,6 +738,12 @@ def expand_generation_args(group, train=False):
         default=None,
         type=str,
         help=("Provide a path for the language model rescoring model"),
+    )
+    group.add_argument(
+        "--lm-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the lm rescoring model"),
     )
 
     # These arguments are only used during training

--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -300,7 +300,4 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
-            dim=1, dtype=torch.float
-        )
-        return hypos_scores
+        return hypos_tokens_probs.sum(dim=1)

--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -35,7 +35,6 @@ class SimpleModelScorer(object):
             utils.maybe_cuda(self.model)
 
     def convert_hypos_to_tgt_tokens(self, hypos):
-        # TODO (T41749218): Add unit tests for rescoring
         """
         hypos is a list of hypotheses containing elements of type dict.
         each hypothesis dictionary contains target tokens.
@@ -58,7 +57,6 @@ class SimpleModelScorer(object):
         return tgt_tokens
 
     def reverse_tgt_tokens(self, tgt_tokens):
-        # TODO (T41749218): Add unit tests for rescoring
         """
         tgt_tokens has paddings to the right since they are batched.
         while reversing, we should roll first to keep paddings.
@@ -80,8 +78,8 @@ class SimpleModelScorer(object):
 
         pad = self.original_task.tgt_dict.pad()
         for i, row in enumerate(tgt_tokens):
-            pad_count = len(row) - sum(row == pad)
-            reversed_tgt_tokens[i] = reversed(roll(row, pad_count))
+            pad_count = sum(row == pad)
+            reversed_tgt_tokens[i] = reversed(roll(row, int(pad_count)))
 
         return reversed_tgt_tokens
 

--- a/pytorch_translate/rescoring/rescorer.py
+++ b/pytorch_translate/rescoring/rescorer.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from enum import Enum
 
-import numpy
+import torch
 from pytorch_translate.rescoring.model_scorers import (
     LMScorer,
     R2LModelScorer,
@@ -46,25 +46,39 @@ class Rescorer:
             ), "Provide --lm-model-path with --enable-lm-scoring"
             self.lm_scorer = LMScorer(args, args.lm_model_path, self.original_task)
 
-    def optimize(self, scores):
+    def optimize(self, scores, src_tokens, hypos):
         """combine scores from different models"""
-        return numpy.argmax(scores.sum(axis=1))
+
+        scores[
+            :, FeatureList.ORIGINAL_MODEL_SCORE.value
+        ] *= self.args.original_model_weight
+        scores[:, FeatureList.R2L_MODEL_SCORE.value] *= self.args.r2l_model_weight
+        scores[
+            :, FeatureList.REVERSE_MODEL_SCORE.value
+        ] *= self.args.reverse_model_weight
+        scores[:, FeatureList.LM_SCORE.value] *= self.args.lm_model_weight
+        return scores.sum(dim=1).max(0)[1]
 
     def score(self, src_tokens, hypos):
         """run models and compute scores based on p(y), p(x|y) etc."""
-        scores = numpy.zeros(shape=(len(hypos), len(FeatureList)))
+        scores = torch.zeros((len(hypos), len(FeatureList)), dtype=torch.float)
 
+        self.compute_original_model_scores(src_tokens, hypos, scores)
         self.compute_r2l_model_scores(src_tokens, hypos, scores)
         self.compute_reverse_model_scores(src_tokens, hypos, scores)
         self.compute_lm_scores(src_tokens, hypos, scores)
 
-        max_score_index = self.optimize(scores)
+        max_score_index = self.optimize(scores, src_tokens, hypos)
         return hypos[max_score_index]["tokens"].int().cpu()
+
+    def compute_original_model_scores(self, src_tokens, hypos, scores):
+        for i, hypo in enumerate(hypos):
+            scores[i, FeatureList.ORIGINAL_MODEL_SCORE.value] = hypo["score"]
 
     def compute_r2l_model_scores(self, src_tokens, hypos, scores):
         if not self.args.enable_r2l_rescoring:
             return
-        r2l_scores = self.r2l_model_scorer.score(src_tokens, hypos).numpy()
+        r2l_scores = self.r2l_model_scorer.score(src_tokens, hypos)
         scores[:, FeatureList.R2L_MODEL_SCORE.value] = r2l_scores[:]
 
     def compute_reverse_model_scores(self, src_tokens, hypos, scores):
@@ -82,5 +96,5 @@ class Rescorer:
         if not self.args.enable_lm_rescoring:
             return
 
-        lm_scores = self.lm_scorer.score(src_tokens, hypos).cpu().numpy()
+        lm_scores = self.lm_scorer.score(src_tokens, hypos)
         scores[:, FeatureList.LM_SCORE.value] = lm_scores[:]

--- a/pytorch_translate/rescoring/test/test_model_scorers.py
+++ b/pytorch_translate/rescoring/test/test_model_scorers.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import patch
+
+import torch
+from pytorch_translate.rescoring.model_scorers import SimpleModelScorer
+from pytorch_translate.tasks import pytorch_translate_task as tasks
+from pytorch_translate.test import utils as test_utils
+
+
+class TestModelScorers(unittest.TestCase):
+    def test_reverse_tgt_tokens(self):
+        test_args = test_utils.ModelParamsDict()
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        task = tasks.PytorchTranslateTask(test_args, src_dict, tgt_dict)
+        model = task.build_model(test_args)
+
+        with patch(
+            "pytorch_translate.utils.load_diverse_ensemble_for_inference",
+            return_value=([model], test_args, task),
+        ):
+            scorer = SimpleModelScorer(test_args, None, task)
+
+            pad = task.tgt_dict.pad()
+            tgt_tokens = torch.Tensor([[1, 2, 3], [1, 2, pad], [1, pad, pad]])
+            expected_tokens = torch.Tensor([[3, 2, 1], [2, 1, pad], [1, pad, pad]])
+            reversed_tgt_tokens = scorer.reverse_tgt_tokens(tgt_tokens)
+            assert torch.equal(reversed_tgt_tokens, expected_tokens)
+
+    def test_convert_hypos_to_tgt_tokens(self):
+        test_args = test_utils.ModelParamsDict()
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        task = tasks.PytorchTranslateTask(test_args, src_dict, tgt_dict)
+        model = task.build_model(test_args)
+
+        with patch(
+            "pytorch_translate.utils.load_diverse_ensemble_for_inference",
+            return_value=([model], test_args, task),
+        ):
+            scorer = SimpleModelScorer(test_args, None, task)
+
+            hypos = [
+                {"tokens": torch.Tensor([1, 2, 3, 4, 5])},
+                {"tokens": torch.Tensor([1, 2, 3, 4])},
+                {"tokens": torch.Tensor([1, 2, 3])},
+                {"tokens": torch.Tensor([1, 2])},
+                {"tokens": torch.Tensor([1])},
+            ]
+            tgt_tokens = scorer.convert_hypos_to_tgt_tokens(hypos)
+
+            pad = task.tgt_dict.pad()
+            eos = task.tgt_dict.eos()
+            expected_tgt_tokens = torch.Tensor(
+                [
+                    [eos, 1, 2, 3, 4, 5],
+                    [eos, 1, 2, 3, 4, pad],
+                    [eos, 1, 2, 3, pad, pad],
+                    [eos, 1, 2, pad, pad, pad],
+                    [eos, 1, pad, pad, pad, pad],
+                ]
+            ).type_as(tgt_tokens)
+            assert torch.equal(tgt_tokens, expected_tgt_tokens)

--- a/pytorch_translate/rescoring/test/test_rescorer.py
+++ b/pytorch_translate/rescoring/test/test_rescorer.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from pytorch_translate.rescoring.rescorer import Rescorer
+from pytorch_translate.tasks import pytorch_translate_task as tasks
+from pytorch_translate.test import utils as test_utils
+
+
+class TestRescorer(unittest.TestCase):
+    def test_optimize(self):
+        test_args = test_utils.ModelParamsDict()
+        test_args.enable_rescoring = True
+        test_args.original_model_weight = 1
+        test_args.r2l_model_weight = 0
+        test_args.reverse_model_weight = 0.5
+        test_args.lm_model_weight = 0.75
+
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
+        rescorer = Rescorer(test_args, task)
+
+        scores = torch.tensor([[10, 20, 30, 40]], dtype=torch.float)
+        src_tokens = torch.tensor([1, 2, 3, 4, 5])
+        hypos = [{"tokens": torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])}]
+        rescorer.optimize(scores, src_tokens, hypos)
+
+        # 10=10., 20*0=0. , 30*(0.5)=15. , 40*(0.75)=30
+        expected = torch.tensor([[10.0, 0.0, 15.0, 30.0]], dtype=torch.float)
+        assert torch.equal(scores, expected)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -106,6 +106,18 @@ class ModelParamsDict:
         self.left_pad_source = "False"
         self.fp16 = False
         self.cpu = None
+        # Rescoring params
+        self.enable_rescoring = False
+        self.original_model_weight = None
+        self.enable_r2l_rescoring = False
+        self.r2l_model_path = None
+        self.r2l_model_weight = None
+        self.enable_reverse_rescoring = False
+        self.reverse_model_path = None
+        self.reverse_model_weight = None
+        self.enable_lm_rescoring = False
+        self.lm_model_path = None
+        self.lm_model_weight = None
         # Modified params
         for param, value in kwargs.items():
             assert hasattr(


### PR DESCRIPTION
Summary: Using getattr without a default value (equivalent to property access) is confusing and causes lint errors randomly in unrelated diffs. Simply fixing it.

Differential Revision: D14736695
