### PR TITLE
Only check dataset_upsampling keyset is a subset of src_bin_path

### DIFF
--- a/pytorch_translate/tasks/pytorch_translate_task.py
+++ b/pytorch_translate/tasks/pytorch_translate_task.py
@@ -230,7 +230,8 @@ class PytorchTranslateTask(FairseqTask):
             assert type(tgt_bin_path) is not str
             assert set(src_bin_path.keys()) == set(tgt_bin_path.keys())
             if dataset_upsampling is not None:
-                assert set(dataset_upsampling.keys()) == set(src_bin_path.keys())
+                for key in dataset_upsampling.keys():
+                    assert key in src_bin_path.keys()
             self._load_dataset_multi_path(
                 split, src_bin_path, tgt_bin_path, dataset_upsampling
             )


### PR DESCRIPTION
Summary: Previously we check the two share same keyset but then users have to specify weights for every entry. Now they could just assign upsample ratio to dataset of interest

Differential Revision: D15032170

