### PR TITLE
Support dataset upsampling / relative ratio in PytorchTranslateTask (#657)

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -131,7 +131,14 @@ def load_models_from_checkpoints(
             model = model.get_student_model()
 
         if isinstance(model, semi_supervised.SemiSupervisedModel):
-            models.append(model.models["src-tgt"])
+            if (
+                model_args.source_lang is not None
+                and model_args.target_lang is not None
+            ):
+                direction = model_args.source_lang + "-" + model_args.target_lang
+            else:
+                direction = "src-tgt"
+            models.append(model.models[direction])
         else:
             models.append(model)
 

--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -654,8 +654,10 @@ def generate(args):
 
     lang_pair = None
     if isinstance(task, PytorchTranslateSemiSupervised):
-        lang_pair = "src-tgt"
-
+        if args.source_lang and args.target_lang:
+            lang_pair = args.source_lang + "-" + args.target_lang
+        else:
+            lang_pair = "src-tgt"
     scorer, num_sentences, gen_timer, _ = generate_score(
         args=args,
         task=task,

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -245,6 +245,27 @@ def add_preprocessing_args(parser):
         help="Path for the binary file containing target training examples.",
     )
     group.add_argument(
+        "--dataset-upsampling",
+        default=None,
+        metavar="FILE",
+        help="Upsampling for certain datasets, with upsampling rate "
+        "represented in a dictionary (dataset, rate). sampling ratio = "
+        "upsampling rate * number of lines of the dataset / "
+        "(upsampling rate * number of lines of the dataset"
+        "+ number of total lines of other datsets). At most one of "
+        "dataset_upsampling / dataset_relative_ratio could be specified.",
+    )
+    group.add_argument(
+        "--dataset-relative-ratio",
+        default=None,
+        metavar="FILE",
+        help="Relative ratio(one-vs-rest) for certain dataset, "
+        "represented in (dataset, ratio) tuple. It would be the final sampling"
+        "ratio for certain dataset. For example when r = 0.5, half of training"
+        "corpus would come from this dataset. At most one of "
+        "dataset_upsampling / dataset_relative_ratio could be specified.",
+    )
+    group.add_argument(
         "--train-weights-path",
         default="",
         metavar="FILE",

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from typing import List, Optional
 
-from pytorch_translate import constants, options as pytorch_translate_options
+from pytorch_translate import constants, options as pytorch_translate_options, utils
 from pytorch_translate.data import char_data, data as pytorch_translate_data
 from pytorch_translate.dictionary import Dictionary
 
@@ -183,12 +183,21 @@ def binarize_text_file_multilingual(
 
 
 def preprocess_corpora(args):
-    args.train_source_binary_path = maybe_generate_temp_file_path(
-        args.train_source_binary_path
-    )
-    args.train_target_binary_path = maybe_generate_temp_file_path(
-        args.train_target_binary_path
-    )
+    if (
+        args.train_source_binary_path is not None
+        and args.train_target_binary_path is not None
+    ):
+        if isinstance(
+            utils.maybe_parse_collection_argument(args.train_source_binary_path), str
+        ) and isinstance(
+            utils.maybe_parse_collection_argument(args.train_target_binary_path), str
+        ):
+            args.train_source_binary_path = maybe_generate_temp_file_path(
+                args.train_source_binary_path
+            )
+            args.train_target_binary_path = maybe_generate_temp_file_path(
+                args.train_target_binary_path
+            )
     args.eval_source_binary_path = maybe_generate_temp_file_path(
         args.eval_source_binary_path
     )

--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 import argparse
+import ast
 import os
 import signal
 import threading
 import time
-from typing import List, Optional
+from typing import Dict, List, Optional, Union
 
 import torch
 from fairseq import distributed_utils, tasks, utils
@@ -297,3 +298,11 @@ def get_source_tokens_tensor(src_tokens):
         return src_tokens[0]
     else:
         return src_tokens
+
+
+def maybe_parse_collection_argument(path: str) -> Union[str, Dict]:
+    try:
+        path_dict = ast.literal_eval(path)
+    except Exception:
+        return path
+    return path_dict


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/fairseq/pull/657

Library side change split from D14924942

Added 2 arguments for load_dataset in PytorchTranslateTask
1. dataset_upsampling. A nested dictionary {direction:{dataset: upsampling_ratio}}. Upsampling_ratio larger than one mean that the bitext is ob- served more often than actually present in the combined bitext and synthetic training corpus.

2. dataset_relative_ratio. A tuple (dataset, ratio). The ratio represents the frequency certain dataset gets sampled to the rest of corpora map.

At most one of them could be specified.

Differential Revision: D15041293

