### PR TITLE
Removing regular expression matching from BPE search

### DIFF
--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -183,4 +183,33 @@ class TestBPE(unittest.TestCase):
         bpe_model._init_params(
             src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
         )
+        assert len(bpe_model.bpe_probs_from_alignment) == 80
+        assert bpe_model.eow_symbol in bpe_model.bpe_probs_from_alignment
+
+        shutil.rmtree(tmp_dir)
+
+    def test_calc_word_probs(self):
+        with patch("builtins.open") as mock_open:
+            bpe_model = bilingual_bpe.BilingualBPE()
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            v = bpe_model._calc_word_probs(txt_path="no_exist_file.txt")
+            assert len(v) == 9
+            assert v["123"] == 2 / 11
+            assert v["123456789"] == 1 / 11
+
+    def test_best_candidate_bilingual(self):
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        num_cpus = 3
+        pool = Pool(num_cpus)
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=num_cpus
+        )
+
+        b1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        c1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        # For the best step, it is the same as monolingual.
+        assert b1 == c1
+
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -122,7 +122,7 @@ class TestBPE(unittest.TestCase):
                 txt_path="no_exist_file.txt", vocab_size=12, num_cpus=3
             )
             # asserting that the size is as expected.
-            assert vocab_size == 12
+            assert vocab_size == len(bpe_model.vocab) == 12
             assert bpe_model.max_bpe_len == len(bpe_model.eow_symbol)
 
     def test_segment_word(self):
@@ -212,4 +212,13 @@ class TestBPE(unittest.TestCase):
         # For the best step, it is the same as monolingual.
         assert b1 == c1
 
+        shutil.rmtree(tmp_dir)
+
+    def test_build_bilingual_vocab(self):
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        vocab_size = bpe_model.build_vocab(
+            src_txt_path=f1, dst_txt_path=f2, vocab_size=12, num_ibm_iters=3, num_cpus=3
+        )
+        assert vocab_size == len(bpe_model.vocab) == 12
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -25,9 +25,8 @@ class TestBPE(unittest.TestCase):
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
 
             vocab_items = Counter()
-            for vocab_entry, freq in bpe_model.current_train_data:
-                items = vocab_entry.split()
-                for item in items:
+            for (vocab_entry, freq) in bpe_model.current_train_data:
+                for item in vocab_entry:
                     vocab_items[item] += freq
 
             assert vocab_items[bpe_model.eow_symbol] == 11
@@ -84,20 +83,6 @@ class TestBPE(unittest.TestCase):
                 candidate=("3", bpe_model.eow_symbol), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
-
-    def test_merge_pattern(self):
-        pattern1 = bpe.BPE.get_merge_pattern("c c")
-        assert pattern1.sub("cc", "x|x?^d@@ c c ^d") == "x|x?^d@@ cc ^d"
-
-        pattern2 = bpe.BPE.get_merge_pattern("^d@ @c")
-        assert (
-            pattern2.sub("^d@@c", "^d@ @cx|x? ^d@ @c c ^d") == "^d@ @cx|x? ^d@@c c ^d"
-        )
-
-        pattern3 = bpe.BPE.get_merge_pattern("x| x")
-        assert (
-            pattern3.sub("x|x", "^d@ @c x| x ?^d@ @c c ^d") == "^d@ @c x|x ?^d@ @c c ^d"
-        )
 
     def test_build_vocab(self):
         bpe_model = bpe.BPE()

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -51,21 +51,3 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)
-
-    def test_em_step(self):
-        ibm_model = CharIBMModel1()
-
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
-
-        pool = Pool(3)
-        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
-
-        assert len(ibm_model.translation_prob) == 80
-        assert (
-            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
-            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
-        )
-        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
-
-        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -51,3 +51,21 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)
+
+    def test_em_step(self):
+        ibm_model = CharIBMModel1()
+
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
+
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
+
+        assert len(ibm_model.translation_prob) == 80
+        assert (
+            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
+            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
+        )
+        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -142,10 +142,12 @@ class BilingualBPE(BPE):
         assert start_index <= end_index
 
         candidates = defaultdict(float)
-        for (seg, freq) in self.current_train_data[start_index:end_index]:
-            symbols = seg.split()
-            for i in range(len(symbols) - 1):
-                bpe_key = (symbols[i], symbols[i + 1])
+        for i in range(start_index, end_index):
+            if i >= len(self.current_train_data):
+                break
+            (seg, freq) = self.current_train_data[i]
+            for i in range(len(seg) - 1):
+                bpe_key = (seg[i], seg[i + 1])
                 bpe_token = "".join(bpe_key)
 
                 # Note that this line is the only difference between this class

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 
+from collections import defaultdict
+from typing import Dict, Tuple
+
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     Word2CharIBMModel1,
 )
 
 
-class BilingualBPE(object):
+class BilingualBPE(BPE):
     """
     An extension of the BPE model that is cross-lingual wrt parallel data.
     """
 
     def __init__(self):
-        self.src_bpe = BPE()
+        super().__init__()
         self.dst2src_ibm_model = Word2CharIBMModel1()
 
     def _init_params(
@@ -25,7 +28,7 @@ class BilingualBPE(object):
             num_ibm_iters: Number of training epochs for the IBM model.
             num_cpus: Number of CPUs for training the IBM model with multi-processing.
         """
-        self.src_bpe._init_vocab(txt_path=src_txt_path)
+        self._init_vocab(txt_path=src_txt_path)
 
         # Note the reverse side of the model. Target is word based, that is why
         # we give it a reverse order.
@@ -35,3 +38,63 @@ class BilingualBPE(object):
             num_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
+
+        self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
+            dst_txt_path=dst_txt_path
+        )
+
+    def _calc_word_probs(self, txt_path: str) -> Dict[str, float]:
+        """
+        Calculates the probability of each word from raw counts in a text file.
+        """
+        vocab = defaultdict(float)
+        with open(txt_path) as txt_file:
+            for line in txt_file:
+                for word in line.strip().split():
+                    vocab[word] += 1
+
+        denom = sum(vocab.values())
+        for word in vocab.keys():
+            vocab[word] /= denom
+        return vocab
+
+    def _calc_bpe_prob_from_alignment(self, dst_txt_path) -> Dict[str, float]:
+        """
+         p(subword=s) = sum_{t in target} p(s|t) p(t)
+         where p(t) is target_word_prob[t] from _calc_word_probs
+         and p(s|t) = self.dst2src_ibm_model.translation_prob[t][s]
+        """
+        target_word_probs = self._calc_word_probs(txt_path=dst_txt_path)
+        bpe_alignment_prob = defaultdict(float)
+        for dst_word in self.dst2src_ibm_model.translation_prob.keys():
+            target_word_prob = target_word_probs[dst_word]
+            alignment_probs = self.dst2src_ibm_model.translation_prob[dst_word]
+            for src_subword in self.dst2src_ibm_model.translation_prob[dst_word]:
+                bpe_alignment_prob[src_subword] += (
+                    alignment_probs[src_subword] * target_word_prob
+                )
+        return bpe_alignment_prob
+
+    def _best_candidate_substep(
+        self, start_end_indices: Tuple[int, int]
+    ) -> Dict[Tuple[str, str], float]:
+        """
+        Args:
+            start_end_indices: first and end index for part of
+                self.current_train_data to search for.
+        """
+
+        start_index, end_index = start_end_indices[0], start_end_indices[1]
+        assert start_index <= end_index
+
+        candidates = defaultdict(float)
+        for (seg, freq) in self.current_train_data[start_index:end_index]:
+            symbols = seg.split()
+            for i in range(len(symbols) - 1):
+                bpe_key = (symbols[i], symbols[i + 1])
+                bpe_token = "".join(bpe_key)
+
+                # Note that this line is the only difference between this class
+                # and its parent BPE.
+                candidates[bpe_key] += freq * self.bpe_probs_from_alignment[bpe_token]
+        return candidates

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 
-import datetime
+import logging
 import math
 from collections import Counter, defaultdict
 from multiprocessing import Pool
 from typing import Dict, List, Tuple
+
+
+logging.basicConfig(format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
 
 
 class IBMModel1(object):
@@ -53,15 +57,11 @@ class IBMModel1(object):
         Args:
             num_iters: Number of EM iterations.
         """
-        print(str(datetime.datetime.now()), "Initializing model parameters")
+        logger.warning("Initializing model parameters")
         self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
         with Pool(processes=num_cpus) as pool:
             for iter in range(num_iters):
-                print(
-                    str(datetime.datetime.now()),
-                    "Iteration of IBM model(1):",
-                    str(iter + 1),
-                )
+                logger.warning(f"Iteration of IBM model: {str(iter+1)}")
                 self.em_step(
                     src_path=src_path, dst_path=dst_path, num_cpus=num_cpus, pool=pool
                 )


### PR DESCRIPTION
Summary: For faster BPE implementation, we should not use regular expressions. Next diffs will implement a trick to make BPE super fast.

Differential Revision: D15032434

