### PR TITLE
Fast BPE implementation with memoization

### DIFF
--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -35,6 +35,12 @@ class TestBPE(unittest.TestCase):
             assert "12" not in vocab_items
             assert "123" not in vocab_items
 
+            assert len(bpe_model.merge_candidate_indices) == 17
+            assert bpe_model.merge_candidate_indices[("2", "3")] == {0, 2, 6, 7}
+
+            assert len(bpe_model.merge_candidate_freq) == 17
+            assert bpe_model.merge_candidate_freq[("2", "3")] == 5
+
     def test_best_candidate(self):
         bpe_model = bpe.BPE()
 
@@ -42,12 +48,7 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
-            num_cpus = 3
-            pool = Pool(processes=num_cpus)
-            assert bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool) == (
-                "1",
-                "2",
-            )
+            assert bpe_model.get_best_candidate() == ("1", "2")
 
     def test_bpe_merge(self):
         bpe_model = bpe.BPE()
@@ -56,33 +57,25 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
-            num_cpus = 3
-            pool = Pool(processes=num_cpus)
 
             # Trying merging a candidate that does not exist.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "1"), num_cpus=num_cpus, pool=pool
-            )
-            assert vocab_size == 10
+            bpe_model.merge_candidate_into_vocab(merge_candidate=("3", "1"))
+            assert len(bpe_model.vocab) == 10
 
-            # Trying merging a candidate that does exists.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("2", "3"), num_cpus=num_cpus, pool=pool
-            )
-            assert vocab_size == 11
+            # Trying merging a candidate that exists.
+            bpe_model.merge_candidate_into_vocab(merge_candidate=("2", "3"))
+            assert len(bpe_model.vocab) == 11
 
-            # Trying merging a candidate that does exists. Entry "3" should remove
+            # Trying merging a candidate that exists. Entry "3" should remove
             # from vocab.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", "4"), num_cpus=num_cpus, pool=pool
-            )
-            assert vocab_size == 11
+            bpe_model.merge_candidate_into_vocab(merge_candidate=("3", "4"))
+            assert len(bpe_model.vocab) == 11
 
             # Trying merging a candidate that does not exist.
-            vocab_size = bpe_model.merge_candidate_into_vocab(
-                candidate=("3", bpe_model.eow_symbol), num_cpus=num_cpus, pool=pool
+            bpe_model.merge_candidate_into_vocab(
+                merge_candidate=("3", bpe_model.eow_symbol)
             )
-            assert vocab_size == 11
+            assert len(bpe_model.vocab) == 11
 
     def test_build_vocab(self):
         bpe_model = bpe.BPE()
@@ -93,7 +86,7 @@ class TestBPE(unittest.TestCase):
 
             # Trying to build a vocab more than the possible size
             vocab_size = bpe_model.build_vocab(
-                txt_path="no_exist_file.txt", vocab_size=20, num_cpus=3
+                txt_path="no_exist_file.txt", vocab_size=20
             )
             # Asserting that we go back to the original size (number of word types.)
             assert vocab_size == 9
@@ -104,11 +97,11 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
             # Trying to build a vocab with an acceptable size.
             vocab_size = bpe_model.build_vocab(
-                txt_path="no_exist_file.txt", vocab_size=12, num_cpus=3
+                txt_path="no_exist_file.txt", vocab_size=12
             )
             # asserting that the size is as expected.
             assert vocab_size == len(bpe_model.vocab) == 12
-            assert bpe_model.max_bpe_len == len(bpe_model.eow_symbol)
+            assert bpe_model.max_bpe_len == 2
 
     def test_segment_word(self):
         bpe_model = bpe.BPE()
@@ -117,9 +110,7 @@ class TestBPE(unittest.TestCase):
             mock_open.return_value.__enter__ = mock_open
             mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
 
-            bpe_model.build_vocab(
-                txt_path="no_exist_file.txt", vocab_size=12, num_cpus=3
-            )
+            bpe_model.build_vocab(txt_path="no_exist_file.txt", vocab_size=12)
             assert bpe_model.segment_word("1234") == ["12", "34", bpe_model.eow_symbol]
 
             # Giving unknown character sequence
@@ -141,7 +132,7 @@ class TestBPE(unittest.TestCase):
 
         with open(input_file, "w", encoding="utf-8") as writer:
             writer.write("\n".join(txt_content))
-        bpe_model.build_vocab(txt_path=input_file, vocab_size=12, num_cpus=3)
+        bpe_model.build_vocab(txt_path=input_file, vocab_size=12)
 
         output = []
         for line in txt_content:
@@ -168,7 +159,7 @@ class TestBPE(unittest.TestCase):
         bpe_model._init_params(
             src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
         )
-        assert len(bpe_model.bpe_probs_from_alignment) == 80
+        assert len(bpe_model.bpe_probs_from_alignment) == 83
         assert bpe_model.eow_symbol in bpe_model.bpe_probs_from_alignment
 
         shutil.rmtree(tmp_dir)
@@ -186,14 +177,12 @@ class TestBPE(unittest.TestCase):
     def test_best_candidate_bilingual(self):
         bpe_model = bilingual_bpe.BilingualBPE()
         tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
-        num_cpus = 3
-        pool = Pool(num_cpus)
         bpe_model._init_params(
-            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=num_cpus
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
         )
 
-        b1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
-        c1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        b1 = bpe_model.get_best_candidate()
+        c1 = bpe_model.get_best_candidate()
         # For the best step, it is the same as monolingual.
         assert b1 == c1
 

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -38,7 +38,7 @@ class TestCharIBMModel1(unittest.TestCase):
         ibm_model = CharIBMModel1()
         ibm_model.initialize_translation_probs(f1, f2)
         assert ibm_model.translation_prob["5"]["d" + ibm_model.eow_symbol] > 0
-        assert len(ibm_model.translation_prob) == 80
+        assert len(ibm_model.translation_prob) == 83
         assert len(ibm_model.training_data) == 4
 
         ibm_model = Word2CharIBMModel1(max_subword_len=4)

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -3,7 +3,7 @@
 import logging
 from collections import defaultdict
 from optparse import OptionParser
-from typing import Dict, Tuple
+from typing import Dict, List, Set, Tuple
 
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
@@ -11,7 +11,7 @@ from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
 )
 
 
-logging.basicConfig(format="%(asctime)s %(message)s")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -81,8 +81,7 @@ class BilingualBPE(BPE):
             num_ibm_iters: Number of training epochs for the IBM model.
             num_cpus: Number of CPUs for training the IBM model with multi-processing.
         """
-        logger.warning("Initializing vocabulary.")
-        self._init_vocab(txt_path=src_txt_path)
+        logger.info("Initializing vocabulary.")
 
         # Note the reverse side of the model. Target is word based, that is why
         # we give it a reverse order.
@@ -92,10 +91,14 @@ class BilingualBPE(BPE):
             num_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
-        logger.warning("calculating alignment-based BPE type probs.")
+        logger.info("calculating alignment-based BPE type probs.")
         self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
             dst_txt_path=dst_txt_path
         )
+
+        # Need to call this at the end, because this funciton calls the
+        # _init_candidate_frequencies method (in this case, it needs dst2src_ibm_model).
+        self._init_vocab(txt_path=src_txt_path)
 
     def _calc_word_probs(self, txt_path: str) -> Dict[str, float]:
         """
@@ -127,33 +130,75 @@ class BilingualBPE(BPE):
                 bpe_alignment_prob[src_subword] += (
                     alignment_probs[src_subword] * target_word_prob
                 )
+        for src_subword in bpe_alignment_prob.keys():
+            bpe_alignment_prob[src_subword] = max(
+                bpe_alignment_prob[src_subword], 1e-30
+            )
         return bpe_alignment_prob
 
-    def _best_candidate_substep(
-        self, start_end_indices: Tuple[int, int]
-    ) -> Dict[Tuple[str, str], float]:
-        """
-        Args:
-            start_end_indices: first and end index for part of
-                self.current_train_data to search for.
-        """
+    def _init_candidate_frequencies(self) -> None:
+        self.merge_candidate_indices: Dict[Tuple[str, str], Set[int]] = defaultdict(set)
+        self.merge_candidate_freq: Dict[Tuple(str, str), float] = defaultdict(float)
 
-        start_index, end_index = start_end_indices[0], start_end_indices[1]
-        assert start_index <= end_index
-
-        candidates = defaultdict(float)
-        for i in range(start_index, end_index):
-            if i >= len(self.current_train_data):
-                break
-            (seg, freq) = self.current_train_data[i]
+        for word_index, (seg, freq) in enumerate(self.current_train_data):
+            (seg, freq) = self.current_train_data[word_index]
             for i in range(len(seg) - 1):
                 bpe_key = (seg[i], seg[i + 1])
                 bpe_token = "".join(bpe_key)
+                self.merge_candidate_freq[bpe_key] += self.bpe_alignment_prob(
+                    bpe_token, freq
+                )
+                self.merge_candidate_indices[bpe_key].add(word_index)
+                self.vocab[seg[i]] += freq
+            self.vocab[seg[-1]] += freq
 
-                # Note that this line is the only difference between this class
-                # and its parent BPE.
-                candidates[bpe_key] += freq * self.bpe_probs_from_alignment[bpe_token]
-        return candidates
+    def bpe_alignment_prob(self, bpe_token: str, freq: int):
+        if bpe_token in self.bpe_probs_from_alignment:
+            return self.bpe_probs_from_alignment[bpe_token]
+        else:
+            # In cases where the alignment model did not cover long character
+            # sequences in training data.
+            return freq * 1e-30
+
+    def update_candidate_frequencies(
+        self, data_index: int, old_tokens: List[str], new_tokens: List[str]
+    ):
+        """
+        After each merge operation, we have to update the frequencies of the BPE
+        candidates, including the ones that are deprecated (old_tokens), and the
+        new ones (new_tokens) with respect to a training word (in data_index).
+        """
+        freq = self.current_train_data[data_index][1]
+        for i in range(len(new_tokens) - 1):
+            self.vocab[new_tokens[i]] += freq
+            bpe_candidate = (new_tokens[i], new_tokens[i + 1])
+            bpe_token = "".join(bpe_candidate)
+            self.merge_candidate_freq[bpe_candidate] += self.bpe_alignment_prob(
+                bpe_token, freq
+            )
+            self.merge_candidate_indices[bpe_candidate].add(data_index)
+
+        self.vocab[new_tokens[-1]] += freq
+
+        for i in range(len(old_tokens) - 1):
+            self.vocab[old_tokens[i]] -= freq
+            if self.vocab[old_tokens[i]] == 0:
+                del self.vocab[old_tokens[i]]
+
+            bpe_candidate = (old_tokens[i], old_tokens[i + 1])
+            bpe_token = "".join(bpe_candidate)
+
+            pfreq = self.bpe_alignment_prob(bpe_token, freq)
+
+            if pfreq > 0:  # just in case there is an underflow in value.
+                self.merge_candidate_freq[bpe_candidate] -= pfreq
+                if self.merge_candidate_freq[bpe_candidate] == 0:
+                    del self.merge_candidate_freq[bpe_candidate]
+                    del self.merge_candidate_indices[bpe_candidate]
+
+        self.vocab[old_tokens[-1]] -= freq
+        if self.vocab[old_tokens[-1]] == 0:
+            del self.vocab[old_tokens[-1]]
 
     def build_vocab(
         self,
@@ -173,7 +218,7 @@ class BilingualBPE(BPE):
             num_ibm_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
-        return self._build_vocab_loop(vocab_size=vocab_size, num_cpus=num_cpus)
+        return self._build_vocab_loop(vocab_size=vocab_size)
 
 
 if __name__ == "__main__":

--- a/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
@@ -41,7 +41,7 @@ def get_arg_parser():
 
 
 class CharIBMModel1(ibm_model1.IBMModel1):
-    def __init__(self, max_subword_len: int = 8):
+    def __init__(self, max_subword_len: int = 20):
         super().__init__()
         self.eow_symbol = "_EW"  # End of word symbol.
         self.max_subword_len = max_subword_len
@@ -90,7 +90,7 @@ class Word2CharIBMModel1(CharIBMModel1):
     the source side is still word-based.
     """
 
-    def __init__(self, max_subword_len: int = 8):
+    def __init__(self, max_subword_len: int = 20):
         super().__init__(max_subword_len=max_subword_len)
 
     def initialize_translation_probs(self, src_path: str, dst_path: str):

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -7,7 +7,7 @@ from multiprocessing import Pool
 from typing import Dict, List, Tuple
 
 
-logging.basicConfig(format="%(asctime)s %(message)s")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -57,11 +57,11 @@ class IBMModel1(object):
         Args:
             num_iters: Number of EM iterations.
         """
-        logger.warning("Initializing model parameters")
+        logger.info("Initializing model parameters")
         self.initialize_translation_probs(src_path=src_path, dst_path=dst_path)
         with Pool(processes=num_cpus) as pool:
             for iter in range(num_iters):
-                logger.warning(f"Iteration of IBM model: {str(iter+1)}")
+                logger.info(f"Iteration of IBM model: {str(iter+1)}")
                 self.em_step(
                     src_path=src_path, dst_path=dst_path, num_cpus=num_cpus, pool=pool
                 )


### PR DESCRIPTION
Summary: In this diff, we go beyond the original BPE implementation and use bookkeeping to keep track of candidates that need to change. In this way, we do not need to rebuild candidate frequencies as well as not needing to try to merge everything including those words where a candidate does not exist.

Differential Revision: D15033109

