### PR TITLE
Allow reverse rescoring to work on any model [8/n]

### DIFF
--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -298,4 +298,7 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        return hypos_tokens_probs.sum(dim=1)
+        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
+            dim=1, dtype=torch.float
+        )
+        return hypos_scores

--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -229,10 +229,6 @@ class ReverseModelScorer(SimpleModelScorer):
     def __init__(self, args, model_path, original_task):
         super().__init__(args, model_path, original_task)
 
-        assert (original_task.src_dict.indices == self.task.tgt_dict.indices) and (
-            original_task.tgt_dict.indices == self.task.src_dict.indices
-        ), "Original and reverse model dictionaries don't match"
-
     def prepare_inputs(self, src_tokens, hypo):
         """
         For reverse model, we need to switch src_tokens and tgt_tokens.
@@ -241,19 +237,33 @@ class ReverseModelScorer(SimpleModelScorer):
         """
         eos = self.task.target_dictionary.eos()
 
-        # Our decoder expects tgt_tokens to have eos at the beginning and end
-        tgt_tokens = torch.cat(
-            (
-                torch.tensor([eos]).type_as(src_tokens),
-                reversed(src_tokens)
-                if self.task.args.reverse_source
-                == self.original_task.args.reverse_source
-                else src_tokens,
-                torch.tensor([eos]).type_as(src_tokens),
-            ),
-            dim=0,
-        ).view(1, -1)
-        src_tokens = reversed(hypo["tokens"])[1:]  # remove eos
+        # Map token ids from original dictionary to reverse model dictionary
+        src_string = self.original_task.src_dict.string(src_tokens)
+        src_tokens_mapped = self.task.tgt_dict.encode_line(
+            src_string, add_if_not_exist=False
+        )
+
+        tgt_string = self.original_task.tgt_dict.string(hypo["tokens"])
+        tgt_tokens_mapped = self.task.src_dict.encode_line(
+            tgt_string, add_if_not_exist=False
+        )
+
+        # Swap target and source tokens with necessary modifications
+        tgt_tokens = (
+            torch.cat(
+                (
+                    torch.tensor([eos]).type_as(src_tokens_mapped),
+                    reversed(src_tokens_mapped)
+                    if self.task.args.reverse_source
+                    != self.original_task.args.reverse_source
+                    else src_tokens_mapped,
+                ),
+                dim=0,
+            )
+            .view(1, -1)
+            .type_as(src_tokens)
+        )
+        src_tokens = tgt_tokens_mapped[:-1].type_as(src_tokens)
 
         encoder_inputs = self.prepare_encoder_inputs(src_tokens)
         return encoder_inputs, tgt_tokens

--- a/pytorch_translate/rescoring/test/test_model_scorers.py
+++ b/pytorch_translate/rescoring/test/test_model_scorers.py
@@ -4,7 +4,10 @@ import unittest
 from unittest.mock import patch
 
 import torch
-from pytorch_translate.rescoring.model_scorers import SimpleModelScorer
+from pytorch_translate.rescoring.model_scorers import (
+    ReverseModelScorer,
+    SimpleModelScorer,
+)
 from pytorch_translate.tasks import pytorch_translate_task as tasks
 from pytorch_translate.test import utils as test_utils
 
@@ -61,3 +64,34 @@ class TestModelScorers(unittest.TestCase):
                 ]
             ).type_as(tgt_tokens)
             assert torch.equal(tgt_tokens, expected_tgt_tokens)
+
+    def test_reverse_scorer_prepare_inputs(self):
+        test_args = test_utils.ModelParamsDict()
+        _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
+        task = tasks.PytorchTranslateTask(test_args, src_dict, tgt_dict)
+        model = task.build_model(test_args)
+
+        with patch(
+            "pytorch_translate.utils.load_diverse_ensemble_for_inference",
+            return_value=([model], test_args, task),
+        ):
+            scorer = ReverseModelScorer(test_args, None, task)
+
+            src_tokens = torch.tensor([6, 7, 8], dtype=torch.int)
+            hypo = {"tokens": torch.tensor([12, 13, 14], dtype=torch.int)}
+            encoder_inputs, tgt_tokens = scorer.prepare_inputs(src_tokens, hypo)
+
+            # make sure encoder input is equal to hypo target
+            assert torch.equal(encoder_inputs[0][0], hypo["tokens"])
+            # make sure new target is equal to source tokens + eos tokens
+            assert torch.equal(
+                torch.cat(
+                    (
+                        torch.tensor([2], dtype=torch.int),
+                        src_tokens,
+                        torch.tensor([2], dtype=torch.int),
+                    ),
+                    dim=0,
+                ).unsqueeze(dim=0),
+                tgt_tokens,
+            )

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -106,6 +106,7 @@ class ModelParamsDict:
         self.left_pad_source = "False"
         self.fp16 = False
         self.cpu = None
+        self.reverse_source = False
         # Rescoring params
         self.enable_rescoring = False
         self.original_model_weight = None


### PR DESCRIPTION
Summary: Reverse model rescoring currently expects a model with a dictionary identical to the original model. In this diff, I am removing this limitation by converting token ids to string and reverting back.

Differential Revision: D14761210
