### PR TITLE
bpe: fix bpe multi-processing speed problem

### DIFF
--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from collections import Counter
+from multiprocessing import Pool
 from os import path
 from unittest.mock import Mock, patch
 
@@ -41,8 +42,12 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
-
-            assert bpe_model.get_best_candidate(num_cpus=3) == ("1", "2")
+            num_cpus = 3
+            pool = Pool(processes=num_cpus)
+            assert bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool) == (
+                "1",
+                "2",
+            )
 
     def test_bpe_merge(self):
         bpe_model = bpe.BPE()
@@ -51,29 +56,31 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
+            num_cpus = 3
+            pool = Pool(processes=num_cpus)
 
             # Trying merging a candidate that does not exist.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "1"), num_cpus=3
+                candidate=("3", "1"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 10
 
             # Trying merging a candidate that does exists.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("2", "3"), num_cpus=3
+                candidate=("2", "3"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 
             # Trying merging a candidate that does exists. Entry "3" should remove
             # from vocab.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "4"), num_cpus=3
+                candidate=("3", "4"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 
             # Trying merging a candidate that does not exist.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", bpe_model.eow_symbol), num_cpus=3
+                candidate=("3", bpe_model.eow_symbol), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -40,21 +40,3 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.translation_prob) == 80
         assert len(ibm_model.training_data) == 4
         shutil.rmtree(tmp_dir)
-
-    def test_em_step(self):
-        ibm_model = CharIBMModel1()
-
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
-
-        pool = Pool(3)
-        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
-
-        assert len(ibm_model.translation_prob) == 80
-        assert (
-            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
-            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
-        )
-        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
-
-        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -2,6 +2,7 @@
 
 import shutil
 import unittest
+from multiprocessing import Pool
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
@@ -37,15 +38,17 @@ class TestCharIBMModel1(unittest.TestCase):
         ibm_model.initialize_translation_probs(f1, f2)
         assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
         assert len(ibm_model.translation_prob) == 80
+        assert len(ibm_model.training_data) == 4
         shutil.rmtree(tmp_dir)
 
     def test_em_step(self):
         ibm_model = CharIBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(f1, f2)
+        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
 
-        ibm_model.em_step(f1, f2)
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
 
         assert len(ibm_model.translation_prob) == 80
         assert (

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from collections import defaultdict
+from multiprocessing import Pool
 from os import path
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
@@ -43,7 +44,8 @@ class TestIBMModel1(unittest.TestCase):
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
-        ibm_model.em_step(f1, f2)
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
@@ -58,7 +60,9 @@ class TestIBMModel1(unittest.TestCase):
         ibm_model = IBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
+        ibm_model.learn_ibm_parameters(
+            src_path=f1, dst_path=f2, num_iters=3, num_cpus=3
+        )
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -3,7 +3,7 @@
 import shutil
 import tempfile
 import unittest
-from collections import defaultdict
+from collections import Counter, defaultdict
 from multiprocessing import Pool
 from os import path
 
@@ -31,8 +31,8 @@ class TestIBMModel1(unittest.TestCase):
         translation_counts = defaultdict(lambda: defaultdict(float))
 
         ibm_model.e_step(
-            ["123", "124", "234", "345", ibm_model.null_str],
-            ["123", "124", "234", "345"],
+            Counter(["123", "124", "234", "345", ibm_model.null_str]),
+            Counter(["123", "124", "234", "345"]),
             translation_counts,
         )
         assert translation_counts["123"]["345"] == 1.0 / 4

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
+import datetime
+import math
 from collections import defaultdict
-from typing import Dict, List
+from multiprocessing import Pool
+from typing import Dict, List, Tuple
 
 
 class IBMModel1(object):
@@ -10,13 +13,15 @@ class IBMModel1(object):
         translation_prob is the translation probability in the IBM model 1.
         the full pseudo-code is available at https://fburl.com/yvp31kuw
         """
-        self.translation_prob = defaultdict(lambda: defaultdict(float))
+        self.translation_prob = defaultdict()
         self.null_str = "<null>"
+        self.training_data = []
 
     def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
         """
+        self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
                 src_words = set(src_line.strip().split() + [self.null_str])
@@ -26,32 +31,73 @@ class IBMModel1(object):
                         self.translation_prob[src_word] = defaultdict(float)
                     for dst_word in dst_words:
                         self.translation_prob[src_word][dst_word] = 1.0
+                self.training_data.append((src_words, dst_words))
 
         for src_word in self.translation_prob.keys():
             denom = len(self.translation_prob[src_word])
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
 
-    def learn_ibm_parameters(self, src_path: str, dst_path: str, num_iters: int):
+    def learn_ibm_parameters(
+        self, src_path: str, dst_path: str, num_iters: int, num_cpus: int
+    ):
         """
         Runs the EM algorithm for IBM model 1.
         Args:
             num_iters: Number of EM iterations.
         """
+        print(str(datetime.datetime.now()), "Initializing model parameters")
         self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
-        for iter in range(num_iters):
-            print("Iteration of IBM model(1):", str(iter + 1))
-            self.em_step(src_path=src_path, dst_path=dst_path)
+        with Pool(processes=num_cpus) as pool:
+            for iter in range(num_iters):
+                print(
+                    str(datetime.datetime.now()),
+                    "Iteration of IBM model(1):",
+                    str(iter + 1),
+                )
+                self.em_step(
+                    src_path=src_path, dst_path=dst_path, num_cpus=num_cpus, pool=pool
+                )
 
-    def em_step(self, src_path: str, dst_path: str) -> None:
-        translation_expectations = defaultdict(lambda: defaultdict(float))
+    def em_step(self, src_path: str, dst_path: str, num_cpus: int, pool: Pool) -> None:
+        """
+        Args:
+            num_cpus: Number of cpus used in multi-processing.
+            pool: Pool object for multi-proceesing.
+        """
+        translation_expectations = defaultdict()
 
-        with open(src_path) as src_file, open(dst_path) as dst_file:
-            for src_line, dst_line in zip(src_file, dst_file):
-                src_words = src_line.strip().split() + [self.null_str]
-                dst_words = dst_line.strip().split()
-                self.e_step(src_words, dst_words, translation_expectations)
+        data_chunk_size = max(1, math.ceil(len(self.training_data) / num_cpus))
+        indices = [
+            (
+                i * data_chunk_size,
+                min(data_chunk_size * (i + 1), len(self.training_data)),
+            )
+            for i in range(num_cpus)
+        ]
+        results = pool.map(self.e_sub_step, indices)
+        for result in results:
+            for src_word in result.keys():
+                if src_word not in translation_expectations:
+                    translation_expectations[src_word] = defaultdict(float)
+                for dst_word in result[src_word].keys():
+                    translation_expectations[src_word][dst_word] += result[src_word][
+                        dst_word
+                    ]
+
         self.m_step(translation_expectations)
+
+    def e_sub_step(self, start_end_index: Tuple[int, int]) -> Dict[str, Dict]:
+        """
+            Running the E step as a substep on the training data based on the
+            start and end indices.
+        """
+        translation_expectations: Dict[str, Dict] = defaultdict()
+        start_index, end_index = start_end_index
+        for i in range(start_index, end_index):
+            src_words, dst_words = self.training_data[i]
+            self.e_step(src_words, dst_words, translation_expectations)
+        return translation_expectations
 
     def e_step(
         self, src_words: List, dst_words: List, translation_expectations: Dict
@@ -62,21 +108,22 @@ class IBMModel1(object):
                 should update this
         """
         denom = defaultdict(float)
-        nominator = defaultdict(float)
+        translation_fractional_counts = defaultdict(lambda: defaultdict(float))
 
         for src_word in src_words:
-            if src_word not in nominator:
-                nominator[src_word] = defaultdict(float)
-
             for dst_word in dst_words:
                 denom[src_word] += self.translation_prob[src_word][dst_word]
-                nominator[src_word][dst_word] += self.translation_prob[src_word][
+                translation_fractional_counts[src_word][
                     dst_word
-                ]
+                ] += self.translation_prob[src_word][dst_word]
 
-        for src_word in nominator.keys():
-            for dst_word in nominator[src_word].keys():
-                delta = nominator[src_word][dst_word] / denom[src_word]
+        for src_word in translation_fractional_counts.keys():
+            if src_word not in translation_expectations:
+                translation_expectations[src_word] = defaultdict(float)
+            for dst_word in translation_fractional_counts[src_word].keys():
+                delta = (
+                    translation_fractional_counts[src_word][dst_word] / denom[src_word]
+                )
                 translation_expectations[src_word][dst_word] += delta
 
     def m_step(self, translation_expectations) -> None:

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -2,7 +2,7 @@
 
 import datetime
 import math
-from collections import defaultdict
+from collections import Counter, defaultdict
 from multiprocessing import Pool
 from typing import Dict, List, Tuple
 
@@ -17,6 +17,13 @@ class IBMModel1(object):
         self.null_str = "<null>"
         self.training_data = []
 
+    @staticmethod
+    def get_word_counts_for_line(self, line: str) -> Dict[str, int]:
+        return sum(
+            [self.get_possible_subwords(word) for word in line.strip().split()],
+            Counter(),
+        )
+
     def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
@@ -24,8 +31,8 @@ class IBMModel1(object):
         self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
-                src_words = set(src_line.strip().split() + [self.null_str])
-                dst_words = set(dst_line.strip().split())
+                src_words = Counter(src_line.strip().split() + [self.null_str])
+                dst_words = Counter(dst_line.strip().split())
                 for src_word in src_words:
                     if src_word not in self.translation_prob:
                         self.translation_prob[src_word] = defaultdict(float)
@@ -100,22 +107,25 @@ class IBMModel1(object):
         return translation_expectations
 
     def e_step(
-        self, src_words: List, dst_words: List, translation_expectations: Dict
+        self,
+        src_words: Dict[str, int],
+        dst_words: Dict[str, int],
+        translation_expectations: Dict,
     ) -> None:
         """
         Args:
             translation_expectations: holder of expectations until now. This method
                 should update this
+            src_words and dst_words are Counter objects.
         """
         denom = defaultdict(float)
         translation_fractional_counts = defaultdict(lambda: defaultdict(float))
-
         for src_word in src_words:
             for dst_word in dst_words:
-                denom[src_word] += self.translation_prob[src_word][dst_word]
-                translation_fractional_counts[src_word][
-                    dst_word
-                ] += self.translation_prob[src_word][dst_word]
+                s_count, d_count = src_words[src_word], dst_words[dst_word]
+                prob = self.translation_prob[src_word][dst_word] * s_count * d_count
+                denom[src_word] += prob
+                translation_fractional_counts[src_word][dst_word] += prob
 
         for src_word in translation_fractional_counts.keys():
             if src_word not in translation_expectations:


### PR DESCRIPTION
Summary: Here is pulled the pool from each sub-method to the higher method. This reduces the overhead for pool creation. It is worth noting that we still suffer from weird problem with pooling (i.e. it does not really improve the speed).

Differential Revision: D14987524

