### PR TITLE
Disallowing char-based IBM models to look at single characters

### DIFF
--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -183,4 +183,33 @@ class TestBPE(unittest.TestCase):
         bpe_model._init_params(
             src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
         )
+        assert len(bpe_model.bpe_probs_from_alignment) == 80
+        assert bpe_model.eow_symbol in bpe_model.bpe_probs_from_alignment
+
+        shutil.rmtree(tmp_dir)
+
+    def test_calc_word_probs(self):
+        with patch("builtins.open") as mock_open:
+            bpe_model = bilingual_bpe.BilingualBPE()
+            mock_open.return_value.__enter__ = mock_open
+            mock_open.return_value.__iter__ = Mock(return_value=iter(txt_content))
+            v = bpe_model._calc_word_probs(txt_path="no_exist_file.txt")
+            assert len(v) == 9
+            assert v["123"] == 2 / 11
+            assert v["123456789"] == 1 / 11
+
+    def test_best_candidate_bilingual(self):
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        num_cpus = 3
+        pool = Pool(num_cpus)
+        bpe_model._init_params(
+            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=num_cpus
+        )
+
+        b1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        c1 = bpe_model.get_best_candidate(num_cpus=num_cpus, pool=pool)
+        # For the best step, it is the same as monolingual.
+        assert b1 == c1
+
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -122,7 +122,7 @@ class TestBPE(unittest.TestCase):
                 txt_path="no_exist_file.txt", vocab_size=12, num_cpus=3
             )
             # asserting that the size is as expected.
-            assert vocab_size == 12
+            assert vocab_size == len(bpe_model.vocab) == 12
             assert bpe_model.max_bpe_len == len(bpe_model.eow_symbol)
 
     def test_segment_word(self):
@@ -212,4 +212,13 @@ class TestBPE(unittest.TestCase):
         # For the best step, it is the same as monolingual.
         assert b1 == c1
 
+        shutil.rmtree(tmp_dir)
+
+    def test_build_bilingual_vocab(self):
+        bpe_model = bilingual_bpe.BilingualBPE()
+        tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
+        vocab_size = bpe_model.build_vocab(
+            src_txt_path=f1, dst_txt_path=f2, vocab_size=12, num_ibm_iters=3, num_cpus=3
+        )
+        assert vocab_size == len(bpe_model.vocab) == 12
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -25,9 +25,8 @@ class TestBPE(unittest.TestCase):
             bpe_model._init_vocab(txt_path="no_exist_file.txt")
 
             vocab_items = Counter()
-            for vocab_entry, freq in bpe_model.current_train_data:
-                items = vocab_entry.split()
-                for item in items:
+            for (vocab_entry, freq) in bpe_model.current_train_data:
+                for item in vocab_entry:
                     vocab_items[item] += freq
 
             assert vocab_items[bpe_model.eow_symbol] == 11
@@ -84,20 +83,6 @@ class TestBPE(unittest.TestCase):
                 candidate=("3", bpe_model.eow_symbol), num_cpus=num_cpus, pool=pool
             )
             assert vocab_size == 11
-
-    def test_merge_pattern(self):
-        pattern1 = bpe.BPE.get_merge_pattern("c c")
-        assert pattern1.sub("cc", "x|x?^d@@ c c ^d") == "x|x?^d@@ cc ^d"
-
-        pattern2 = bpe.BPE.get_merge_pattern("^d@ @c")
-        assert (
-            pattern2.sub("^d@@c", "^d@ @cx|x? ^d@ @c c ^d") == "^d@ @cx|x? ^d@@c c ^d"
-        )
-
-        pattern3 = bpe.BPE.get_merge_pattern("x| x")
-        assert (
-            pattern3.sub("x|x", "^d@ @c x| x ?^d@ @c c ^d") == "^d@ @c x|x ?^d@ @c c ^d"
-        )
 
     def test_build_vocab(self):
         bpe_model = bpe.BPE()

--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -159,8 +159,8 @@ class TestBPE(unittest.TestCase):
         bpe_model._init_params(
             src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
         )
-        assert len(bpe_model.bpe_probs_from_alignment) == 80
-        assert bpe_model.eow_symbol in bpe_model.bpe_probs_from_alignment
+        assert len(bpe_model.bpe_probs_from_alignment) == 70
+        assert bpe_model.eow_symbol not in bpe_model.bpe_probs_from_alignment
 
         shutil.rmtree(tmp_dir)
 

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -51,21 +51,3 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)
-
-    def test_em_step(self):
-        ibm_model = CharIBMModel1()
-
-        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
-        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
-
-        pool = Pool(3)
-        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
-
-        assert len(ibm_model.translation_prob) == 80
-        assert (
-            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
-            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
-        )
-        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
-
-        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -51,3 +51,21 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)
+
+    def test_em_step(self):
+        ibm_model = CharIBMModel1()
+
+        tmp_dir, f1, f2 = morph_utils.get_two_tmp_files()
+        ibm_model.initialize_translation_probs(src_path=f1, dst_path=f2)
+
+        pool = Pool(3)
+        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
+
+        assert len(ibm_model.translation_prob) == 80
+        assert (
+            ibm_model.translation_prob[ibm_model.eow_symbol][ibm_model.eow_symbol]
+            > ibm_model.translation_prob[ibm_model.eow_symbol]["345"]
+        )
+        assert ibm_model.translation_prob["5"]["5" + ibm_model.eow_symbol] > 0
+
+        shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -16,8 +16,8 @@ class TestCharIBMModel1(unittest.TestCase):
         char_ibm_model = CharIBMModel1(max_subword_len=4)
 
         substrs = char_ibm_model.get_possible_subwords("123412345")
-        assert len(substrs) == 24
-        assert substrs[char_ibm_model.eow_symbol] == 1
+        assert len(substrs) == 18
+        assert char_ibm_model.eow_symbol not in substrs
         assert substrs["5" + char_ibm_model.eow_symbol] == 1
         assert substrs["123"] == 2
         assert "12345" not in substrs
@@ -26,8 +26,8 @@ class TestCharIBMModel1(unittest.TestCase):
         char_ibm_model = CharIBMModel1(max_subword_len=4)
 
         substrs = char_ibm_model.get_subword_counts_for_line("123412345 12345")
-        assert len(substrs) == 24
-        assert substrs[char_ibm_model.eow_symbol] == 2
+        assert len(substrs) == 18
+        assert char_ibm_model.eow_symbol not in substrs
         assert substrs["5" + char_ibm_model.eow_symbol] == 2
         assert substrs["123"] == 3
         assert "12345" not in substrs
@@ -37,8 +37,8 @@ class TestCharIBMModel1(unittest.TestCase):
 
         ibm_model = CharIBMModel1()
         ibm_model.initialize_translation_probs(f1, f2)
-        assert ibm_model.translation_prob["5"]["d" + ibm_model.eow_symbol] > 0
-        assert len(ibm_model.translation_prob) == 80
+        assert ibm_model.translation_prob["45"]["d" + ibm_model.eow_symbol] > 0
+        assert len(ibm_model.translation_prob) == 70
         assert len(ibm_model.training_data) == 4
 
         ibm_model = Word2CharIBMModel1(max_subword_len=4)
@@ -46,7 +46,7 @@ class TestCharIBMModel1(unittest.TestCase):
         assert "abcdefghi" not in ibm_model.translation_prob["123456789"]
         assert "cdef" in ibm_model.translation_prob["123456789"]
         assert "cde" in ibm_model.translation_prob["123456789"]
-        assert len(ibm_model.translation_prob["123456789"]) == 34
+        assert len(ibm_model.translation_prob["123456789"]) == 24
         assert len(ibm_model.translation_prob) == 9
         assert len(ibm_model.training_data) == 4
 

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -3,7 +3,7 @@
 import datetime
 from collections import defaultdict
 from optparse import OptionParser
-from typing import Dict, Tuple
+from typing import Dict, List, Set, Tuple
 
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
@@ -78,7 +78,6 @@ class BilingualBPE(BPE):
             num_cpus: Number of CPUs for training the IBM model with multi-processing.
         """
         print(str(datetime.datetime.now()), "Initializing vocabulary.")
-        self._init_vocab(txt_path=src_txt_path)
 
         # Note the reverse side of the model. Target is word based, that is why
         # we give it a reverse order.
@@ -95,6 +94,8 @@ class BilingualBPE(BPE):
         self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
             dst_txt_path=dst_txt_path
         )
+
+        self._init_vocab(txt_path=src_txt_path)
 
     def _calc_word_probs(self, txt_path: str) -> Dict[str, float]:
         """
@@ -126,33 +127,66 @@ class BilingualBPE(BPE):
                 bpe_alignment_prob[src_subword] += (
                     alignment_probs[src_subword] * target_word_prob
                 )
+        for src_subword in bpe_alignment_prob.keys():
+            bpe_alignment_prob[src_subword] = max(
+                bpe_alignment_prob[src_subword], 1e-30
+            )
         return bpe_alignment_prob
 
-    def _best_candidate_substep(
-        self, start_end_indices: Tuple[int, int]
-    ) -> Dict[Tuple[str, str], float]:
-        """
-        Args:
-            start_end_indices: first and end index for part of
-                self.current_train_data to search for.
-        """
+    def _init_candidate_frequencies(self) -> None:
+        self.merge_candidate_indices: Dict[Tuple[str, str], Set[int]] = defaultdict(set)
+        self.merge_candidate_freq: Dict[Tuple(str, str), float] = defaultdict(float)
 
-        start_index, end_index = start_end_indices[0], start_end_indices[1]
-        assert start_index <= end_index
-
-        candidates = defaultdict(float)
-        for i in range(start_index, end_index):
-            if i >= len(self.current_train_data):
-                break
-            (seg, freq) = self.current_train_data[i]
+        for word_index, (seg, freq) in enumerate(self.current_train_data):
+            (seg, freq) = self.current_train_data[word_index]
             for i in range(len(seg) - 1):
                 bpe_key = (seg[i], seg[i + 1])
                 bpe_token = "".join(bpe_key)
+                self.merge_candidate_freq[bpe_key] += (
+                    freq * self.bpe_probs_from_alignment[bpe_token]
+                )
+                self.merge_candidate_indices[bpe_key].add(word_index)
+                self.vocab[seg[i]] += freq
+            self.vocab[seg[-1]] += freq
 
-                # Note that this line is the only difference between this class
-                # and its parent BPE.
-                candidates[bpe_key] += freq * self.bpe_probs_from_alignment[bpe_token]
-        return candidates
+    def update_candidate_frequencies(
+        self, data_index: int, old_tokens: List[str], new_tokens: List[str]
+    ) -> int:
+        """
+        After each merge operation, we have to update the frequencies of the BPE
+        candiates, including the ones that are deprecated (old_tokens), and the
+        new ones (new_tokens) with respect to a training word (in data_index).
+        """
+        freq = self.current_train_data[data_index][1]
+        for i in range(len(new_tokens) - 1):
+            self.vocab[new_tokens[i]] += freq
+            bpe_candidate = (new_tokens[i], new_tokens[i + 1])
+            bpe_token = "".join(bpe_candidate)
+            self.merge_candidate_freq[bpe_candidate] += (
+                freq * self.bpe_probs_from_alignment[bpe_token]
+            )
+            self.merge_candidate_indices[bpe_candidate].add(data_index)
+
+        self.vocab[new_tokens[-1]] += freq
+
+        for i in range(len(old_tokens) - 1):
+            self.vocab[old_tokens[i]] -= freq
+            if self.vocab[old_tokens[i]] == 0:
+                del self.vocab[old_tokens[i]]
+
+            bpe_candidate = (old_tokens[i], old_tokens[i + 1])
+            bpe_token = "".join(bpe_candidate)
+
+            self.merge_candidate_freq[bpe_candidate] -= (
+                freq * self.bpe_probs_from_alignment[bpe_token]
+            )
+            if self.merge_candidate_freq[bpe_candidate] == 0:
+                del self.merge_candidate_freq[bpe_candidate]
+                del self.merge_candidate_indices[bpe_candidate]
+
+        self.vocab[old_tokens[-1]] -= freq
+        if self.vocab[old_tokens[-1]] == 0:
+            del self.vocab[old_tokens[-1]]
 
     def build_vocab(
         self,
@@ -172,7 +206,7 @@ class BilingualBPE(BPE):
             num_ibm_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
-        return self._build_vocab_loop(vocab_size=vocab_size, num_cpus=num_cpus)
+        return self._build_vocab_loop(vocab_size=vocab_size)
 
 
 if __name__ == "__main__":

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,12 +1,61 @@
 #!/usr/bin/env python3
 
+import datetime
 from collections import defaultdict
+from optparse import OptionParser
 from typing import Dict, Tuple
 
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     Word2CharIBMModel1,
 )
+
+
+def get_arg_parser():
+    parser = OptionParser()
+    parser.add_option(
+        "--src-file",
+        dest="src_train_file",
+        help="Source raw text as training data.",
+        metavar="FILE",
+        default=None,
+    )
+    parser.add_option(
+        "--dst-file",
+        dest="dst_train_file",
+        help="Target raw text as training data.",
+        metavar="FILE",
+        default=None,
+    )
+    parser.add_option(
+        "--vocab-size",
+        type="int",
+        dest="vocab_size",
+        help="Source vocabulary Size.",
+        default=20000,
+    )
+    parser.add_option(
+        "--train-out",
+        dest="train_output_file",
+        help="BPE tokenized source train file.",
+        metavar="FILE",
+        default=None,
+    )
+    parser.add_option(
+        "--ibm-iters",
+        type="int",
+        dest="num_ibm_iters",
+        help="Number of training epochs for character IBM models.",
+        default=3,
+    )
+    parser.add_option(
+        "--num-cpus",
+        type="int",
+        dest="num_cpus",
+        help="Number of cpus for multi-processing.",
+        default=3,
+    )
+    return parser
 
 
 class BilingualBPE(BPE):
@@ -28,6 +77,7 @@ class BilingualBPE(BPE):
             num_ibm_iters: Number of training epochs for the IBM model.
             num_cpus: Number of CPUs for training the IBM model with multi-processing.
         """
+        print(str(datetime.datetime.now()), "Initializing vocabulary.")
         self._init_vocab(txt_path=src_txt_path)
 
         # Note the reverse side of the model. Target is word based, that is why
@@ -39,6 +89,9 @@ class BilingualBPE(BPE):
             num_cpus=num_cpus,
         )
 
+        print(
+            str(datetime.datetime.now()), "calculating alignment-based BPE type probs"
+        )
         self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
             dst_txt_path=dst_txt_path
         )
@@ -58,7 +111,7 @@ class BilingualBPE(BPE):
             vocab[word] /= denom
         return vocab
 
-    def _calc_bpe_prob_from_alignment(self, dst_txt_path) -> Dict[str, float]:
+    def _calc_bpe_prob_from_alignment(self, dst_txt_path: str) -> Dict[str, float]:
         """
          p(subword=s) = sum_{t in target} p(s|t) p(t)
          where p(t) is target_word_prob[t] from _calc_word_probs
@@ -98,3 +151,39 @@ class BilingualBPE(BPE):
                 # and its parent BPE.
                 candidates[bpe_key] += freq * self.bpe_probs_from_alignment[bpe_token]
         return candidates
+
+    def build_vocab(
+        self,
+        src_txt_path: str,
+        dst_txt_path: str,
+        vocab_size: int,
+        num_ibm_iters: int,
+        num_cpus: int,
+    ):
+        """
+        Note that except initalization, other parts are the same as the
+        original bpe build_vocab method.
+        """
+        self._init_params(
+            src_txt_path=src_txt_path,
+            dst_txt_path=dst_txt_path,
+            num_ibm_iters=num_ibm_iters,
+            num_cpus=num_cpus,
+        )
+        return self._build_vocab_loop(vocab_size=vocab_size, num_cpus=num_cpus)
+
+
+if __name__ == "__main__":
+    arg_parser = get_arg_parser()
+    options, args = arg_parser.parse_args()
+    bpe_model = BilingualBPE()
+    bpe_model.build_vocab(
+        src_txt_path=options.src_train_file,
+        dst_txt_path=options.dst_train_file,
+        vocab_size=options.vocab_size,
+        num_ibm_iters=options.num_ibm_iters,
+        num_cpus=options.num_cpus,
+    )
+    bpe_model.segment_txt(
+        input_path=options.src_train_file, output_path=options.train_output_file
+    )

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -141,10 +141,12 @@ class BilingualBPE(BPE):
         assert start_index <= end_index
 
         candidates = defaultdict(float)
-        for (seg, freq) in self.current_train_data[start_index:end_index]:
-            symbols = seg.split()
-            for i in range(len(symbols) - 1):
-                bpe_key = (symbols[i], symbols[i + 1])
+        for i in range(start_index, end_index):
+            if i >= len(self.current_train_data):
+                break
+            (seg, freq) = self.current_train_data[i]
+            for i in range(len(seg) - 1):
+                bpe_key = (seg[i], seg[i + 1])
                 bpe_token = "".join(bpe_key)
 
                 # Note that this line is the only difference between this class

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 
+from collections import defaultdict
+from typing import Dict, Tuple
+
 from pytorch_translate.research.unsupervised_morphology.bpe import BPE
 from pytorch_translate.research.unsupervised_morphology.char_ibm_model1 import (
     Word2CharIBMModel1,
 )
 
 
-class BilingualBPE(object):
+class BilingualBPE(BPE):
     """
     An extension of the BPE model that is cross-lingual wrt parallel data.
     """
 
     def __init__(self):
-        self.src_bpe = BPE()
+        super().__init__()
         self.dst2src_ibm_model = Word2CharIBMModel1()
 
     def _init_params(
@@ -25,7 +28,7 @@ class BilingualBPE(object):
             num_ibm_iters: Number of training epochs for the IBM model.
             num_cpus: Number of CPUs for training the IBM model with multi-processing.
         """
-        self.src_bpe._init_vocab(txt_path=src_txt_path)
+        self._init_vocab(txt_path=src_txt_path)
 
         # Note the reverse side of the model. Target is word based, that is why
         # we give it a reverse order.
@@ -35,3 +38,63 @@ class BilingualBPE(object):
             num_iters=num_ibm_iters,
             num_cpus=num_cpus,
         )
+
+        self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
+            dst_txt_path=dst_txt_path
+        )
+
+    def _calc_word_probs(self, txt_path: str) -> Dict[str, float]:
+        """
+        Calculates the probability of each word from raw counts in a text file.
+        """
+        vocab = defaultdict(float)
+        with open(txt_path) as txt_file:
+            for line in txt_file:
+                for word in line.strip().split():
+                    vocab[word] += 1
+
+        denom = sum(vocab.values())
+        for word in vocab.keys():
+            vocab[word] /= denom
+        return vocab
+
+    def _calc_bpe_prob_from_alignment(self, dst_txt_path) -> Dict[str, float]:
+        """
+         p(subword=s) = sum_{t in target} p(s|t) p(t)
+         where p(t) is target_word_prob[t] from _calc_word_probs
+         and p(s|t) = self.dst2src_ibm_model.translation_prob[t][s]
+        """
+        target_word_probs = self._calc_word_probs(txt_path=dst_txt_path)
+        bpe_alignment_prob = defaultdict(float)
+        for dst_word in self.dst2src_ibm_model.translation_prob.keys():
+            target_word_prob = target_word_probs[dst_word]
+            alignment_probs = self.dst2src_ibm_model.translation_prob[dst_word]
+            for src_subword in self.dst2src_ibm_model.translation_prob[dst_word]:
+                bpe_alignment_prob[src_subword] += (
+                    alignment_probs[src_subword] * target_word_prob
+                )
+        return bpe_alignment_prob
+
+    def _best_candidate_substep(
+        self, start_end_indices: Tuple[int, int]
+    ) -> Dict[Tuple[str, str], float]:
+        """
+        Args:
+            start_end_indices: first and end index for part of
+                self.current_train_data to search for.
+        """
+
+        start_index, end_index = start_end_indices[0], start_end_indices[1]
+        assert start_index <= end_index
+
+        candidates = defaultdict(float)
+        for (seg, freq) in self.current_train_data[start_index:end_index]:
+            symbols = seg.split()
+            for i in range(len(symbols) - 1):
+                bpe_key = (symbols[i], symbols[i + 1])
+                bpe_token = "".join(bpe_key)
+
+                # Note that this line is the only difference between this class
+                # and its parent BPE.
+                candidates[bpe_key] += freq * self.bpe_probs_from_alignment[bpe_token]
+        return candidates

--- a/pytorch_translate/research/unsupervised_morphology/bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bpe.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
 import datetime
-import math
 from collections import Counter, defaultdict
-from multiprocessing import Pool
 from optparse import OptionParser
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -31,13 +29,6 @@ def get_arg_parser():
         metavar="FILE",
         default=None,
     )
-    parser.add_option(
-        "--num-cpus",
-        type="int",
-        dest="num_cpus",
-        help="Number of cpus for multi-processing.",
-        default=3,
-    )
     return parser
 
 
@@ -60,7 +51,17 @@ class BPE(object):
         # character sequence wrt max_bpe_len.
         self.max_bpe_len = 1
 
+        # Saving the set of training data indices for each merge candidate. This
+        # structure gets updated after every merge operation.
+        self.merge_candidate_indices: Dict[Tuple[str, str], Set[int]] = defaultdict(set)
+
+        # Merge candidate is the key, and frequency is the value.
+        self.merge_candidate_freq: Dict[Tuple(str, str), float] = defaultdict(float)
+
     def _init_vocab(self, txt_path: str):
+        self.vocab: Dict[str, int] = Counter()
+        self.max_bpe_len = 1
+
         data_freq: Dict[str, int] = Counter()
         with open(txt_path, "r", encoding="utf-8") as input_stream:
             for line in input_stream:
@@ -75,63 +76,42 @@ class BPE(object):
         for i, (segmentation, freq) in enumerate(data_freq.items()):
             self.current_train_data[i] = (segmentation.split(" "), freq)
 
-    def _best_candidate_substep(
-        self, start_end_indices: Tuple[int, int]
-    ) -> Dict[str, float]:
-        """
-        Args:
-            first and end index for part of self.current_train_data to search for.
-        """
-        start_index, end_index = start_end_indices[0], start_end_indices[1]
-        assert start_index <= end_index
+        self._init_candidate_frequencies()
 
-        candidates = defaultdict(float)
-        for i in range(start_index, end_index):
-            if i >= len(self.current_train_data):
-                break
-            (seg, freq) = self.current_train_data[i]
+    def _init_candidate_frequencies(self) -> None:
+        """
+        We initialize frequency of candidates. This is the bigrams that are
+        extracted from merging pairs of unigrams. This is kept updated after every
+        merge operation.
+        """
+        self.merge_candidate_indices: Dict[Tuple[str, str], Set[int]] = defaultdict(set)
+        self.merge_candidate_freq: Dict[Tuple(str, str), float] = defaultdict(float)
+
+        for word_index, (seg, freq) in enumerate(self.current_train_data):
+            (seg, freq) = self.current_train_data[word_index]
             for i in range(len(seg) - 1):
-                candidates[(seg[i], seg[i + 1])] += freq
-        return candidates
+                self.merge_candidate_freq[(seg[i], seg[i + 1])] += freq
+                self.merge_candidate_indices[(seg[i], seg[i + 1])].add(word_index)
+                self.vocab[seg[i]] += freq
+            self.vocab[seg[-1]] += freq
 
-    def get_best_candidate(
-        self, num_cpus: int, pool: Pool
-    ) -> Optional[Tuple[str, str]]:
-        """
-        Calculates frequencies for new candidiates from the current vocabulary,
-        and returns the candidate with the most frequency.
-        """
-        data_chunk_size = max(1, math.ceil(len(self.current_train_data) / num_cpus))
-        indices = [
-            (
-                i * data_chunk_size,
-                min(data_chunk_size * (i + 1), len(self.current_train_data)),
-            )
-            for i in range(num_cpus)
-        ]
-        results = pool.map(self._best_candidate_substep, indices)
-        candidates = defaultdict(float)
-        for result in results:
-            for (k, v) in result.items():
-                candidates[k] += v
-        return max(candidates, key=candidates.get) if len(candidates) > 0 else None
+    def get_best_candidate(self) -> Optional[Tuple[str, str]]:
+        return (
+            max(self.merge_candidate_freq, key=self.merge_candidate_freq.get)
+            if len(self.merge_candidate_freq) > 0
+            else None
+        )
 
-    def merge_substep(
-        self, merge_candidate: Tuple[str, str], start_end_index: Tuple[int, int]
-    ) -> Tuple[List[Tuple[str, int]], Set]:
+    def merge_candidate_into_vocab(self, merge_candidate: Tuple[str, str]) -> None:
         """
         Returns Bpe types in the current substep.
         """
         candidate_replacement = "".join(merge_candidate)
-        offset, stop_index = start_end_index
-        assert offset < stop_index
+        self.max_bpe_len = max(self.max_bpe_len, len(candidate_replacement))
+        word_indices_for_merging = set(self.merge_candidate_indices[merge_candidate])
 
-        new_bpe_entries = set()
-        new_data: Dict[int, List[Tuple[str, int]]] = {}
-        for i in range(offset, stop_index):
-            if i >= len(self.current_train_data):
-                break
-            vocab_entry, freq = self.current_train_data[i]
+        for word_index in word_indices_for_merging:
+            vocab_entry, freq = self.current_train_data[word_index]
             new_entry, current_index = [], 0
             while current_index < len(vocab_entry):
                 if (
@@ -140,49 +120,49 @@ class BPE(object):
                     == merge_candidate
                 ):
                     new_entry.append(candidate_replacement)
-                    new_bpe_entries.add(candidate_replacement)
                     current_index += 2
                 else:
                     new_entry.append(vocab_entry[current_index])
-                    new_bpe_entries.add(vocab_entry[current_index])
                     current_index += 1
+            self.current_train_data[word_index] = (new_entry, freq)
+            self.update_candidate_frequencies(
+                data_index=word_index, old_tokens=vocab_entry, new_tokens=new_entry
+            )
 
-            new_data[i] = (new_entry, freq)
-
-        return (new_data, new_bpe_entries)
-
-    def merge_candidate_into_vocab(
-        self, candidate: Tuple[str, str], num_cpus: int, pool: Pool
+    def update_candidate_frequencies(
+        self, data_index: int, old_tokens: List[str], new_tokens: List[str]
     ) -> int:
         """
-        Returns the vocabulary size (number of BPE types).
-        Args:
-            candidate: a pair of strings to be merged in all entries.
+        After each merge operation, we have to update the frequencies of the BPE
+        candiates, including the ones that are deprecated (old_tokens), and the
+        new ones (new_tokens) with respect to a training word (in data_index).
         """
-        data_chunk_size = max(1, math.ceil(len(self.current_train_data) / num_cpus))
-        candidate_str_list = [
-            (
-                (candidate[0], candidate[1]),
-                (
-                    i * data_chunk_size,
-                    min(data_chunk_size * (i + 1), len(self.current_train_data)),
-                ),
-            )
-            for i in range(num_cpus)
-        ]
+        freq = self.current_train_data[data_index][1]
+        for i in range(len(new_tokens) - 1):
+            self.vocab[new_tokens[i]] += freq
+            bpe_candidate = (new_tokens[i], new_tokens[i + 1])
+            self.merge_candidate_freq[bpe_candidate] += freq
+            self.merge_candidate_indices[bpe_candidate].add(data_index)
 
-        results = pool.starmap(self.merge_substep, candidate_str_list)
+        self.vocab[new_tokens[-1]] += freq
 
-        # Each first element in results is a List[Tuple[str, int]]. By using
-        # the * operation with chain we concatenate the lists in order to
-        # reconstruct the training data.
-        for result in results:
-            for k, v in result[0].items():
-                self.current_train_data[k] = v
-        bpe_types_union = set.union(*[result[1] for result in results])
-        return len(bpe_types_union)
+        for i in range(len(old_tokens) - 1):
+            self.vocab[old_tokens[i]] -= freq
+            if self.vocab[old_tokens[i]] == 0:
+                del self.vocab[old_tokens[i]]
 
-    def build_vocab(self, txt_path: str, vocab_size: int, num_cpus: int) -> int:
+            bpe_candidate = (old_tokens[i], old_tokens[i + 1])
+
+            self.merge_candidate_freq[bpe_candidate] -= freq
+            if self.merge_candidate_freq[bpe_candidate] == 0:
+                del self.merge_candidate_freq[bpe_candidate]
+                del self.merge_candidate_indices[bpe_candidate]
+
+        self.vocab[old_tokens[-1]] -= freq
+        if self.vocab[old_tokens[-1]] == 0:
+            del self.vocab[old_tokens[-1]]
+
+    def build_vocab(self, txt_path: str, vocab_size: int) -> int:
         """
         After building the vocab, sends the current number of bpe types.
 
@@ -191,46 +171,30 @@ class BPE(object):
             vocab_size: The maximum number of vocabulary items we need to have.
         """
         self._init_vocab(txt_path=txt_path)
-        return self._build_vocab_loop(vocab_size=vocab_size, num_cpus=num_cpus)
+        return self._build_vocab_loop(vocab_size=vocab_size)
 
-    def _build_vocab_loop(self, vocab_size: int, num_cpus: int) -> int:
+    def _build_vocab_loop(self, vocab_size: int) -> int:
         step = 0
-        with Pool(processes=num_cpus) as pool:
-            while True:
-                merge_candidate = self.get_best_candidate(num_cpus=num_cpus, pool=pool)
-                if merge_candidate is not None:
-                    cur_v_size = self.merge_candidate_into_vocab(
-                        candidate=merge_candidate, num_cpus=num_cpus, pool=pool
-                    )
-                    if cur_v_size >= vocab_size:
-                        break
-                else:
-                    # No more merges possible
+        while True:
+            merge_candidate = self.get_best_candidate()
+            if merge_candidate is not None:
+                self.merge_candidate_into_vocab(merge_candidate=merge_candidate)
+                if len(self.vocab) >= vocab_size:
                     break
-                step += 1
-                if step % 50 == 0:
-                    print(
-                        str(datetime.datetime.now()),
-                        "BPE merging step",
-                        step,
-                        "data size",
-                        len(self.current_train_data),
-                        "current vocabulary size",
-                        cur_v_size,
-                    )
-        return self.finalize_vocab()
-
-    def finalize_vocab(self) -> int:
-        # Now we get rid of the current vocab that is based on the corpus (not
-        # memory-efficient). We now only keep the final bpe tokens.
-        self.vocab: Dict[str, int] = Counter()
-        self.max_bpe_len = 1
-        for (vocab_entry, freq) in self.current_train_data:
-            for bpe_token in vocab_entry:
-                self.vocab[bpe_token] += freq
-                self.max_bpe_len = max(self.max_bpe_len, len(bpe_token))
-
-        print("BPE vocab built with size", len(self.vocab))
+            else:
+                # No more merges possible
+                break
+            step += 1
+            if step % 50 == 0:
+                print(
+                    str(datetime.datetime.now()),
+                    "BPE merging step",
+                    step,
+                    "data size",
+                    len(self.current_train_data),
+                    "current vocabulary size",
+                    len(self.vocab),
+                )
         return len(self.vocab)
 
     def segment_word(self, word: str) -> List[str]:
@@ -270,11 +234,7 @@ if __name__ == "__main__":
     arg_parser = get_arg_parser()
     options, args = arg_parser.parse_args()
     bpe_model = BPE()
-    bpe_model.build_vocab(
-        txt_path=options.train_file,
-        vocab_size=options.vocab_size,
-        num_cpus=options.num_cpus,
-    )
+    bpe_model.build_vocab(txt_path=options.train_file, vocab_size=options.vocab_size)
     bpe_model.segment_txt(
         input_path=options.train_file, output_path=options.train_output_file
     )

--- a/pytorch_translate/research/unsupervised_morphology/bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bpe.py
@@ -185,6 +185,9 @@ class BPE(object):
             vocab_size: The maximum number of vocabulary items we need to have.
         """
         self._init_vocab(txt_path=txt_path)
+        return self._build_vocab_loop(vocab_size=vocab_size, num_cpus=num_cpus)
+
+    def _build_vocab_loop(self, vocab_size: int, num_cpus: int) -> int:
         step = 0
         with Pool(processes=num_cpus) as pool:
             while True:
@@ -209,7 +212,9 @@ class BPE(object):
                         "current vocabulary size",
                         cur_v_size,
                     )
+        return self.finalize_vocab()
 
+    def finalize_vocab(self) -> int:
         # Now we get rid of the current vocab that is based on the corpus (not
         # memory-efficient). We now only keep the final bpe tokens.
         self.vocab: Dict[str, int] = Counter()

--- a/pytorch_translate/research/unsupervised_morphology/bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bpe.py
@@ -2,9 +2,7 @@
 
 import datetime
 import math
-import re
 from collections import Counter, defaultdict
-from itertools import chain
 from multiprocessing import Pool
 from optparse import OptionParser
 from typing import Dict, List, Optional, Set, Tuple
@@ -73,9 +71,9 @@ class BPE(object):
                     # that is a clear indicator of a suffix.
                     data_freq[" ".join(list(word) + [self.eow_symbol])] += 1
 
-        self.current_train_data: List[Tuple[str, int]] = []
-        for segmentation, freq in data_freq.items():
-            self.current_train_data.append((segmentation, freq))
+        self.current_train_data: List[Tuple[str, int]] = [None] * len(data_freq)
+        for i, (segmentation, freq) in enumerate(data_freq.items()):
+            self.current_train_data[i] = (segmentation.split(" "), freq)
 
     def _best_candidate_substep(
         self, start_end_indices: Tuple[int, int]
@@ -88,10 +86,12 @@ class BPE(object):
         assert start_index <= end_index
 
         candidates = defaultdict(float)
-        for (seg, freq) in self.current_train_data[start_index:end_index]:
-            symbols = seg.split()
-            for i in range(len(symbols) - 1):
-                candidates[(symbols[i], symbols[i + 1])] += freq
+        for i in range(start_index, end_index):
+            if i >= len(self.current_train_data):
+                break
+            (seg, freq) = self.current_train_data[i]
+            for i in range(len(seg) - 1):
+                candidates[(seg[i], seg[i + 1])] += freq
         return candidates
 
     def get_best_candidate(
@@ -116,35 +116,39 @@ class BPE(object):
                 candidates[k] += v
         return max(candidates, key=candidates.get) if len(candidates) > 0 else None
 
-    @staticmethod
-    def get_merge_pattern(candidate_str):
-        return re.compile(r"(?<!\S)" + re.escape(candidate_str) + r"(?!\S)")
-
     def merge_substep(
         self, merge_candidate: Tuple[str, str], start_end_index: Tuple[int, int]
     ) -> Tuple[List[Tuple[str, int]], Set]:
         """
         Returns Bpe types in the current substep.
         """
-        candidate_str = " ".join(merge_candidate)
         candidate_replacement = "".join(merge_candidate)
-        pattern = BPE.get_merge_pattern(candidate_str)
         offset, stop_index = start_end_index
         assert offset < stop_index
 
         new_bpe_entries = set()
-        new_data: List[Tuple[str, int]] = [None] * (stop_index - offset)
+        new_data: Dict[int, List[Tuple[str, int]]] = {}
         for i in range(offset, stop_index):
+            if i >= len(self.current_train_data):
+                break
             vocab_entry, freq = self.current_train_data[i]
-            new_entry = vocab_entry
-            if candidate_str in vocab_entry:
-                # Regex is usually slow. We just apply it on words that have the
-                # potential of replacement.
-                new_entry = pattern.sub(candidate_replacement, vocab_entry)
+            new_entry, current_index = [], 0
+            while current_index < len(vocab_entry):
+                if (
+                    current_index < len(vocab_entry) - 1
+                    and (vocab_entry[current_index], vocab_entry[current_index + 1])
+                    == merge_candidate
+                ):
+                    new_entry.append(candidate_replacement)
+                    new_bpe_entries.add(candidate_replacement)
+                    current_index += 2
+                else:
+                    new_entry.append(vocab_entry[current_index])
+                    new_bpe_entries.add(vocab_entry[current_index])
+                    current_index += 1
 
-            new_data[i - offset] = (new_entry, freq)
-            for entry in new_entry.split():
-                new_bpe_entries.add(entry)
+            new_data[i] = (new_entry, freq)
+
         return (new_data, new_bpe_entries)
 
     def merge_candidate_into_vocab(
@@ -172,7 +176,9 @@ class BPE(object):
         # Each first element in results is a List[Tuple[str, int]]. By using
         # the * operation with chain we concatenate the lists in order to
         # reconstruct the training data.
-        self.current_train_data = list(chain(*[result[0] for result in results]))
+        for result in results:
+            for k, v in result[0].items():
+                self.current_train_data[k] = v
         bpe_types_union = set.union(*[result[1] for result in results])
         return len(bpe_types_union)
 
@@ -220,7 +226,7 @@ class BPE(object):
         self.vocab: Dict[str, int] = Counter()
         self.max_bpe_len = 1
         for (vocab_entry, freq) in self.current_train_data:
-            for bpe_token in vocab_entry.split():
+            for bpe_token in vocab_entry:
                 self.vocab[bpe_token] += freq
                 self.max_bpe_len = max(self.max_bpe_len, len(bpe_token))
 

--- a/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
@@ -47,10 +47,13 @@ class CharIBMModel1(ibm_model1.IBMModel1):
         self.max_subword_len = max_subword_len
 
     def get_possible_subwords(self, word: str) -> Dict[str, int]:
+        """
+        Note that it only extracts subwords of more than one character (>=2).
+        """
         subwords = []
         chars = list(word) + [self.eow_symbol]
         for i in range(len(chars)):
-            for j in range(i + 1, min(i + 1 + self.max_subword_len, len(chars) + 1)):
+            for j in range(i + 2, min(i + 1 + self.max_subword_len, len(chars) + 1)):
                 subword = "".join(chars[i:j])
                 subwords.append(subword)
         return Counter(subwords)


### PR DESCRIPTION
Summary: We need subword IBM for BPE: BPE does not search for single characters as candidates. Thus we disallow them to be candidates for translation.

Differential Revision: D15039124

