### PR TITLE
Support loading dataset from multiple paths in PytorchTranslateTask

### DIFF
--- a/pytorch_translate/data/data.py
+++ b/pytorch_translate/data/data.py
@@ -2,7 +2,7 @@
 
 import os
 import tempfile
-from typing import NamedTuple, Optional
+from typing import Dict, NamedTuple, Optional
 
 import numpy as np
 import torch
@@ -35,6 +35,11 @@ class ParallelCorpusConfig(NamedTuple):
     source: CorpusConfig
     target: CorpusConfig
     weights_file: Optional[str]
+
+
+class ParallelCorporaMapConfig(NamedTuple):
+    src_files: Dict[str, str]
+    tgt_files: Dict[str, str]
 
 
 class InMemoryNumpyDataset(data.indexed_dataset.IndexedDataset):


### PR DESCRIPTION
Summary:
With the capability of loading binaries from multiple paths, the task could support controlling sample ratio of different sources. Useful for backtranslation experiments.

If dataset is from multi-source, we use MultiCorpusSampledDataset to control the sampling ratio between different datasets. The default strategy is to sample uniformly.

Question:

~~(1) What is the future for WeightedLanguagePairDataset / weights_file?~~ Will switch to LanguagePairDataset as weights are not used for now anyway

Differential Revision: D14946072

