### PR TITLE
Semi-online BBPE part 4: Building BPE candidates

### DIFF
--- a/pytorch_translate/research/test/morphology_test_utils.py
+++ b/pytorch_translate/research/test/morphology_test_utils.py
@@ -4,7 +4,7 @@ import tempfile
 from os import path
 
 
-def get_two_tmp_files():
+def get_two_same_tmp_files():
     src_txt_content = [
         "123 124 234 345",
         "112 122 123 345",
@@ -16,6 +16,30 @@ def get_two_tmp_files():
         "112 122 123 345",
         "123456789",
         "123456 456789",
+    ]
+    content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
+    tmp_dir = tempfile.mkdtemp()
+    file1, file2 = path.join(tmp_dir, "test1.txt"), path.join(tmp_dir, "test2.txt")
+    with open(file1, "w") as f1:
+        f1.write(content1)
+    with open(file2, "w") as f2:
+        f2.write(content2)
+
+    return tmp_dir, file1, file2
+
+
+def get_two_different_tmp_files():
+    src_txt_content = [
+        "123 124 234 345",
+        "112 122 123 345",
+        "123456789",
+        "123456 456789",
+    ]
+    dst_txt_content = [
+        "abc abd bcd cde",
+        "aab abb abc cde",
+        "abcdefghi",
+        "abcdef defghi",
     ]
     content1, content2 = "\n".join(src_txt_content), "\n".join(dst_txt_content)
     tmp_dir = tempfile.mkdtemp()

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -215,3 +215,19 @@ class TestBPE(unittest.TestCase):
             assert len(v) == 9
             assert v["123"] == 2 / 11
             assert v["123456789"] == 1 / 11
+
+    def test_best_candidate_bilingual(self):
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        num_cpus = 3
+        pool = Pool(num_cpus)
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=num_cpus
+        )
+
+        b1 = bpe_model.src_bpe.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        c1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        # For the best step, it is the same as monolingual.
+        assert b1 == c1
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from collections import Counter
+from multiprocessing import Pool
 from os import path
 from unittest.mock import Mock, patch
 
@@ -41,8 +42,12 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
-
-            assert bpe_model.get_best_candidate(num_cpus=3) == ("1", "2")
+            num_cpus = 3
+            pool = Pool(processes=num_cpus)
+            assert bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool) == (
+                "1",
+                "2",
+            )
 
     def test_bpe_merge(self):
         bpe_model = bpe.BPE()
@@ -51,29 +56,31 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
+            num_cpus = 3
+            pool = Pool(processes=num_cpus)
 
             # Trying merging a candidate that does not exist.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "1"), num_cpus=3
+                candidate=("3", "1"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 10
 
             # Trying merging a candidate that does exists.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("2", "3"), num_cpus=3
+                candidate=("2", "3"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 
             # Trying merging a candidate that does exists. Entry "3" should remove
             # from vocab.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "4"), num_cpus=3
+                candidate=("3", "4"), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 
             # Trying merging a candidate that does not exist.
             vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", bpe_model.eow_symbol), num_cpus=3
+                candidate=("3", bpe_model.eow_symbol), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
 

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -8,7 +8,8 @@ from multiprocessing import Pool
 from os import path
 from unittest.mock import Mock, patch
 
-from pytorch_translate.research.unsupervised_morphology import bpe
+from pytorch_translate.research.test import morphology_test_utils as morph_utils
+from pytorch_translate.research.unsupervised_morphology import bilingual_bpe, bpe
 
 
 txt_content = ["123 124 234 345", "112 122 123 345", "123456789", "123456 456789"]
@@ -170,4 +171,16 @@ class TestBPE(unittest.TestCase):
         model_output = open(output_file, "r", encoding="utf-8").read().strip()
         assert expected_output == model_output
 
+        shutil.rmtree(tmp_dir)
+
+    def test_bilingual_bpe_init(self):
+        """
+            This looks more like an integration test because each subpeace is tested
+            in different places.
+        """
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
+        )
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -6,6 +6,7 @@ from multiprocessing import Pool
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
+    Char2WordIBMModel1,
     CharIBMModel1,
 )
 
@@ -32,11 +33,21 @@ class TestCharIBMModel1(unittest.TestCase):
         assert "12345" not in substrs
 
     def test_morph_init(self):
-        ibm_model = CharIBMModel1()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        ibm_model = CharIBMModel1()
         ibm_model.initialize_translation_probs(f1, f2)
-        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
+        assert ibm_model.translation_prob["5"]["d" + ibm_model.eow_symbol] > 0
         assert len(ibm_model.translation_prob) == 80
         assert len(ibm_model.training_data) == 4
+
+        ibm_model = Char2WordIBMModel1(max_subword_len=4)
+        ibm_model.initialize_translation_probs(f1, f2)
+        assert "abcdefghi" not in ibm_model.translation_prob["123456789"]
+        assert "cdef" in ibm_model.translation_prob["123456789"]
+        assert "cde" in ibm_model.translation_prob["123456789"]
+        assert len(ibm_model.translation_prob["123456789"]) == 34
+        assert len(ibm_model.translation_prob) == 9
+        assert len(ibm_model.training_data) == 4
+
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -40,21 +40,3 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.translation_prob) == 80
         assert len(ibm_model.training_data) == 4
         shutil.rmtree(tmp_dir)
-
-    def test_em_step(self):
-        ibm_model = CharIBMModel1()
-
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
-
-        pool = Pool(3)
-        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
-
-        assert len(ibm_model.translation_prob) == 80
-        assert (
-            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
-            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
-        )
-        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
-
-        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -2,6 +2,7 @@
 
 import shutil
 import unittest
+from multiprocessing import Pool
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
@@ -37,15 +38,17 @@ class TestCharIBMModel1(unittest.TestCase):
         ibm_model.initialize_translation_probs(f1, f2)
         assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
         assert len(ibm_model.translation_prob) == 80
+        assert len(ibm_model.training_data) == 4
         shutil.rmtree(tmp_dir)
 
     def test_em_step(self):
         ibm_model = CharIBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(f1, f2)
+        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
 
-        ibm_model.em_step(f1, f2)
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
 
         assert len(ibm_model.translation_prob) == 80
         assert (

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -15,7 +15,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_morph_init(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         assert len(ibm_model.translation_prob) == 10
         assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
@@ -26,7 +26,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_e_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         translation_counts = defaultdict(lambda: defaultdict(float))
 
@@ -41,7 +41,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_em_step(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
         pool = Pool(3)
@@ -59,7 +59,7 @@ class TestIBMModel1(unittest.TestCase):
     def test_ibm_train(self):
         ibm_model = IBMModel1()
 
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.learn_ibm_parameters(
             src_path=f1, dst_path=f2, num_iters=3, num_cpus=3
         )

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from collections import defaultdict
+from multiprocessing import Pool
 from os import path
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
@@ -43,7 +44,8 @@ class TestIBMModel1(unittest.TestCase):
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
 
-        ibm_model.em_step(f1, f2)
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
@@ -58,7 +60,9 @@ class TestIBMModel1(unittest.TestCase):
         ibm_model = IBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
+        ibm_model.learn_ibm_parameters(
+            src_path=f1, dst_path=f2, num_iters=3, num_cpus=3
+        )
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -3,7 +3,7 @@
 import shutil
 import tempfile
 import unittest
-from collections import defaultdict
+from collections import Counter, defaultdict
 from multiprocessing import Pool
 from os import path
 
@@ -31,8 +31,8 @@ class TestIBMModel1(unittest.TestCase):
         translation_counts = defaultdict(lambda: defaultdict(float))
 
         ibm_model.e_step(
-            ["123", "124", "234", "345", ibm_model.null_str],
-            ["123", "124", "234", "345"],
+            Counter(["123", "124", "234", "345", ibm_model.null_str]),
+            Counter(["123", "124", "234", "345"]),
             translation_counts,
         )
         assert translation_counts["123"]["345"] == 1.0 / 4

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import math
 from collections import defaultdict
-from typing import Dict
+from multiprocessing import Pool
+from typing import Dict, Optional, Tuple
 
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
@@ -49,6 +51,18 @@ class BilingualBPE(object):
         # Probability of target words.
         self.target_word_prob = BilingualBPE.calc_word_probs(txt_path=dst_txt_path)
 
+        # This is the reverse of self.dst2src_ibm_model.translation_prob, but since
+        # we need to search p(s|t) for only those candidates that are relevant,
+        # this value is useful.
+        self.dst_candidate4src_subword = {}
+        for dst_word in self.dst2src_ibm_model.translation_prob.keys():
+            for src_subword in self.dst2src_ibm_model.translation_prob[dst_word]:
+                if src_subword not in self.dst_candidate4src_subword:
+                    self.dst_candidate4src_subword[src_subword] = {}
+                self.dst_candidate4src_subword[src_subword][
+                    dst_word
+                ] = self.dst2src_ibm_model.translation_prob[dst_word][src_subword]
+
     @staticmethod
     def calc_word_probs(txt_path: str) -> Dict[str, float]:
         vocab = defaultdict(float)
@@ -68,12 +82,70 @@ class BilingualBPE(object):
         Instead we keep a small number of top items for each candidate.
         We also normalize their value to form a probability distribution.
         """
-        for bpe_type in self.dst2src_ibm_model.translation_prob.keys():
+        for target_word in self.dst2src_ibm_model.translation_prob.keys():
             top_k_pairs = sorted(
-                self.dst2src_ibm_model.translation_prob[bpe_type].items(),
+                self.dst2src_ibm_model.translation_prob[target_word].items(),
                 key=lambda x: -x[1],
             )[:topk]
             denom = sum(v for (_, v) in top_k_pairs)
-            self.dst2src_ibm_model.translation_prob[bpe_type] = defaultdict(
+            self.dst2src_ibm_model.translation_prob[target_word] = defaultdict(
                 float, {k: v / denom for (k, v) in top_k_pairs}
             )
+
+    def _best_candidate_substep(
+        self, start_end_indices: Tuple[int, int]
+    ) -> Dict[Tuple[str, str], float]:
+        """
+        Args:
+            start_end_indices: first and end index for part of
+                self.current_train_data to search for.
+        """
+
+        start_index, end_index = start_end_indices[0], start_end_indices[1]
+        assert start_index <= end_index
+
+        candidates = defaultdict(float)
+        for (seg, freq) in self.src_bpe.current_train_data[start_index:end_index]:
+            symbols = seg.split()
+            for i in range(len(symbols) - 1):
+                bpe_key = (symbols[i], symbols[i + 1])
+                candidates[bpe_key] += freq
+
+        for bpe_key in candidates.keys():
+            prob = 0  # To avoid zero proability.
+            bpe_token = "".join(bpe_key)
+
+            if bpe_token in self.dst_candidate4src_subword:
+                # p(bpe_token=c) = \sum_{t \in other_side} p(c|t) p(t)
+                for target_word in self.dst_candidate4src_subword[bpe_token].keys():
+                    prob += (
+                        self.dst_candidate4src_subword[bpe_token][target_word]
+                        * self.target_word_prob[target_word]
+                    )
+            candidates[bpe_key] *= max(1e-20, prob)
+
+        return candidates
+
+    def get_best_candidate(
+        self, num_cpus: int, pool: Pool
+    ) -> Optional[Tuple[str, str]]:
+        """
+        Calculates frequencies for new candidiates from the current vocabulary,
+        and returns the candidate with the most frequency.
+        """
+        data_chunk_size = max(
+            1, math.ceil(len(self.src_bpe.current_train_data) / num_cpus)
+        )
+        indices = [
+            (
+                i * data_chunk_size,
+                min(data_chunk_size * (i + 1), len(self.src_bpe.current_train_data)),
+            )
+            for i in range(num_cpus)
+        ]
+        results = pool.map(self._best_candidate_substep, indices)
+        candidates = defaultdict(float)
+        for result in results:
+            for (k, v) in result.items():
+                candidates[k] += v
+        return max(candidates, key=candidates.get) if len(candidates) > 0 else None

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+from collections import defaultdict
+from typing import Dict
+
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     Char2WordIBMModel1,
@@ -16,7 +19,12 @@ class BilingualBPE(object):
         self.dst2src_ibm_model = Char2WordIBMModel1()
 
     def _init_params(
-        self, src_txt_path: str, dst_txt_path: str, num_ibm_iters: int, num_cpus: int
+        self,
+        src_txt_path: str,
+        dst_txt_path: str,
+        num_ibm_iters: int,
+        num_cpus: int,
+        top_k_translations: int = 5,
     ):
         """
         Args:
@@ -24,6 +32,7 @@ class BilingualBPE(object):
             dst_txt_path: Text path for target language in parallel data.
             num_ibm_iters: Number of training epochs for the IBM model.
             num_cpus: Number of CPUs for training the IBM model with multi-processing.
+            top_k_translations: Just keep the top k in memory (for speed purposes).
         """
         self.src_bpe._init_vocab(txt_path=src_txt_path)
 
@@ -35,3 +44,36 @@ class BilingualBPE(object):
             num_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
+        self._prune_translation_candidates(topk=top_k_translations)
+
+        # Probability of target words.
+        self.target_word_prob = BilingualBPE.calc_word_probs(txt_path=dst_txt_path)
+
+    @staticmethod
+    def calc_word_probs(txt_path: str) -> Dict[str, float]:
+        vocab = defaultdict(float)
+        with open(txt_path) as txt_file:
+            for line in txt_file:
+                for word in line.strip().split():
+                    vocab[word] += 1
+
+        denom = sum(vocab.values())
+        for word in vocab.keys():
+            vocab[word] /= denom
+        return vocab
+
+    def _prune_translation_candidates(self, topk: int = 5):
+        """
+        Searching over all possible translation candidates is very time-consuming.
+        Instead we keep a small number of top items for each candidate.
+        We also normalize their value to form a probability distribution.
+        """
+        for bpe_type in self.dst2src_ibm_model.translation_prob.keys():
+            top_k_pairs = sorted(
+                self.dst2src_ibm_model.translation_prob[bpe_type].items(),
+                key=lambda x: -x[1],
+            )[:topk]
+            denom = sum(v for (_, v) in top_k_pairs)
+            self.dst2src_ibm_model.translation_prob[bpe_type] = defaultdict(
+                float, {k: v / denom for (k, v) in top_k_pairs}
+            )

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from pytorch_translate.research.unsupervised_morphology.bpe import BPE
+from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
+    Char2WordIBMModel1,
+)
+
+
+class BilingualBPE(object):
+    """
+    An extension of the BPE model that is cross-lingual wrt parallel data.
+    """
+
+    def __init__(self):
+        self.src_bpe = BPE()
+        self.dst2src_ibm_model = Char2WordIBMModel1()
+
+    def _init_params(
+        self, src_txt_path: str, dst_txt_path: str, num_ibm_iters: int, num_cpus: int
+    ):
+        """
+        Args:
+            src_txt_path: Text path for source language in parallel data.
+            dst_txt_path: Text path for target language in parallel data.
+            num_ibm_iters: Number of training epochs for the IBM model.
+            num_cpus: Number of CPUs for training the IBM model with multi-processing.
+        """
+        self.src_bpe._init_vocab(txt_path=src_txt_path)
+
+        # Note the reverse side of the model. Target is word based, that is why
+        # we give it a reverse order.
+        self.dst2src_ibm_model.learn_ibm_parameters(
+            src_path=dst_txt_path,
+            dst_path=src_txt_path,
+            num_iters=num_ibm_iters,
+            num_cpus=num_cpus,
+        )

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
+import datetime
+import math
 from collections import defaultdict
-from typing import Dict, List
+from multiprocessing import Pool
+from typing import Dict, List, Tuple
 
 
 class IBMModel1(object):
@@ -10,13 +13,15 @@ class IBMModel1(object):
         translation_prob is the translation probability in the IBM model 1.
         the full pseudo-code is available at https://fburl.com/yvp31kuw
         """
-        self.translation_prob = defaultdict(lambda: defaultdict(float))
+        self.translation_prob = defaultdict()
         self.null_str = "<null>"
+        self.training_data = []
 
     def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
         """
+        self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
                 src_words = set(src_line.strip().split() + [self.null_str])
@@ -26,32 +31,73 @@ class IBMModel1(object):
                         self.translation_prob[src_word] = defaultdict(float)
                     for dst_word in dst_words:
                         self.translation_prob[src_word][dst_word] = 1.0
+                self.training_data.append((src_words, dst_words))
 
         for src_word in self.translation_prob.keys():
             denom = len(self.translation_prob[src_word])
             for dst_word in self.translation_prob[src_word].keys():
                 self.translation_prob[src_word][dst_word] = 1.0 / denom
 
-    def learn_ibm_parameters(self, src_path: str, dst_path: str, num_iters: int):
+    def learn_ibm_parameters(
+        self, src_path: str, dst_path: str, num_iters: int, num_cpus: int
+    ):
         """
         Runs the EM algorithm for IBM model 1.
         Args:
             num_iters: Number of EM iterations.
         """
+        print(str(datetime.datetime.now()), "Initializing model parameters")
         self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
-        for iter in range(num_iters):
-            print("Iteration of IBM model(1):", str(iter + 1))
-            self.em_step(src_path=src_path, dst_path=dst_path)
+        with Pool(processes=num_cpus) as pool:
+            for iter in range(num_iters):
+                print(
+                    str(datetime.datetime.now()),
+                    "Iteration of IBM model(1):",
+                    str(iter + 1),
+                )
+                self.em_step(
+                    src_path=src_path, dst_path=dst_path, num_cpus=num_cpus, pool=pool
+                )
 
-    def em_step(self, src_path: str, dst_path: str) -> None:
-        translation_expectations = defaultdict(lambda: defaultdict(float))
+    def em_step(self, src_path: str, dst_path: str, num_cpus: int, pool: Pool) -> None:
+        """
+        Args:
+            num_cpus: Number of cpus used in multi-processing.
+            pool: Pool object for multi-proceesing.
+        """
+        translation_expectations = defaultdict()
 
-        with open(src_path) as src_file, open(dst_path) as dst_file:
-            for src_line, dst_line in zip(src_file, dst_file):
-                src_words = src_line.strip().split() + [self.null_str]
-                dst_words = dst_line.strip().split()
-                self.e_step(src_words, dst_words, translation_expectations)
+        data_chunk_size = max(1, math.ceil(len(self.training_data) / num_cpus))
+        indices = [
+            (
+                i * data_chunk_size,
+                min(data_chunk_size * (i + 1), len(self.training_data)),
+            )
+            for i in range(num_cpus)
+        ]
+        results = pool.map(self.e_sub_step, indices)
+        for result in results:
+            for src_word in result.keys():
+                if src_word not in translation_expectations:
+                    translation_expectations[src_word] = defaultdict(float)
+                for dst_word in result[src_word].keys():
+                    translation_expectations[src_word][dst_word] += result[src_word][
+                        dst_word
+                    ]
+
         self.m_step(translation_expectations)
+
+    def e_sub_step(self, start_end_index: Tuple[int, int]) -> Dict[str, Dict]:
+        """
+            Running the E step as a substep on the training data based on the
+            start and end indices.
+        """
+        translation_expectations: Dict[str, Dict] = defaultdict()
+        start_index, end_index = start_end_index
+        for i in range(start_index, end_index):
+            src_words, dst_words = self.training_data[i]
+            self.e_step(src_words, dst_words, translation_expectations)
+        return translation_expectations
 
     def e_step(
         self, src_words: List, dst_words: List, translation_expectations: Dict
@@ -62,21 +108,22 @@ class IBMModel1(object):
                 should update this
         """
         denom = defaultdict(float)
-        nominator = defaultdict(float)
+        translation_fractional_counts = defaultdict(lambda: defaultdict(float))
 
         for src_word in src_words:
-            if src_word not in nominator:
-                nominator[src_word] = defaultdict(float)
-
             for dst_word in dst_words:
                 denom[src_word] += self.translation_prob[src_word][dst_word]
-                nominator[src_word][dst_word] += self.translation_prob[src_word][
+                translation_fractional_counts[src_word][
                     dst_word
-                ]
+                ] += self.translation_prob[src_word][dst_word]
 
-        for src_word in nominator.keys():
-            for dst_word in nominator[src_word].keys():
-                delta = nominator[src_word][dst_word] / denom[src_word]
+        for src_word in translation_fractional_counts.keys():
+            if src_word not in translation_expectations:
+                translation_expectations[src_word] = defaultdict(float)
+            for dst_word in translation_fractional_counts[src_word].keys():
+                delta = (
+                    translation_fractional_counts[src_word][dst_word] / denom[src_word]
+                )
                 translation_expectations[src_word][dst_word] += delta
 
     def m_step(self, translation_expectations) -> None:

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -2,7 +2,7 @@
 
 import datetime
 import math
-from collections import defaultdict
+from collections import Counter, defaultdict
 from multiprocessing import Pool
 from typing import Dict, List, Tuple
 
@@ -17,6 +17,13 @@ class IBMModel1(object):
         self.null_str = "<null>"
         self.training_data = []
 
+    @staticmethod
+    def get_word_counts_for_line(self, line: str) -> Dict[str, int]:
+        return sum(
+            [self.get_possible_subwords(word) for word in line.strip().split()],
+            Counter(),
+        )
+
     def initialize_translation_probs(self, src_path: str, dst_path: str):
         """
         Direction of translation is conditioned on the source text: t(dst|src).
@@ -24,8 +31,8 @@ class IBMModel1(object):
         self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
-                src_words = set(src_line.strip().split() + [self.null_str])
-                dst_words = set(dst_line.strip().split())
+                src_words = Counter(src_line.strip().split() + [self.null_str])
+                dst_words = Counter(dst_line.strip().split())
                 for src_word in src_words:
                     if src_word not in self.translation_prob:
                         self.translation_prob[src_word] = defaultdict(float)
@@ -100,22 +107,25 @@ class IBMModel1(object):
         return translation_expectations
 
     def e_step(
-        self, src_words: List, dst_words: List, translation_expectations: Dict
+        self,
+        src_words: Dict[str, int],
+        dst_words: Dict[str, int],
+        translation_expectations: Dict,
     ) -> None:
         """
         Args:
             translation_expectations: holder of expectations until now. This method
                 should update this
+            src_words and dst_words are Counter objects.
         """
         denom = defaultdict(float)
         translation_fractional_counts = defaultdict(lambda: defaultdict(float))
-
         for src_word in src_words:
             for dst_word in dst_words:
-                denom[src_word] += self.translation_prob[src_word][dst_word]
-                translation_fractional_counts[src_word][
-                    dst_word
-                ] += self.translation_prob[src_word][dst_word]
+                s_count, d_count = src_words[src_word], dst_words[dst_word]
+                prob = self.translation_prob[src_word][dst_word] * s_count * d_count
+                denom[src_word] += prob
+                translation_fractional_counts[src_word][dst_word] += prob
 
         for src_word in translation_fractional_counts.keys():
             if src_word not in translation_expectations:


### PR DESCRIPTION
Summary:
In original BPE probability of each candidate is uniform, thus we basically count it as one. But here we use

$$$ p(s) = \sum_t p(s | t ) p(t) $$$

where t is a word in the other language in parallel data.

Differential Revision: D15005453

