### PR TITLE
Make sure all tensors are converted to cpu tensors before pickling (#485)

### DIFF
--- a/pytorch_translate/research/rescore/cloze_transformer_model.py
+++ b/pytorch_translate/research/rescore/cloze_transformer_model.py
@@ -109,6 +109,7 @@ class ClozeTransformerDecoder(TransformerDecoder):
            [[0, -inf, 0]
             [0,  0, -inf]
             [0,  0,   0]]
+        The attention map is not ture diagonal since we predict y_{t+1} at time-step t
         """
         dim = tensor.size(0)
         if (

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -258,12 +258,10 @@ class TransformerModel(FairseqModel):
 class TransformerEncoder(FairseqEncoder):
     """Transformer encoder."""
 
-    def __init__(
-        self, args, dictionary, embed_tokens, proj_to_decoder=True
-    ):
+    def __init__(self, args, dictionary, embed_tokens, proj_to_decoder=True):
         super().__init__(dictionary)
         self.transformer_embedding = TransformerEmbedding(
-            args=args, embed_tokens=embed_tokens,
+            args=args, embed_tokens=embed_tokens
         )
 
         self.transformer_encoder_given_embeddings = TransformerEncoderGivenEmbeddings(
@@ -354,10 +352,7 @@ class TransformerDecoder(FairseqIncrementalDecoder):
         self.embed_tokens = embed_tokens
         self.embed_scale = math.sqrt(embed_dim)
         self.embed_positions = fairseq_transformer.PositionalEmbedding(
-            1024,
-            embed_dim,
-            padding_idx,
-            learned=args.decoder_learned_pos,
+            1024, embed_dim, padding_idx, learned=args.decoder_learned_pos
         )
 
         self.layers = nn.ModuleList([])


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/translate/pull/485

Pickling tensors save their gpu metadata together with them. This means when we are loading pickle, they are loaded to exactly same GPU's. We don't want this.

Reviewed By: qingerVT

Differential Revision: D15003183

