### PR TITLE
Bilingual BPE --> part 22 ( bilingual part 2)

### DIFF
--- a/pytorch_translate/research/test/morphology_test_utils.py
+++ b/pytorch_translate/research/test/morphology_test_utils.py
@@ -4,7 +4,7 @@ import tempfile
 from os import path
 
 
-def get_two_tmp_files():
+def get_two_same_tmp_files():
     src_txt_content = [
         "123 124 234 345",
         "112 122 123 345",
@@ -16,6 +16,30 @@ def get_two_tmp_files():
         "112 122 123 345",
         "123456789",
         "123456 456789",
+    ]
+    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
+    tmp_dir = tempfile.mkdtemp()
+    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
+    with open(file1, "w") as f1:
+        f1.write(content1)
+    with open(file2, "w") as f2:
+        f2.write(content2)
+
+    return tmp_dir, file1, file2
+
+
+def get_two_different_tmp_files():
+    src_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    dst_txt_content = [
+        "abc abd bcd cde",
+        "aab abb abc cde",
+        "abcdefghi",
+        "abcdef defghi",
     ]
     content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
     tmp_dir = tempfile.mkdtemp()

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -8,7 +8,8 @@ from multiprocessing import Pool
 from os import path
 from unittest.mock import Mock, patch
 
-from pytorch_translate.research.unsupervised_morphology import bpe
+from pytorch_translate.research.test import morphology_test_utils as morph_utils
+from pytorch_translate.research.unsupervised_morphology import bilingual_bpe, bpe
 
 
 txt_content = ["123 124 234 345", "112 122 123 345", "123456789", "123456 456789"]
@@ -175,4 +176,16 @@ class TestBPE(unittest.TestCase):
         model_output = open(output_file, "r", encoding="utf-8").read().strip()
         assert expected_output == model_output
 
+        shutil.rmtree(tmp_dir)
+
+    def test_bilingual_bpe_init(self):
+        """
+            This looks more like an integration test because each subpeace is tested
+            in different places.
+        """
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
+        )
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -189,3 +189,24 @@ class TestBPE(unittest.TestCase):
             src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
         )
         shutil.rmtree(tmp_dir)
+
+    def test_best_candidate_bilingual(self):
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        num_cpus = 3
+        pool = Pool(num_cpus)
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=num_cpus
+        )
+
+        b1 = bpe_model.src_bpe.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        c1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool, for_src=True)
+        # For the best step, it is the same as monolingual.
+        assert b1 == c1
+
+        c2 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool, for_src=False)
+        b2 = bpe_model.dst_bpe.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        # For the best step, it is the same as monolingual.
+        assert b2 == c2
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from collections import Counter
+from multiprocessing import Pool
 from os import path
 from unittest.mock import Mock, patch
 
@@ -41,8 +42,12 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
-
-            assert bpe_model.get_best_candidate(num_cpus=3) == ("1", "2")
+            num_cpus = 3
+            pool = Pool(processes=num_cpus)
+            assert bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool) == (
+                "1",
+                "2",
+            )
 
     def test_bpe_merge(self):
         bpe_model = bpe.BPE()
@@ -51,29 +56,31 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
+            num_cpus = 3
+            pool = Pool(processes=num_cpus)
 
             # Trying merging a candidate that does not exist.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "1"), num_cpus=3
+                candidate=("3", "1"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 10
 
             # Trying merging a candidate that does exists.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("2", "3"), num_cpus=3
+                candidate=("2", "3"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 
             # Trying merging a candidate that does exists. Entry "3" should remove
             # from vocab.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "4"), num_cpus=3
+                candidate=("3", "4"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 
             # Trying merging a candidate that does not exist.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", bpe_model.eow_symbol), num_cpus=3
+                candidate=("3", bpe_model.eow_symbol), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -35,6 +35,11 @@ class TestBPE(unittest.TestCase):
             assert "12" not in vocab_items
             assert "123" not in vocab_items
 
+            assert len(bpe_model.vocab) == 10
+            assert bpe_model.vocab[bpe_model.eow_symbol] == 11.0 / 56
+            assert bpe_model.vocab["3"] == 7.0 / 56
+            assert "12" not in bpe_model.vocab
+
     def test_best_candidate(self):
         bpe_model = bpe.BPE()
 
@@ -60,29 +65,29 @@ class TestBPE(unittest.TestCase):
             pool = Pool(processes=num_cpus)
 
             # Trying merging a candidate that does not exist.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
+            bpe_model.merge_candidate_into_vocab(
                 candidate=("3", "1"), num_cpus=num_cpus, pool=pool
             )
-            assert vocab_size == 10
+            assert len(bpe_model.vocab) == 10
 
             # Trying merging a candidate that does exists.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
+            bpe_model.merge_candidate_into_vocab(
                 candidate=("2", "3"), num_cpus=num_cpus, pool=pool
             )
-            assert vocab_size == 11
+            assert len(bpe_model.vocab) == 11
 
             # Trying merging a candidate that does exists. Entry "3" should remove
             # from vocab.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
+            bpe_model.merge_candidate_into_vocab(
                 candidate=("3", "4"), num_cpus=num_cpus, pool=pool
             )
-            assert vocab_size == 11
+            assert len(bpe_model.vocab) == 11
 
             # Trying merging a candidate that does not exist.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
+            bpe_model.merge_candidate_into_vocab(
                 candidate=("3", bpe_model.eow_symbol), num_cpus=num_cpus, pool=pool
             )
-            assert vocab_size == 11
+            assert len(bpe_model.vocab) == 11
 
     def test_merge_pattern(self):
         pattern1 = bpe.BPE.get_merge_pattern("c c")
@@ -106,22 +111,22 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
 
             # Trying to build a vocab more than the possible size
-            vocab_size = bpe_model.build_vocab(
+            bpe_model.build_vocab(
                 txt_path="no_exist_file.txt", vocab_size=20, num_cpus=3
             )
             # Asserting that we go back to the original size (number of word types.)
-            assert vocab_size == 9
+            assert len(bpe_model.vocab) == 9
             assert bpe_model.max_bpe_len == 9 + len(bpe_model.eow_symbol)
 
         with patch("builtins.open") as mock_open:
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             # Trying to build a vocab with an acceptable size.
-            vocab_size = bpe_model.build_vocab(
+            bpe_model.build_vocab(
                 txt_path="no_exist_file.txt", vocab_size=12, num_cpus=3
             )
             # asserting that the size is as expected.
-            assert vocab_size == 12
+            assert len(bpe_model.vocab) == 12
             assert bpe_model.max_bpe_len == len(bpe_model.eow_symbol)
 
     def test_segment_word(self):

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -2,6 +2,7 @@
 
 import shutil
 import unittest
+from multiprocessing import Pool
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
@@ -37,15 +38,17 @@ class TestCharIBMModel1(unittest.TestCase):
         ibm_model.initialize_translation_probs(f1, f2)
         assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
         assert len(ibm_model.translation_prob) == 80
+        assert len(ibm_model.training_data) == 4
         shutil.rmtree(tmp_dir)
 
     def test_em_step(self):
         ibm_model = CharIBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(f1, f2)
+        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
 
-        ibm_model.em_step(f1, f2)
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
 
         assert len(ibm_model.translation_prob) == 80
         assert (

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -34,7 +34,7 @@ class TestCharIBMModel1(unittest.TestCase):
     def test_morph_init(self):
         ibm_model = CharIBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
         assert len(ibm_model.translation_prob) == 80
@@ -44,7 +44,7 @@ class TestCharIBMModel1(unittest.TestCase):
     def test_em_step(self):
         ibm_model = CharIBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
 
         pool = Pool(3)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -15,7 +15,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_morph_init(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         assert len(ibm_model.translation_prob) == 10
         assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
@@ -26,7 +26,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_e_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         translation_counts = defaultdict(lambda: defaultdict(float))
 
@@ -41,7 +41,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_em_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
         pool = Pool(3)
@@ -59,7 +59,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_ibm_train(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.learn_ibm_parameters(
             src_path=f1, dst_path=f2, num_iters=3, num_cpus=3
         )

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from collections import defaultdict
+from multiprocessing import Pool
 from os import path
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
@@ -43,7 +44,8 @@ class TestIBMModel1(unittest.TestCase):
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
-        ibm_model.em_step(f1, f2)
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
@@ -58,7 +60,9 @@ class TestIBMModel1(unittest.TestCase):
         ibm_model = IBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
+        ibm_model.learn_ibm_parameters(
+            src_path=f1, dst_path=f2, num_iters=3, num_cpus=3
+        )
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+import math
+from collections import defaultdict
+from multiprocessing import Pool
+from typing import Dict, Optional, Tuple
+
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     CharIBMModel1,
@@ -41,3 +46,73 @@ class BilingualBPE(object):
             num_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
+
+    def _best_candidate_substep(
+        self, start_end_indices: Tuple[int, int], for_src: bool
+    ) -> Dict[Tuple[str, str], float]:
+        """
+        Args:
+            start_end_indices: first and end index for part of
+                self.current_train_data to search for.
+            for_src: finding the best candidate for src or target.
+        """
+        bpe_model = self.src_bpe if for_src else self.dst_bpe
+        other_side_bpe_model = self.dst_bpe if for_src else self.src_bpe
+        ibm_model = self.src2dst_ibm_model if for_src else self.dst2src_ibm_model
+
+        start_index, end_index = start_end_indices[0], start_end_indices[1]
+        assert start_index <= end_index
+
+        candidates = defaultdict(float)
+        for (seg, freq) in bpe_model.current_train_data[start_index:end_index]:
+            symbols = seg.split()
+            for i in range(len(symbols) - 1):
+                bpe_key = (symbols[i], symbols[i + 1])
+                bpe_token = "".join([symbols[i], symbols[i + 1]])
+                prob = 0
+
+                # p(bpe_type=c) = \sum_{t \in other_side} p(c|t) p(t)
+                for other_side_bpe_type in other_side_bpe_model.vocab.keys():
+                    translation_prob = (
+                        ibm_model.translation_prob[bpe_token][other_side_bpe_type]
+                        if bpe_token in ibm_model.translation_prob
+                        else 1e-10
+                    )
+                    prob += freq * (
+                        other_side_bpe_model.vocab[other_side_bpe_type]
+                        * translation_prob
+                    )
+                candidates[bpe_key] += prob
+
+        return candidates
+
+    def get_best_candidate(
+        self, num_cpus: int, pool: Pool, for_src: bool
+    ) -> Optional[Tuple[str, str]]:
+        """
+        Calculates frequencies for new candidiates from the current vocabulary,
+        and returns the candidate with the most frequency.
+        Args:
+            for_src: finding the best candidate for src or target.
+        """
+        data_chunk_size = max(
+            1, math.ceil(len(self.src_bpe.current_train_data) / num_cpus)
+        )
+        indices = [
+            (
+                (
+                    i * data_chunk_size,
+                    min(
+                        data_chunk_size * (i + 1), len(self.src_bpe.current_train_data)
+                    ),
+                ),
+                for_src,
+            )
+            for i in range(num_cpus)
+        ]
+        results = pool.starmap(self._best_candidate_substep, indices)
+        candidates = defaultdict(float)
+        for result in results:
+            for (k, v) in result.items():
+                candidates[k] += v
+        return max(candidates, key=candidates.get) if len(candidates) > 0 else None

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+from pytorch_translate.research.unsupervised_morphology.bpe import BPE
+from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
+    CharIBMModel1,
+)
+
+
+class BilingualBPE(object):
+    """
+    An extension of the BPE model that is cross-lingual wrt parallel data.
+    """
+
+    def __init__(self):
+        self.src_bpe = BPE()
+        self.dst_bpe = BPE()
+        self.src2dst_ibm_model = CharIBMModel1()
+        self.dst2src_ibm_model = CharIBMModel1()
+
+    def _init_params(
+        self, src_txt_path: str, dst_txt_path: str, num_ibm_iters: int, num_cpus: int
+    ):
+        """
+        Args:
+            src_txt_path: Text path for source language in parallel data.
+            dst_txt_path: Text path for target language in parallel data.
+            num_ibm_iters: Number of training epochs for the IBM model.
+            num_cpus: Number of CPUs for training the IBM model with multi-processing.
+        """
+        self.src_bpe._init_vocab(txt_path=src_txt_path)
+        self.dst_bpe._init_vocab(txt_path=dst_txt_path)
+        self.src2dst_ibm_model.learn_ibm_parameters(
+            src_path=src_txt_path,
+            dst_path=dst_txt_path,
+            num_iters=num_ibm_iters,
+            num_cpus=num_cpus,
+        )
+        self.dst2src_ibm_model.learn_ibm_parameters(
+            src_path=dst_txt_path,
+            dst_path=src_txt_path,
+            num_iters=num_ibm_iters,
+            num_cpus=num_cpus,
+        )

--- a/pytorch_translate/research/unsupervised_morphology/bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bpe.py
@@ -7,7 +7,7 @@ from collections import Counter, defaultdict
 from itertools import chain
 from multiprocessing import Pool
 from optparse import OptionParser
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Tuple
 
 
 def get_arg_parser():
@@ -85,7 +85,9 @@ class BPE(object):
         for bpe_type in self.vocab.keys():
             self.vocab[bpe_type] /= bpe_type_count
 
-    def _best_candidate_substep(self, start_end_indices: Tuple[int, int]):
+    def _best_candidate_substep(
+        self, start_end_indices: Tuple[int, int]
+    ) -> Dict[Tuple[str, str], int]:
         """
         Args:
             first and end index for part of self.current_train_data to search for.
@@ -100,7 +102,9 @@ class BPE(object):
                 candidates[(symbols[i], symbols[i + 1])] += freq
         return candidates
 
-    def get_best_candidate(self, num_cpus: int, pool: Pool):
+    def get_best_candidate(
+        self, num_cpus: int, pool: Pool
+    ) -> Optional[Tuple[str, str]]:
         """
         Calculates frequencies for new candidiates from the current vocabulary,
         and returns the candidate with the most frequency.

--- a/pytorch_translate/research/unsupervised_morphology/bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bpe.py
@@ -3,7 +3,7 @@
 import datetime
 import math
 import re
-from collections import Counter
+from collections import Counter, defaultdict
 from itertools import chain
 from multiprocessing import Pool
 from optparse import OptionParser
@@ -49,7 +49,7 @@ class BPE(object):
     """
 
     def __init__(self):
-        self.vocab: Dict[str, int] = Counter()
+        self.vocab: Dict[str, float] = defaultdict(float)
         self.eow_symbol = "_EOW"  # End of word symbol.
 
         # This data structure holds current segmentation of training data. This
@@ -63,6 +63,8 @@ class BPE(object):
         self.max_bpe_len = 1
 
     def _init_vocab(self, txt_path: str):
+        self.vocab: Dict[str, float] = defaultdict(float)
+        self.max_bpe_len = 1
         data_freq: Dict[str, int] = Counter()
         with open(txt_path, "r", encoding="utf-8") as input_stream:
             for line in input_stream:
@@ -75,7 +77,13 @@ class BPE(object):
 
         self.current_train_data: List[Tuple[str, int]] = []
         for segmentation, freq in data_freq.items():
+            for bpe_type in segmentation.split():
+                self.vocab[bpe_type] += freq
             self.current_train_data.append((segmentation, freq))
+
+        bpe_type_count = sum(self.vocab.values())
+        for bpe_type in self.vocab.keys():
+            self.vocab[bpe_type] /= bpe_type_count
 
     def _best_candidate_substep(self, start_end_indices: Tuple[int, int]):
         """
@@ -115,9 +123,10 @@ class BPE(object):
 
     def merge_substep(
         self, merge_candidate: Tuple[str, str], start_end_index: Tuple[int, int]
-    ) -> Tuple[List[Tuple[str, int]], Set]:
+    ) -> Tuple[List[Tuple[str, int]], Dict[str, int]]:
         """
-        Returns Bpe types in the current substep.
+        Returns 1) new data in the partition, 2) bpe types in the current substep
+        with their count.
         """
         candidate_str = " ".join(merge_candidate)
         candidate_replacement = "".join(merge_candidate)
@@ -125,7 +134,7 @@ class BPE(object):
         offset, stop_index = start_end_index
         assert offset < stop_index
 
-        new_bpe_entries = set()
+        new_bpe_entries = Counter()
         new_data: List[Tuple[str, int]] = [None] * (stop_index - offset)
         for i in range(offset, stop_index):
             vocab_entry, freq = self.current_train_data[i]
@@ -137,12 +146,12 @@ class BPE(object):
 
             new_data[i - offset] = (new_entry, freq)
             for entry in new_entry.split():
-                new_bpe_entries.add(entry)
+                new_bpe_entries[entry] += freq
         return (new_data, new_bpe_entries)
 
     def merge_candidate_into_vocab(
         self, candidate: Tuple[str, str], num_cpus: int, pool: Pool
-    ) -> int:
+    ) -> None:
         """
         Returns the vocabulary size (number of BPE types).
         Args:
@@ -166,10 +175,15 @@ class BPE(object):
         # the * operation with chain we concatenate the lists in order to
         # reconstruct the training data.
         self.current_train_data = list(chain(*[result[0] for result in results]))
-        bpe_types_union = set.union(*[result[1] for result in results])
-        return len(bpe_types_union)
 
-    def build_vocab(self, txt_path: str, vocab_size: int, num_cpus: int) -> int:
+        new_vocab = sum([result[1] for result in results], Counter())
+        bpe_sum_count = sum(new_vocab.values())
+        self.vocab = defaultdict(float)
+        for bpe_type in new_vocab.keys():
+            self.vocab[bpe_type] = new_vocab[bpe_type] / bpe_sum_count
+            self.max_bpe_len = max(self.max_bpe_len, len(bpe_type))
+
+    def build_vocab(self, txt_path: str, vocab_size: int, num_cpus: int) -> None:
         """
         After building the vocab, sends the current number of bpe types.
 
@@ -183,10 +197,10 @@ class BPE(object):
             while True:
                 merge_candidate = self.get_best_candidate(num_cpus=num_cpus, pool=pool)
                 if merge_candidate is not None:
-                    cur_v_size = self.merge_candidate_into_vocab(
+                    self.merge_candidate_into_vocab(
                         candidate=merge_candidate, num_cpus=num_cpus, pool=pool
                     )
-                    if cur_v_size >= vocab_size:
+                    if len(self.vocab) >= vocab_size:
                         break
                 else:
                     # No more merges possible
@@ -200,7 +214,7 @@ class BPE(object):
                         "data size",
                         len(self.current_train_data),
                         "current vocabulary size",
-                        cur_v_size,
+                        len(self.vocab),
                     )
 
         # Now we get rid of the current vocab that is based on the corpus (not

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
+import datetime
+import math
 from collections import defaultdict
-from typing import Dict, List
+from multiprocessing import Pool
+from typing import Dict, List, Tuple
 
 
 class IBMModel1(object):
@@ -10,13 +13,15 @@ class IBMModel1(object):
         translation_prob is the translation probability in the IBM model 1.
         the full pseudo-code is available at https://fburl.com/yvp31kuw
         """
-        self.translation_prob = defaultdict(lambda: defaultdict(float))
+        self.translation_prob = defaultdict()
         self.null_str = "<null>"
+        self.training_data = []
 
     def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
         """
+        self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
                 src_words = set(src_line.strip().split() + [self.null_str])
@@ -26,32 +31,73 @@ class IBMModel1(object):
                         self.translation_prob[src_word] = defaultdict(float)
                     for dst_word in dst_words:
                         self.translation_prob[src_word][dst_word] = 1.0
+                self.training_data.append((src_words, dst_words))
 
         for src_word in self.translation_prob.keys():
             denom = len(self.translation_prob[src_word])
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
 
-    def learn_ibm_parameters(self, src_path: str, dst_path: str, num_iters: int):
+    def learn_ibm_parameters(
+        self, src_path: str, dst_path: str, num_iters: int, num_cpus: int
+    ):
         """
         Runs the EM algorithm for IBM model 1.
         Args:
             num_iters: Number of EM iterations.
         """
+        print(str(datetime.datetime.now()), "Initializing model parameters")
         self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
-        for iter in range(num_iters):
-            print("Iteration of IBM model(1):", str(iter + 1))
-            self.em_step(src_path=src_path, dst_path=dst_path)
+        with Pool(processes=num_cpus) as pool:
+            for iter in range(num_iters):
+                print(
+                    str(datetime.datetime.now()),
+                    "Iteration of IBM model(1):",
+                    str(iter + 1),
+                )
+                self.em_step(
+                    src_path=src_path, dst_path=dst_path, num_cpus=num_cpus, pool=pool
+                )
 
-    def em_step(self, src_path: str, dst_path: str) -> None:
-        translation_expectations = defaultdict(lambda: defaultdict(float))
+    def em_step(self, src_path: str, dst_path: str, num_cpus: int, pool: Pool) -> None:
+        """
+        Args:
+            num_cpus: Number of cpus used in multi-processing.
+            pool: Pool object for multi-proceesing.
+        """
+        translation_expectations = defaultdict()
 
-        with open(src_path) as src_file, open(dst_path) as dst_file:
-            for src_line, dst_line in zip(src_file, dst_file):
-                src_words = src_line.strip().split() + [self.null_str]
-                dst_words = dst_line.strip().split()
-                self.e_step(src_words, dst_words, translation_expectations)
+        data_chunk_size = max(1, math.ceil(len(self.training_data) / num_cpus))
+        indices = [
+            (
+                i * data_chunk_size,
+                min(data_chunk_size * (i + 1), len(self.training_data)),
+            )
+            for i in range(num_cpus)
+        ]
+        results = pool.map(self.e_sub_step, indices)
+        for result in results:
+            for src_word in result.keys():
+                if src_word not in translation_expectations:
+                    translation_expectations[src_word] = defaultdict(float)
+                for dst_word in result[src_word].keys():
+                    translation_expectations[src_word][dst_word] += result[src_word][
+                        dst_word
+                    ]
+
         self.m_step(translation_expectations)
+
+    def e_sub_step(self, start_end_index: Tuple[int, int]) -> Dict[str, Dict]:
+        """
+            Running the E step as a substep on the training data based on the
+            start and end indices.
+        """
+        translation_expectations: Dict[str, Dict] = defaultdict()
+        start_index, end_index = start_end_index
+        for i in range(start_index, end_index):
+            src_words, dst_words = self.training_data[i]
+            self.e_step(src_words, dst_words, translation_expectations)
+        return translation_expectations
 
     def e_step(
         self, src_words: List, dst_words: List, translation_expectations: Dict
@@ -62,21 +108,22 @@ class IBMModel1(object):
                 should update this
         """
         denom = defaultdict(float)
-        nominator = defaultdict(float)
+        translation_fractional_counts = defaultdict(lambda: defaultdict(float))
 
         for src_word in src_words:
-            if src_word not in nominator:
-                nominator[src_word] = defaultdict(float)
-
             for dst_word in dst_words:
                 denom[src_word] += self.translation_prob[src_word][dst_word]
-                nominator[src_word][dst_word] += self.translation_prob[src_word][
+                translation_fractional_counts[src_word][
                     dst_word
-                ]
+                ] += self.translation_prob[src_word][dst_word]
 
-        for src_word in nominator.keys():
-            for dst_word in nominator[src_word].keys():
-                delta = nominator[src_word][dst_word] / denom[src_word]
+        for src_word in translation_fractional_counts.keys():
+            if src_word not in translation_expectations:
+                translation_expectations[src_word] = defaultdict(float)
+            for dst_word in translation_fractional_counts[src_word].keys():
+                delta = (
+                    translation_fractional_counts[src_word][dst_word] / denom[src_word]
+                )
                 translation_expectations[src_word][dst_word] += delta
 
     def m_step(self, translation_expectations) -> None:


### PR DESCRIPTION
Summary:
In monolingual BPE, the probability of each token is uniformly taken into account. Here, we use the following clue from the other side:

$$$ p(c) = \sum_{t \in other_lang} p(c|t) p(t) $$$, where p(t) comes from the BPE vocabulary in the other language, and p(c|t) is from the subword-based IBM model.

Differential Revision: D14945807

