### PR TITLE
bi-directional transformer rescoring

### DIFF
--- a/pytorch_translate/research/rescore/cloze_transformer_model.py
+++ b/pytorch_translate/research/rescore/cloze_transformer_model.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from fairseq import options, utils
+from fairseq.models import (
+    FairseqEncoder,
+    FairseqIncrementalDecoder,
+    FairseqModel,
+    register_model,
+    register_model_architecture,
+    transformer as fairseq_transformer,
+)
+from fairseq.modules import AdaptiveSoftmax, SinusoidalPositionalEmbedding
+from pytorch_translate import utils as pytorch_translate_utils, vocab_reduction
+from pytorch_translate.common_layers import (
+    TransformerEmbedding,
+    TransformerEncoderGivenEmbeddings,
+    TransformerTokenEmbedding,
+    VariableTracker,
+)
+from pytorch_translate.semi_supervised import SemiSupervisedModel
+from pytorch_translate.transformer import (
+    TransformerDecoder,
+    TransformerModel,
+    base_architecture,
+    build_embedding,
+)
+from pytorch_translate.utils import torch_find
+
+
+@register_model("cloze_transformer")
+class ClozeTransformerModel(TransformerModel):
+    @classmethod
+    def build_model(cls, args, task):
+        """Build a new model instance."""
+        # make sure that all args are properly defaulted
+        # (in case there are any new ones)
+        cloze_transformer_architecture(args)
+
+        src_dict, tgt_dict = task.source_dictionary, task.target_dictionary
+
+        if args.share_all_embeddings:
+            if src_dict != tgt_dict:
+                raise RuntimeError(
+                    "--share-all-embeddings requires a joined dictionary"
+                )
+            if args.encoder_embed_dim != args.decoder_embed_dim:
+                raise RuntimeError(
+                    "--share-all-embeddings requires --encoder-embed-dim "
+                    "to match --decoder-embed-dim"
+                )
+            if args.decoder_pretrained_embed and (
+                args.decoder_pretrained_embed != args.encoder_pretrained_embed
+            ):
+                raise RuntimeError(
+                    "--share-all-embeddings not compatible with "
+                    "--decoder-pretrained-embed"
+                )
+            encoder_embed_tokens = build_embedding(
+                dictionary=src_dict,
+                embed_dim=args.encoder_embed_dim,
+                path=args.encoder_pretrained_embed,
+                freeze=args.encoder_freeze_embed,
+            )
+            decoder_embed_tokens = encoder_embed_tokens
+            args.share_decoder_input_output_embed = True
+        else:
+            encoder_embed_tokens = build_embedding(
+                dictionary=src_dict,
+                embed_dim=args.encoder_embed_dim,
+                path=args.encoder_pretrained_embed,
+                freeze=args.encoder_freeze_embed,
+            )
+            decoder_embed_tokens = build_embedding(
+                dictionary=tgt_dict,
+                embed_dim=args.decoder_embed_dim,
+                path=args.decoder_pretrained_embed,
+                freeze=args.decoder_freeze_embed,
+            )
+
+        encoder = ClozeTransformerModel.build_encoder(
+            args, src_dict, embed_tokens=encoder_embed_tokens
+        )
+        decoder = ClozeTransformerModel.build_decoder(
+            args, src_dict, tgt_dict, embed_tokens=decoder_embed_tokens
+        )
+        return ClozeTransformerModel(task, encoder, decoder)
+
+    @classmethod
+    def build_decoder(cls, args, src_dict, dst_dict, embed_tokens):
+        return ClozeTransformerDecoder(
+            args, src_dict, dst_dict, embed_tokens=embed_tokens
+        )
+
+
+class ClozeTransformerDecoder(TransformerDecoder):
+    """Cloze-Transformer decoder."""
+
+    def __init__(self, args, src_dict, dst_dict, embed_tokens, left_pad=False):
+        super().__init__(args, src_dict, dst_dict, embed_tokens)
+        assert args.decoder_layers == 1
+
+    def buffered_future_mask(self, tensor):
+        """attend all surounding words except itself
+           [[0, -inf, 0]
+            [0,  0, -inf]
+            [0,  0,   0]]
+        """
+        dim = tensor.size(0)
+        if (
+            not hasattr(self, "_future_mask")
+            or self._future_mask is None
+            or self._future_mask.device != tensor.device
+        ):
+            self._future_mask = torch.triu(
+                utils.fill_with_neg_inf(tensor.new(dim, dim)), 1
+            )
+            self._future_mask = torch.tril(self._future_mask, 1)
+        if self._future_mask.size(0) < dim:
+            self._future_mask = torch.triu(
+                utils.fill_with_neg_inf(self._future_mask.resize_(dim, dim)), 1
+            )
+            self._future_mask = torch.tril(self._future_mask, 1)
+        return self._future_mask[:dim, :dim]
+
+
+@register_model_architecture("cloze_transformer", "cloze_transformer")
+def cloze_transformer_architecture(args):
+    base_architecture(args)

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -50,6 +50,7 @@ from pytorch_translate.research.knowledge_distillation import (  # noqa
     hybrid_dual_decoder_kd_model,
     knowledge_distillation_loss,
 )
+from pytorch_translate.research.rescore import cloze_transformer_model  # noqa
 from pytorch_translate.word_prediction import word_prediction_criterion  # noqa
 from pytorch_translate.word_prediction import word_prediction_model  # noqa
 


### PR DESCRIPTION
Summary:
rescore the generated sentences by bi-directioanl transformer. The idea is predict every word given all surronding words except itself, i.e., p(y_t | y_{\neq t}).
The training strategy is quite like BERT, but don't need to mask any words to avoid self-attention when we only have a single layer (check out FAIR's paper: "Cloze-driven Pretraining of Self-attention Networks")

The loss function keeps unchanged, such as cross entropy. The score of a given hypothesis is \sum log p(y_t | y_{\neq t})

Differential Revision: D14926425
