### PR TITLE
Semi-online BBPE part 3: Pruning translation candidates

### DIFF
--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -183,4 +183,33 @@ class TestBPE(unittest.TestCase):
         bpe_model._init_params(
             src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
         )
+        assert len(bpe_model.bpe_probs_from_alignment) == 80
+        assert bpe_model.eow_symbol in bpe_model.bpe_probs_from_alignment
+
+        shutil.rmtree(tmp_dir)
+
+    def test_calc_word_probs(self):
+        with patch("builtins.open") as mock_open:
+            bpe_model = bilingual_bpe.BilingualBPE()
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            v = bpe_model._calc_word_probs(txt_path="no_exist_file.txt")
+            assert len(v) == 9
+            assert v["123"] == 2 / 11
+            assert v["123456789"] == 1 / 11
+
+    def test_best_candidate_bilingual(self):
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        num_cpus = 3
+        pool = Pool(num_cpus)
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=num_cpus
+        )
+
+        b1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        c1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        # For the best step, it is the same as monolingual.
+        assert b1 == c1
+
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -51,21 +51,3 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)
-
-    def test_em_step(self):
-        ibm_model = CharIBMModel1()
-
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
-
-        pool = Pool(3)
-        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
-
-        assert len(ibm_model.translation_prob) == 80
-        assert (
-            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
-            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
-        )
-        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
-
-        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -51,3 +51,21 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)
+
+    def test_em_step(self):
+        ibm_model = CharIBMModel1()
+
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
+
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
+
+        assert len(ibm_model.translation_prob) == 80
+        assert (
+            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
+            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
+        )
+        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 
+from collections import defaultdict
+from typing import Dict, Tuple
+
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     Word2CharIBMModel1,
 )
 
 
-class BilingualBPE(object):
+class BilingualBPE(BPE):
     """
     An extension of the BPE model that is cross-lingual wrt parallel data.
     """
 
     def __init__(self):
-        self.src_bpe = BPE()
+        super().__init__()
         self.dst2src_ibm_model = Word2CharIBMModel1()
 
     def _init_params(
@@ -25,7 +28,7 @@ class BilingualBPE(object):
             num_ibm_iters: Number of training epochs for the IBM model.
             num_cpus: Number of CPUs for training the IBM model with multi-processing.
         """
-        self.src_bpe._init_vocab(txt_path=src_txt_path)
+        self._init_vocab(txt_path=src_txt_path)
 
         # Note the reverse side of the model. Target is word based, that is why
         # we give it a reverse order.
@@ -35,3 +38,63 @@ class BilingualBPE(object):
             num_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
+
+        self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
+            dst_txt_path=dst_txt_path
+        )
+
+    def _calc_word_probs(self, txt_path: str) -> Dict[str, float]:
+        """
+        Calculates the probability of each word from raw counts in a text file.
+        """
+        vocab = defaultdict(float)
+        with open(txt_path) as txt_file:
+            for line in txt_file:
+                for word in line.strip().split():
+                    vocab[word] += 1
+
+        denom = sum(vocab.values())
+        for word in vocab.keys():
+            vocab[word] /= denom
+        return vocab
+
+    def _calc_bpe_prob_from_alignment(self, dst_txt_path) -> Dict[str, float]:
+        """
+         p(subword=s) = sum_{t in target} p(s|t) p(t)
+         where p(t) is target_word_prob[t] from _calc_word_probs
+         and p(s|t) = self.dst2src_ibm_model.translation_prob[t][s]
+        """
+        target_word_probs = self._calc_word_probs(txt_path=dst_txt_path)
+        bpe_alignment_prob = defaultdict(float)
+        for dst_word in self.dst2src_ibm_model.translation_prob.keys():
+            target_word_prob = target_word_probs[dst_word]
+            alignment_probs = self.dst2src_ibm_model.translation_prob[dst_word]
+            for src_subword in self.dst2src_ibm_model.translation_prob[dst_word]:
+                bpe_alignment_prob[src_subword] += (
+                    alignment_probs[src_subword] * target_word_prob
+                )
+        return bpe_alignment_prob
+
+    def _best_candidate_substep(
+        self, start_end_indices: Tuple[int, int]
+    ) -> Dict[Tuple[str, str], float]:
+        """
+        Args:
+            start_end_indices: first and end index for part of
+                self.current_train_data to search for.
+        """
+
+        start_index, end_index = start_end_indices[0], start_end_indices[1]
+        assert start_index <= end_index
+
+        candidates = defaultdict(float)
+        for (seg, freq) in self.current_train_data[start_index:end_index]:
+            symbols = seg.split()
+            for i in range(len(symbols) - 1):
+                bpe_key = (symbols[i], symbols[i + 1])
+                bpe_token = "".join(bpe_key)
+
+                # Note that this line is the only difference between this class
+                # and its parent BPE.
+                candidates[bpe_key] += freq * self.bpe_probs_from_alignment[bpe_token]
+        return candidates


### PR DESCRIPTION
Summary: Pruning p(subword | target_word) to just top_k in order to 1) speed up the search, 2) reduce ibm model noise.

Differential Revision: D15003646

