### PR TITLE
Bilingual BPE --> part 17 (character ibm_model1 -- part 3)

### DIFF
--- a/pytorch_translate/research/test/morphology_test_utils.py
+++ b/pytorch_translate/research/test/morphology_test_utils.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import tempfile
+from os import path
+
+
+def get_two_tmp_files():
+    src_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    dst_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
+    tmp_dir = tempfile.mkdtemp()
+    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
+    with open(file1, "w") as f1:
+        f1.write(content1)
+    with open(file2, "w") as f2:
+        f2.write(content2)
+
+    return tmp_dir, file1, file2

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import shutil
 import unittest
 
+from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     CharIBMModel1,
 )
@@ -17,3 +19,22 @@ class TestCharIBMModel1(unittest.TestCase):
         assert substrs["5" + char_ibm_model.eow_symbol] == 1
         assert substrs["123"] == 2
         assert "12345" not in substrs
+
+    def test_get_subwords_counts_for_line(self):
+        char_ibm_model = CharIBMModel1(max_subword_len=4)
+
+        substrs = char_ibm_model.get_subword_counts_for_line("123412345 12345")
+        assert len(substrs) == 24
+        assert substrs[char_ibm_model.eow_symbol] == 2
+        assert substrs["5" + char_ibm_model.eow_symbol] == 2
+        assert substrs["123"] == 3
+        assert "12345" not in substrs
+
+    def test_morph_init(self):
+        ibm_model = CharIBMModel1()
+
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        ibm_model.initialize_translation_probs(f1, f2)
+        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
+        assert len(ibm_model.translation_prob) == 80
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -6,38 +6,15 @@ import unittest
 from collections import defaultdict
 from os import path
 
+from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.ibm_model1 import IBMModel1
-
-
-def get_two_tmp_files():
-    src_txt_content = [
-        "123 124 234 345",
-        "112 122 123 345",
-        "123456789",
-        "123456 456789",
-    ]
-    dst_txt_content = [
-        "123 124 234 345",
-        "112 122 123 345",
-        "123456789",
-        "123456 456789",
-    ]
-    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
-    tmp_dir = tempfile.mkdtemp()
-    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
-    with open(file1, "w") as f1:
-        f1.write(content1)
-    with open(file2, "w") as f2:
-        f2.write(content2)
-
-    return tmp_dir, file1, file2
 
 
 class TestIBMModel1(unittest.TestCase):
     def test_morph_init(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         assert len(ibm_model.translation_prob) == 10
         assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
@@ -48,7 +25,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_e_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         translation_counts = defaultdict()
 
@@ -63,7 +40,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_em_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
         ibm_model.em_step(f1, f2)
@@ -80,7 +57,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_ibm_train(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
 
         assert ibm_model.translation_prob["456789"]["345"] == 0

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -10,7 +10,7 @@ class IBMModel1(object):
         translation_prob is the translation probability in the IBM model 1.
         the full pseudo-code is available at https://fburl.com/yvp31kuw
         """
-        self.translation_prob = defaultdict()
+        self.translation_prob = defaultdict(lambda: defaultdict(float))
         self.null_str = "<null>"
 
     def initialize_translation_probs(self, src_path: str, dst_path: str):


### PR DESCRIPTION
Summary: In this diff I wrote the initializer for the subword-based IBM model. In order to decrease code redundancy I create a morphology utils file that is used both in the original IBM model as well the subword-based IBM model.

Differential Revision: D14885790
