### PR TITLE
Bilingual BPE --> part 21 ( bilingual part 1)

### DIFF
--- a/pytorch_translate/research/test/morphology_test_utils.py
+++ b/pytorch_translate/research/test/morphology_test_utils.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import tempfile
+from os import path
+
+
+def get_two_tmp_files():
+    src_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    dst_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
+    tmp_dir = tempfile.mkdtemp()
+    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
+    with open(file1, "w") as f1:
+        f1.write(content1)
+    with open(file2, "w") as f2:
+        f2.write(content2)
+
+    return tmp_dir, file1, file2

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -34,6 +34,11 @@ class TestBPE(unittest.TestCase):
             assert "12" not in vocab_items
             assert "123" not in vocab_items
 
+            assert len(bpe_model.vocab) == 10
+            assert bpe_model.vocab[bpe_model.eow_symbol] == 11.0 / 56
+            assert bpe_model.vocab["3"] == 7.0 / 56
+            assert "12" not in bpe_model.vocab
+
     def test_best_candidate(self):
         bpe_model = bpe.BPE()
 
@@ -53,29 +58,23 @@ class TestBPE(unittest.TestCase):
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
 
             # Trying merging a candidate that does not exist.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "1"), num_cpus=3
-            )
-            assert vocab_size == 10
+            bpe_model.merge_candidate_into_vocab(candidate=("3", "1"), num_cpus=3)
+            assert len(bpe_model.vocab) == 10
 
             # Trying merging a candidate that does exists.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("2", "3"), num_cpus=3
-            )
-            assert vocab_size == 11
+            bpe_model.merge_candidate_into_vocab(candidate=("2", "3"), num_cpus=3)
+            assert len(bpe_model.vocab) == 11
 
             # Trying merging a candidate that does exists. Entry "3" should remove
             # from vocab.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "4"), num_cpus=3
-            )
-            assert vocab_size == 11
+            bpe_model.merge_candidate_into_vocab(candidate=("3", "4"), num_cpus=3)
+            assert len(bpe_model.vocab) == 11
 
             # Trying merging a candidate that does not exist.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
+            bpe_model.merge_candidate_into_vocab(
                 candidate=("3", bpe_model.eow_symbol), num_cpus=3
             )
-            assert vocab_size == 11
+            assert len(bpe_model.vocab) == 11
 
     def test_merge_pattern(self):
         pattern1 = bpe.BPE.get_merge_pattern("c c")
@@ -99,22 +98,22 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
 
             # Trying to build a vocab more than the possible size
-            vocab_size = bpe_model.build_vocab(
+            bpe_model.build_vocab(
                 txt_path="no_exist_file.txt", vocab_size=20, num_cpus=3
             )
             # Asserting that we go back to the original size (number of word types.)
-            assert vocab_size == 9
+            assert len(bpe_model.vocab) == 9
             assert bpe_model.max_bpe_len == 9 + len(bpe_model.eow_symbol)
 
         with patch("builtins.open") as mock_open:
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             # Trying to build a vocab with an acceptable size.
-            vocab_size = bpe_model.build_vocab(
+            bpe_model.build_vocab(
                 txt_path="no_exist_file.txt", vocab_size=12, num_cpus=3
             )
             # asserting that the size is as expected.
-            assert vocab_size == 12
+            assert len(bpe_model.vocab) == 12
             assert bpe_model.max_bpe_len == len(bpe_model.eow_symbol)
 
     def test_segment_word(self):

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -7,7 +7,8 @@ from collections import Counter
 from os import path
 from unittest.mock import Mock, patch
 
-from pytorch_translate.research.unsupervised_morphology import bpe
+from pytorch_translate.research.test import morphology_test_utils as morph_utils
+from pytorch_translate.research.unsupervised_morphology import bilingual_bpe, bpe
 
 
 txt_content = ["123 124 234 345", "112 122 123 345", "123456789", "123456 456789"]
@@ -162,4 +163,16 @@ class TestBPE(unittest.TestCase):
         model_output = open(output_file, "r", encoding="utf-8").read().strip()
         assert expected_output == model_output
 
+        shutil.rmtree(tmp_dir)
+
+    def test_bilingual_bpe_init(self):
+        """
+            This looks more like an integration test because each subpeace is tested
+            in different places.
+        """
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
+        )
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import shutil
 import unittest
 
+from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     CharIBMModel1,
 )
@@ -17,3 +19,22 @@ class TestCharIBMModel1(unittest.TestCase):
         assert substrs["5" + char_ibm_model.eow_symbol] == 1
         assert substrs["123"] == 2
         assert "12345" not in substrs
+
+    def test_get_subwords_counts_for_line(self):
+        char_ibm_model = CharIBMModel1(max_subword_len=4)
+
+        substrs = char_ibm_model.get_subword_counts_for_line("123412345 12345")
+        assert len(substrs) == 24
+        assert substrs[char_ibm_model.eow_symbol] == 2
+        assert substrs["5" + char_ibm_model.eow_symbol] == 2
+        assert substrs["123"] == 3
+        assert "12345" not in substrs
+
+    def test_morph_init(self):
+        ibm_model = CharIBMModel1()
+
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        ibm_model.initialize_translation_probs(f1, f2)
+        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
+        assert len(ibm_model.translation_prob) == 80
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -37,15 +37,16 @@ class TestCharIBMModel1(unittest.TestCase):
         ibm_model.initialize_translation_probs(f1, f2)
         assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
         assert len(ibm_model.translation_prob) == 80
+        assert len(ibm_model.training_data) == 4
         shutil.rmtree(tmp_dir)
 
     def test_em_step(self):
         ibm_model = CharIBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(f1, f2)
+        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
 
-        ibm_model.em_step(f1, f2)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3)
 
         assert len(ibm_model.translation_prob) == 80
         assert (

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -38,3 +38,20 @@ class TestCharIBMModel1(unittest.TestCase):
         assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
         assert len(ibm_model.translation_prob) == 80
         shutil.rmtree(tmp_dir)
+
+    def test_em_step(self):
+        ibm_model = CharIBMModel1()
+
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        ibm_model.initialize_translation_probs(f1, f2)
+
+        ibm_model.em_step(f1, f2)
+
+        assert len(ibm_model.translation_prob) == 80
+        assert (
+            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
+            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
+        )
+        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -20,6 +20,7 @@ class TestIBMModel1(unittest.TestCase):
         assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
         assert len(ibm_model.translation_prob["345"]) == 6
         assert ibm_model.translation_prob["122"]["123"] == 1.0 / 4
+        assert len(ibm_model.training_data) == 4
         shutil.rmtree(tmp_dir)
 
     def test_e_step(self):
@@ -43,7 +44,7 @@ class TestIBMModel1(unittest.TestCase):
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
-        ibm_model.em_step(f1, f2)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3)
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
@@ -58,7 +59,9 @@ class TestIBMModel1(unittest.TestCase):
         ibm_model = IBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
+        ibm_model.learn_ibm_parameters(
+            src_path=f1, dst_path=f2, num_iters=3, num_cpus=3
+        )
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -6,38 +6,15 @@ import unittest
 from collections import defaultdict
 from os import path
 
+from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.ibm_model1 import IBMModel1
-
-
-def get_two_tmp_files():
-    src_txt_content = [
-        "123 124 234 345",
-        "112 122 123 345",
-        "123456789",
-        "123456 456789",
-    ]
-    dst_txt_content = [
-        "123 124 234 345",
-        "112 122 123 345",
-        "123456789",
-        "123456 456789",
-    ]
-    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
-    tmp_dir = tempfile.mkdtemp()
-    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
-    with open(file1, "w") as f1:
-        f1.write(content1)
-    with open(file2, "w") as f2:
-        f2.write(content2)
-
-    return tmp_dir, file1, file2
 
 
 class TestIBMModel1(unittest.TestCase):
     def test_morph_init(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         assert len(ibm_model.translation_prob) == 10
         assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
@@ -48,7 +25,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_e_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         translation_counts = defaultdict()
 
@@ -63,7 +40,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_em_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
         ibm_model.em_step(f1, f2)
@@ -80,7 +57,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_ibm_train(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
 
         assert ibm_model.translation_prob["456789"]["345"] == 0

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+from pytorch_translate.research.unsupervised_morphology.bpe import BPE
+from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
+    CharIBMModel1,
+)
+
+
+class BilingualBPE(object):
+    """
+    An extension of the BPE model that is cross-lingual wrt parallel data.
+    """
+
+    def __init__(self):
+        self.src_bpe = BPE()
+        self.dst_bpe = BPE()
+        self.src2dst_ibm_model = CharIBMModel1()
+        self.dst2src_ibm_model = CharIBMModel1()
+
+    def _init_params(
+        self, src_txt_path: str, dst_txt_path: str, num_ibm_iters: int, num_cpus: int
+    ):
+        """
+        Args:
+            src_txt_path: Text path for source language in parallel data.
+            dst_txt_path: Text path for target language in parallel data.
+            num_ibm_iters: Number of training epochs for the IBM model.
+            num_cpus: Number of CPUs for training the IBM model with multi-processing.
+        """
+        self.src_bpe._init_vocab(txt_path=src_txt_path)
+        self.dst_bpe._init_vocab(txt_path=dst_txt_path)
+        self.src2dst_ibm_model.learn_ibm_parameters(
+            src_path=src_txt_path,
+            dst_path=dst_txt_path,
+            num_iters=num_ibm_iters,
+            num_cpus=num_cpus,
+        )
+        self.dst2src_ibm_model.learn_ibm_parameters(
+            src_path=dst_txt_path,
+            dst_path=src_txt_path,
+            num_iters=num_ibm_iters,
+            num_cpus=num_cpus,
+        )

--- a/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
@@ -31,46 +31,55 @@ class CharIBMModel1(ibm_model1.IBMModel1):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
         """
+        self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
-                src_subwords = self.get_subword_counts_for_line(src_line).keys()
-                dst_subwords = self.get_subword_counts_for_line(dst_line).keys()
+                src_subwords_counts = self.get_subword_counts_for_line(src_line)
+                dst_subwords_counts = self.get_subword_counts_for_line(dst_line)
 
-                for src_subword in src_subwords:
+                for src_subword in src_subwords_counts.keys():
                     if src_subword not in self.translation_prob:
                         self.translation_prob[src_subword] = defaultdict(float)
-                    for dst_subword in dst_subwords:
+                    for dst_subword in dst_subwords_counts.keys():
                         self.translation_prob[src_subword][dst_subword] = 1.0
+                self.training_data.append((src_subwords_counts, dst_subwords_counts))
 
         for src_subword in self.translation_prob.keys():
             denom = len(self.translation_prob[src_subword])
             for dst_subword in self.translation_prob[src_subword].keys():
                 self.translation_prob[src_subword][dst_subword] = 1.0 / denom
 
-    def em_step(self, src_path: str, dst_path: str) -> None:
+    def e_step(
+        self,
+        src_words: Dict[str, int],
+        dst_words: Dict[str, int],
+        translation_expectations: Dict,
+    ) -> None:
         """
-            The main difference between this method and the parent method is that
-            here we deal with subwords instead of words.
-            Note: In the subword model, we do not use the null_str because
-            eow_symbol can somehow represent a null_str.
+        Args:
+            translation_expectations: holder of expectations until now. This method
+                should update this
         """
-        translation_expectations = defaultdict()
+        denom = defaultdict(float)
+        nominator = defaultdict(float)
 
-        with open(src_path) as src_file, open(dst_path) as dst_file:
-            for src_line, dst_line in zip(src_file, dst_file):
-                src_subword_counts = self.get_subword_counts_for_line(src_line)
-                src_subwords = []
-                for src_subword in src_subword_counts.keys():
-                    src_subwords.extend([src_subword] * src_subword_counts[src_subword])
-
-                dst_subword_counts = self.get_subword_counts_for_line(dst_line)
-                dst_subwords = []
-                for dst_subword in dst_subword_counts.keys():
-                    dst_subwords.extend([dst_subword] * dst_subword_counts[dst_subword])
-
-                self.e_step(
-                    src_words=src_subwords,
-                    dst_words=dst_subwords,
-                    translation_expectations=translation_expectations,
+        for src_word in src_words.keys():
+            if src_word not in nominator:
+                nominator[src_word] = defaultdict(float)
+            src_word_count = src_words[src_word]
+            for dst_word in dst_words.keys():
+                dst_word_count = dst_words[dst_word]
+                num_combinations = src_word_count * dst_word_count
+                denom[src_word] += (
+                    num_combinations * self.translation_prob[src_word][dst_word]
                 )
-        self.m_step(translation_expectations)
+                nominator[src_word][dst_word] += (
+                    num_combinations * self.translation_prob[src_word][dst_word]
+                )
+
+        for src_word in nominator.keys():
+            if src_word not in translation_expectations:
+                translation_expectations[src_word] = defaultdict(float)
+            for dst_word in nominator[src_word].keys():
+                delta = nominator[src_word][dst_word] / denom[src_word]
+                translation_expectations[src_word][dst_word] += delta

--- a/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from collections import Counter
+from collections import Counter, defaultdict
 from typing import Dict
 
 from pytorch_translate.research.unsupervised_morphology import ibm_model1
@@ -20,3 +20,29 @@ class CharIBMModel1(ibm_model1.IBMModel1):
                 subword = "".join(chars[i:j])
                 subwords[subword] += 1
         return subwords
+
+    def get_subword_counts_for_line(self, line: str) -> Dict[str, int]:
+        return sum(
+            [self.get_possible_subwords(word) for word in line.strip().split()],
+            Counter(),
+        )
+
+    def initialize_translation_probs(self, src_path: str, dst_path: str):
+        """
+        Direction of translation is conditioned on the source text: t(dst|src).
+        """
+        with open(src_path) as src_file, open(dst_path) as dst_file:
+            for src_line, dst_line in zip(src_file, dst_file):
+                src_subwords = self.get_subword_counts_for_line(src_line).keys()
+                dst_subwords = self.get_subword_counts_for_line(dst_line).keys()
+
+                for src_subword in src_subwords:
+                    if src_subword not in self.translation_prob:
+                        self.translation_prob[src_subword] = defaultdict(float)
+                    for dst_subword in dst_subwords:
+                        self.translation_prob[src_subword][dst_subword] = 1.0
+
+        for src_subword in self.translation_prob.keys():
+            denom = len(self.translation_prob[src_subword])
+            for dst_subword in self.translation_prob[src_subword].keys():
+                self.translation_prob[src_subword][dst_subword] = 1.0 / denom

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -43,7 +43,7 @@ class IBMModel1(object):
             print("Iteration of IBM model(1):", str(iter + 1))
             self.em_step(src_path=src_path, dst_path=dst_path)
 
-    def em_step(self, src_path: str, dst_path: str):
+    def em_step(self, src_path: str, dst_path: str) -> None:
         translation_expectations = defaultdict()
 
         with open(src_path) as src_file, open(dst_path) as dst_file:
@@ -53,7 +53,9 @@ class IBMModel1(object):
                 self.e_step(src_words, dst_words, translation_expectations)
         self.m_step(translation_expectations)
 
-    def e_step(self, src_words: List, dst_words: List, translation_expectations: Dict):
+    def e_step(
+        self, src_words: List, dst_words: List, translation_expectations: Dict
+    ) -> None:
         """
         Args:
             translation_expectations: holder of expectations until now. This method
@@ -79,7 +81,7 @@ class IBMModel1(object):
                 delta = nominator[src_word][dst_word] / denom[src_word]
                 translation_expectations[src_word][dst_word] += delta
 
-    def m_step(self, translation_expectations):
+    def m_step(self, translation_expectations) -> None:
         for src_word in translation_expectations.keys():
             denom = sum(translation_expectations[src_word].values())
             for dst_word in translation_expectations[src_word].keys():

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import math
 from collections import defaultdict
-from typing import Dict, List
+from multiprocessing import Pool
+from typing import Dict, List, Tuple
 
 
 class IBMModel1(object):
@@ -12,11 +14,13 @@ class IBMModel1(object):
         """
         self.translation_prob = defaultdict()
         self.null_str = "<null>"
+        self.training_data = []
 
     def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
         """
+        self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
                 src_words = set(src_line.strip().split() + [self.null_str])
@@ -26,13 +30,16 @@ class IBMModel1(object):
                         self.translation_prob[src_word] = defaultdict(float)
                     for dst_word in dst_words:
                         self.translation_prob[src_word][dst_word] = 1.0
+                self.training_data.append((src_words, dst_words))
 
         for src_word in self.translation_prob.keys():
             denom = len(self.translation_prob[src_word])
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
 
-    def learn_ibm_parameters(self, src_path: str, dst_path: str, num_iters: int):
+    def learn_ibm_parameters(
+        self, src_path: str, dst_path: str, num_iters: int, num_cpus: int
+    ):
         """
         Runs the EM algorithm for IBM model 1.
         Args:
@@ -41,17 +48,43 @@ class IBMModel1(object):
         self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
         for iter in range(num_iters):
             print("Iteration of IBM model(1):", str(iter + 1))
-            self.em_step(src_path=src_path, dst_path=dst_path)
+            self.em_step(src_path=src_path, dst_path=dst_path, num_cpus=num_cpus)
 
-    def em_step(self, src_path: str, dst_path: str) -> None:
+    def em_step(self, src_path: str, dst_path: str, num_cpus: int) -> None:
         translation_expectations = defaultdict()
 
-        with open(src_path) as src_file, open(dst_path) as dst_file:
-            for src_line, dst_line in zip(src_file, dst_file):
-                src_words = src_line.strip().split() + [self.null_str]
-                dst_words = dst_line.strip().split()
-                self.e_step(src_words, dst_words, translation_expectations)
+        with Pool(processes=num_cpus) as pool:
+            data_chunk_size = max(1, math.ceil(len(self.training_data) / num_cpus))
+            indices = [
+                (
+                    i * data_chunk_size,
+                    min(data_chunk_size * (i + 1), len(self.training_data)),
+                )
+                for i in range(num_cpus)
+            ]
+            results = pool.map(self.e_sub_step, indices)
+            for result in results:
+                for src_word in result.keys():
+                    if src_word not in translation_expectations:
+                        translation_expectations[src_word] = defaultdict(float)
+                    for dst_word in result[src_word].keys():
+                        translation_expectations[src_word][dst_word] += result[
+                            src_word
+                        ][dst_word]
+
         self.m_step(translation_expectations)
+
+    def e_sub_step(self, start_end_index: Tuple[int, int]) -> Dict[str, Dict]:
+        """
+            Running the E step as a substep on the training data based on the
+            start and end indices.
+        """
+        translation_expectations: Dict[str, Dict] = defaultdict()
+        start_index, end_index = start_end_index
+        for i in range(start_index, end_index):
+            src_words, dst_words = self.training_data[i]
+            self.e_step(src_words, dst_words, translation_expectations)
+        return translation_expectations
 
     def e_step(
         self, src_words: List, dst_words: List, translation_expectations: Dict


### PR DESCRIPTION
Summary: The first step towards having a bilingual BPE is to have data holders for translation probabilities and two individual monolingual BPE models. Next diffs should have the functionalities for merge.

Differential Revision: D14941604

