### PR TITLE
Fix hybrid transformer state dict update after encoder layernorm rename

### DIFF
--- a/pytorch_translate/common_layers.py
+++ b/pytorch_translate/common_layers.py
@@ -12,6 +12,7 @@ from pytorch_translate import rnn_cell  # noqa
 from pytorch_translate import utils as pytorch_translate_utils, vocab_reduction
 from pytorch_translate.research.lexical_choice import lexical_translation
 
+
 class ContextEmbedding(nn.Module):
     """
     This class implements context-dependent word embeddings as described in
@@ -562,6 +563,11 @@ class TransformerEncoderGivenEmbeddings(nn.Module):
             x = self.output_fc(x)
 
         return x
+
+    def upgrade_state_dict_named(self, state_dict, name):
+        for i in range(len(self.layers)):
+            # update layer norms
+            self.layers[i].upgrade_state_dict_named(state_dict, f"{name}.layers.{i}")
 
 
 def TransformerTokenEmbedding(

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -323,6 +323,9 @@ class TransformerEncoder(FairseqEncoder):
             state_dict[
                 f"{name}.transformer_embedding.embed_positions._float_tensor"
             ] = torch.FloatTensor(1)
+        self.transformer_encoder_given_embeddings.upgrade_state_dict_named(
+            state_dict, f"{name}.transformer_encoder_given_embeddings"
+        )
         return state_dict
 
     def set_gradient_tracking_mode(self, mode=True):


### PR DESCRIPTION
Summary: This diff makes it easier to upgrade the state dict for components that use TransformerEncoderLayer

Differential Revision: D14916941
