### PR TITLE
Faster channel model scoring and testing [10/n]

### DIFF
--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -286,4 +286,7 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        return hypos_tokens_probs.sum(dim=1)
+        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
+            dim=1, dtype=torch.float
+        )
+        return hypos_scores

--- a/pytorch_translate/rescoring/rescorer.py
+++ b/pytorch_translate/rescoring/rescorer.py
@@ -92,10 +92,9 @@ class Rescorer:
         if not self.args.enable_reverse_rescoring:
             return
 
-        for i, hypo in enumerate(hypos):
-            scores[
-                i, FeatureList.REVERSE_MODEL_SCORE.value
-            ] = self.reverse_model_scorer.score(src_tokens, hypo)
+        scores[
+            :, FeatureList.REVERSE_MODEL_SCORE.value
+        ] = self.reverse_model_scorer.score(src_tokens, hypos)
 
     def compute_lm_scores(self, src_tokens, hypos, scores):
         """computes p(x|y) for each hypothesis. """

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -124,6 +124,7 @@ class ModelParamsDict:
         self.fp16 = False
         self.cpu = None
         self.reverse_source = False
+        self.append_eos_to_source = False
         # Rescoring params
         self.enable_rescoring = False
         self.original_model_weight = None


### PR DESCRIPTION
Summary:
A bunch of changes

* Change the way we are preparing encoder_output. Previously we passed src_tokens as a [1, src_len] array and we used reorder_encoder_out to repeat encoder_outs nbest times. I copied this from beam_decode when I started the project, but we don't need this logic as we are not using incremental states. Therefore, I am just making src_tokens [nbest, src_len] now. This makes reverse scoring faster.
* Update reverse_scorer_prepare_input test with the updated logic.

Differential Revision: D14820501
