### PR TITLE
Refactor rescoring to be independent of generation

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -190,7 +190,7 @@ def _generate_score(models, args, task, dataset):
     rescorer = None
     rescoring_bleu_scorer = None
     if args.enable_rescoring:
-        rescorer = Rescorer(args, task)
+        rescorer = Rescorer(args)
         rescoring_bleu_scorer = bleu.Scorer(
             dst_dict.pad(), dst_dict.eos(), dst_dict.unk()
         )

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -694,10 +694,16 @@ def expand_generation_args(group, train=False):
         help=("Enable running rescoring during beam decoding"),
     )
     group.add_argument(
-        "--original-model-weight",
+        "--l2r-model-path",
+        default=None,
+        type=str,
+        help=("Provide a path for the l2r rescoring model"),
+    )
+    group.add_argument(
+        "--l2r-model-weight",
         default=1.0,
         type=float,
-        help=("Provide a weight for the r2l rescoring model"),
+        help=("Provide a weight for the l2r rescoring model"),
     )
     group.add_argument(
         "--enable-r2l-rescoring",

--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -290,4 +290,7 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        return hypos_tokens_probs.sum(dim=1)
+        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
+            dim=1, dtype=torch.float
+        )
+        return hypos_scores

--- a/pytorch_translate/rescoring/test/test_model_scorers.py
+++ b/pytorch_translate/rescoring/test/test_model_scorers.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import torch
 from pytorch_translate.rescoring.model_scorers import (
+    R2LModelScorer,
     ReverseModelScorer,
     SimpleModelScorer,
 )
@@ -23,7 +24,7 @@ class TestModelScorers(unittest.TestCase):
             "pytorch_translate.utils.load_diverse_ensemble_for_inference",
             return_value=([model], test_args, task),
         ):
-            scorer = SimpleModelScorer(test_args, None, task)
+            scorer = R2LModelScorer(test_args, None)
 
             pad = task.tgt_dict.pad()
             tgt_tokens = torch.Tensor([[1, 2, 3], [1, 2, pad], [1, pad, pad]])
@@ -41,7 +42,7 @@ class TestModelScorers(unittest.TestCase):
             "pytorch_translate.utils.load_diverse_ensemble_for_inference",
             return_value=([model], test_args, task),
         ):
-            scorer = SimpleModelScorer(test_args, None, task)
+            scorer = SimpleModelScorer(test_args, None)
 
             hypos = [
                 {"tokens": torch.Tensor([1, 2, 3, 4, 5])},
@@ -76,7 +77,7 @@ class TestModelScorers(unittest.TestCase):
             "pytorch_translate.utils.load_diverse_ensemble_for_inference",
             return_value=([model], test_args, task),
         ):
-            scorer = SimpleModelScorer(test_args, None, task)
+            scorer = SimpleModelScorer(test_args, None)
             tgt_tokens = torch.tensor([[2, 11, 22, 0], [2, 33, 44, 55]])
             logprobs = torch.zeros(
                 tgt_tokens.shape[0], tgt_tokens.shape[1], len(tgt_dict)

--- a/pytorch_translate/rescoring/test/test_rescorer.py
+++ b/pytorch_translate/rescoring/test/test_rescorer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
+from unittest.mock import patch
 
 import torch
 from pytorch_translate.rescoring.rescorer import Rescorer
@@ -14,19 +15,27 @@ class TestRescorer(unittest.TestCase):
         test_args.enable_rescoring = True
         test_args.length_penalty = 1
         test_args.original_model_weight = 1
+        test_args.l2r_model_path = ""
+        test_args.l2r_model_weight = 1
         test_args.r2l_model_weight = 0
         test_args.reverse_model_weight = 0.5
         test_args.lm_model_weight = 0.75
+        test_args.length_penalty = 1
 
         _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
-        task = tasks.DictionaryHolderTask(src_dict, tgt_dict)
-        rescorer = Rescorer(test_args, task)
+        task = tasks.PytorchTranslateTask(test_args, src_dict, tgt_dict)
+        model = task.build_model(test_args)
+        with patch(
+            "pytorch_translate.utils.load_diverse_ensemble_for_inference",
+            return_value=([model], test_args, task),
+        ):
+            rescorer = Rescorer(test_args)
 
-        scores = torch.tensor([[10, 20, 30, 40]], dtype=torch.float)
-        src_tokens = torch.tensor([1, 2, 3, 4, 5])
-        hypos = [{"tokens": torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])}]
-        rescorer.combine_weighted_scores(scores, src_tokens, hypos)
+            scores = torch.tensor([[10, 20, 30, 40]], dtype=torch.float)
+            src_tokens = torch.tensor([1, 2, 3, 4, 5])
+            hypos = [{"tokens": torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])}]
+            rescorer.combine_weighted_scores(scores, src_tokens, hypos)
 
-        # 10/1=10. , 20*0=0. , 30*(0.5/5)=3. , 40*(0.75/5)=6.
-        expected = torch.tensor([[10.0, 0.0, 3.0, 6.0]], dtype=torch.float)
-        assert torch.equal(scores, expected)
+            # 10=1. , 20*0=0. , 30*(0.5/5)=3. , 40*(0.75/5)=6.
+            expected = torch.tensor([[10.0, 0.0, 3.0, 6.0]], dtype=torch.float)
+            assert torch.equal(scores, expected)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -129,7 +129,8 @@ class ModelParamsDict:
         self.length_penalty = 0.0
         # Rescoring params
         self.enable_rescoring = False
-        self.original_model_weight = None
+        self.l2r_model_path = None
+        self.l2r_model_weight = None
         self.enable_r2l_rescoring = False
         self.r2l_model_path = None
         self.r2l_model_weight = None


### PR DESCRIPTION
Summary:
A bunch of changes
* Move reverse_tgt_tokens from SimpleModelScorer to where its used(R2LModelScorer). Update test accordingly.
* Get rid of passing original_task to SimpleModelScorer initializer. Previously we were using this to get arguments or special tokens of original model which generated the hypotheses. Now,  ReverseModel or LMScorer require forward_task to find those special tokens.
* Change feature name ORIGINAL_MODEL_SCORE to L2R_MODEL_SCORE, as the name ORIGINAL is vague.
* Expect l2r model path, since now we are supposed to run rescoring independent, which means, we can't rely on --path any more.

Differential Revision: D14935847
