### PR TITLE
Fix failing test_scorer test

### DIFF
--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -290,4 +290,7 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        return hypos_tokens_probs.sum(dim=1)
+        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
+            dim=1, dtype=torch.float
+        )
+        return hypos_scores

--- a/pytorch_translate/rescoring/test/test_rescorer.py
+++ b/pytorch_translate/rescoring/test/test_rescorer.py
@@ -12,6 +12,7 @@ class TestRescorer(unittest.TestCase):
     def test_combine_weighted_scores(self):
         test_args = test_utils.ModelParamsDict()
         test_args.enable_rescoring = True
+        test_args.length_penalty = 1
         test_args.original_model_weight = 1
         test_args.r2l_model_weight = 0
         test_args.reverse_model_weight = 0.5
@@ -26,6 +27,6 @@ class TestRescorer(unittest.TestCase):
         hypos = [{"tokens": torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])}]
         rescorer.combine_weighted_scores(scores, src_tokens, hypos)
 
-        # 10/10=1. , 20*0=0. , 30*(0.5/5)=3. , 40*(0.75/5)=6.
-        expected = torch.tensor([[1.0, 0.0, 3.0, 6.0]], dtype=torch.float)
+        # 10/1=10. , 20*0=0. , 30*(0.5/5)=3. , 40*(0.75/5)=6.
+        expected = torch.tensor([[10.0, 0.0, 3.0, 6.0]], dtype=torch.float)
         assert torch.equal(scores, expected)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -125,6 +125,8 @@ class ModelParamsDict:
         self.cpu = None
         self.reverse_source = False
         self.append_eos_to_source = False
+        self.word_reward = 0.0
+        self.length_penalty = 0.0
         # Rescoring params
         self.enable_rescoring = False
         self.original_model_weight = None


### PR DESCRIPTION
Summary: https://our.intern.facebook.com/intern/test/281474988393180?ref_report_id=0  has been failing after latest changes. The reason is because our test class didn't have the same params. And also we changed the logic without updating corresponding test.

Differential Revision: D14941067

