### PR TITLE
Force length penalty on original scoring

### DIFF
--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -290,4 +290,7 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        return hypos_tokens_probs.sum(dim=1)
+        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
+            dim=1, dtype=torch.float
+        )
+        return hypos_scores

--- a/pytorch_translate/rescoring/rescorer.py
+++ b/pytorch_translate/rescoring/rescorer.py
@@ -24,6 +24,10 @@ class Rescorer:
         self.args = args
         self.original_task = original_task
 
+        assert (
+            self.args.word_reward == 0.0 and self.args.length_penalty != 0.0
+        ), "For rescoring, original model should be scored with length penalty"
+
         if args.enable_r2l_rescoring:
             assert (
                 args.r2l_model_path
@@ -53,9 +57,11 @@ class Rescorer:
             [len(hypo["tokens"]) for hypo in hypos], dtype=torch.float
         )
 
-        scores[:, FeatureList.ORIGINAL_MODEL_SCORE.value] *= (
-            self.args.original_model_weight / tgt_len
-        )
+        scores[
+            :, FeatureList.ORIGINAL_MODEL_SCORE.value
+        ] *= (
+            self.args.original_model_weight
+        )  # Original model score should be length normalized already
         scores[:, FeatureList.R2L_MODEL_SCORE.value] *= (
             self.args.r2l_model_weight / tgt_len
         )


### PR DESCRIPTION
Summary: Currently, we rescore after generation. Original generation should apply length penalty, and we shouldn't reapply it in rescoring.

Differential Revision: D14906687
