### PR TITLE
Implement weighted scoring of multiple models [6/n]

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -680,6 +680,12 @@ def expand_generation_args(group, train=False):
         help=("Enable running rescoring during beam decoding"),
     )
     group.add_argument(
+        "--original-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the r2l rescoring model"),
+    )
+    group.add_argument(
         "--enable-r2l-rescoring",
         nargs="?",
         const=True,
@@ -692,6 +698,12 @@ def expand_generation_args(group, train=False):
         default=None,
         type=str,
         help=("Provide a path for the r2l rescoring model"),
+    )
+    group.add_argument(
+        "--r2l-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the r2l rescoring model"),
     )
     group.add_argument(
         "--enable-reverse-rescoring",
@@ -708,6 +720,12 @@ def expand_generation_args(group, train=False):
         help=("Provide a path for the reverse rescoring model"),
     )
     group.add_argument(
+        "--reverse-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the reverse rescoring model"),
+    )
+    group.add_argument(
         "--enable-lm-rescoring",
         nargs="?",
         const=True,
@@ -720,6 +738,12 @@ def expand_generation_args(group, train=False):
         default=None,
         type=str,
         help=("Provide a path for the language model rescoring model"),
+    )
+    group.add_argument(
+        "--lm-model-weight",
+        default=1.0,
+        type=float,
+        help=("Provide a weight for the lm rescoring model"),
     )
 
     # These arguments are only used during training

--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -300,7 +300,4 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
-            dim=1, dtype=torch.float
-        )
-        return hypos_scores
+        return hypos_tokens_probs.sum(dim=1)

--- a/pytorch_translate/rescoring/rescorer.py
+++ b/pytorch_translate/rescoring/rescorer.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from enum import Enum
 
-import numpy
+import torch
 from pytorch_translate.rescoring.model_scorers import (
     LMScorer,
     R2LModelScorer,
@@ -46,25 +46,45 @@ class Rescorer:
             ), "Provide --lm-model-path with --enable-lm-scoring"
             self.lm_scorer = LMScorer(args, args.lm_model_path, self.original_task)
 
-    def optimize(self, scores):
+    def combine_weighted_scores(self, scores, src_tokens, hypos):
         """combine scores from different models"""
-        return numpy.argmax(scores.sum(axis=1))
+        src_len = torch.tensor(len(src_tokens), dtype=torch.float)
+        tgt_len = torch.tensor(
+            [len(hypo["tokens"]) for hypo in hypos], dtype=torch.float
+        )
+
+        scores[:, FeatureList.ORIGINAL_MODEL_SCORE.value] *= (
+            self.args.original_model_weight / tgt_len
+        )
+        scores[:, FeatureList.R2L_MODEL_SCORE.value] *= (
+            self.args.r2l_model_weight / tgt_len
+        )
+        scores[:, FeatureList.REVERSE_MODEL_SCORE.value] *= (
+            self.args.reverse_model_weight / src_len
+        )
+        scores[:, FeatureList.LM_SCORE.value] *= self.args.lm_model_weight / src_len
+        return scores.sum(dim=1).max(0)[1]
 
     def score(self, src_tokens, hypos):
         """run models and compute scores based on p(y), p(x|y) etc."""
-        scores = numpy.zeros(shape=(len(hypos), len(FeatureList)))
+        scores = torch.zeros((len(hypos), len(FeatureList)), dtype=torch.float)
 
+        self.compute_original_model_scores(src_tokens, hypos, scores)
         self.compute_r2l_model_scores(src_tokens, hypos, scores)
         self.compute_reverse_model_scores(src_tokens, hypos, scores)
         self.compute_lm_scores(src_tokens, hypos, scores)
 
-        max_score_index = self.optimize(scores)
+        max_score_index = self.combine_weighted_scores(scores, src_tokens, hypos)
         return hypos[max_score_index]["tokens"].int().cpu()
+
+    def compute_original_model_scores(self, src_tokens, hypos, scores):
+        for i, hypo in enumerate(hypos):
+            scores[i, FeatureList.ORIGINAL_MODEL_SCORE.value] = hypo["score"]
 
     def compute_r2l_model_scores(self, src_tokens, hypos, scores):
         if not self.args.enable_r2l_rescoring:
             return
-        r2l_scores = self.r2l_model_scorer.score(src_tokens, hypos).numpy()
+        r2l_scores = self.r2l_model_scorer.score(src_tokens, hypos)
         scores[:, FeatureList.R2L_MODEL_SCORE.value] = r2l_scores[:]
 
     def compute_reverse_model_scores(self, src_tokens, hypos, scores):
@@ -82,5 +102,5 @@ class Rescorer:
         if not self.args.enable_lm_rescoring:
             return
 
-        lm_scores = self.lm_scorer.score(src_tokens, hypos).cpu().numpy()
+        lm_scores = self.lm_scorer.score(src_tokens, hypos)
         scores[:, FeatureList.LM_SCORE.value] = lm_scores[:]

--- a/pytorch_translate/rescoring/test/test_rescorer.py
+++ b/pytorch_translate/rescoring/test/test_rescorer.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from pytorch_translate.rescoring.rescorer import Rescorer
+from pytorch_translate.tasks import pytorch_translate_task as tasks
+from pytorch_translate.test import utils as test_utils
+
+
+class TestRescorer(unittest.TestCase):
+    def test_combine_weighted_scores(self):
+        test_args = test_utils.ModelParamsDict()
+        test_args.enable_rescoring = True
+        test_args.original_model_weight = 1
+        test_args.r2l_model_weight = 0
+        test_args.reverse_model_weight = 0.5
+        test_args.lm_model_weight = 0.75
+
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
+        rescorer = Rescorer(test_args, task)
+
+        scores = torch.tensor([[10, 20, 30, 40]], dtype=torch.float)
+        src_tokens = torch.tensor([1, 2, 3, 4, 5])
+        hypos = [{"tokens": torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])}]
+        rescorer.combine_weighted_scores(scores, src_tokens, hypos)
+
+        # 10/10=1. , 20*0=0. , 30*(0.5/5)=3. , 40*(0.75/5)=6.
+        expected = torch.tensor([[1.0, 0.0, 3.0, 6.0]], dtype=torch.float)
+        assert torch.equal(scores, expected)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -106,6 +106,18 @@ class ModelParamsDict:
         self.left_pad_source = "False"
         self.fp16 = False
         self.cpu = None
+        # Rescoring params
+        self.enable_rescoring = False
+        self.original_model_weight = None
+        self.enable_r2l_rescoring = False
+        self.r2l_model_path = None
+        self.r2l_model_weight = None
+        self.enable_reverse_rescoring = False
+        self.reverse_model_path = None
+        self.reverse_model_weight = None
+        self.enable_lm_rescoring = False
+        self.lm_model_path = None
+        self.lm_model_weight = None
         # Modified params
         for param, value in kwargs.items():
             assert hasattr(


### PR DESCRIPTION
Summary:
* Added ability to provide different weights to different rescoring models.
* Added default p(y|x) model to rescoring models list
* Added unit tests
* Remove previous numpy dependency

Differential Revision: D14494820
