### PR TITLE
Make sure all tensors are converted to cpu tensors before pickling

### DIFF
--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -287,4 +287,7 @@ class LMScorer(SimpleModelScorer):
         pad = self.task.dictionary.pad_index
         hypos_tokens_probs = (tgt_tokens != pad).float() * hypos_tokens_probs
 
-        return hypos_tokens_probs.sum(dim=1)
+        hypos_scores = hypos_tokens_probs.sum(dim=1) / (hypos_tokens_probs != 0).sum(
+            dim=1, dtype=torch.float
+        )
+        return hypos_scores

--- a/pytorch_translate/rescoring/rescorer.py
+++ b/pytorch_translate/rescoring/rescorer.py
@@ -186,13 +186,18 @@ def main():
 
     translation_info_list = pickle.load(open(args.translation_info_export_path, "rb"))
     for trans_info in tqdm(translation_info_list):
+        trans_info["hypos"] = [
+            {"score": hypo["score"], "tokens": hypo["tokens"].cuda()}
+            for hypo in trans_info["hypos"]
+        ]
+
         base_bleu_scorer.add(
             trans_info["target_tokens"].int().cpu(),
             trans_info["hypos"][0]["tokens"].int().cpu(),
         )
 
         rescoring_top_tokens = rescorer.score(
-            trans_info["src_tokens"], trans_info["hypos"]
+            trans_info["src_tokens"].cuda(), trans_info["hypos"]
         )
         rescoring_bleu_scorer.add(
             trans_info["target_tokens"].int().cpu(), rescoring_top_tokens.int().cpu()


### PR DESCRIPTION
Summary: Pickling tensors save their gpu metadata together with them. This means when we are loading pickle, they are loaded to exactly same GPU's. We don't want this.

Differential Revision: D15003183

