### PR TITLE
Add noiser option in PytorchTranslateTask

### DIFF
--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -266,6 +266,24 @@ def add_preprocessing_args(parser):
         "dataset_upsampling / dataset_relative_ratio could be specified.",
     )
     group.add_argument(
+        "--word-dropout-prob-map",
+        default=None,
+        help="Use NoisingDataset, and this argument specifies "
+        "the probability a token is dropped randomly",
+    )
+    group.add_argument(
+        "--word-blank-prob-map",
+        default=None,
+        help="Use NoisingDataset, and this argument specifies "
+        "the probability a token is replaced by unk",
+    )
+    group.add_argument(
+        "--max-word-shuffle-distance-map",
+        default=None,
+        help="Use NoisingDataset, and this argument specifies "
+        "the maximum distance a word could move during the shuffle",
+    )
+    group.add_argument(
         "--train-weights-path",
         default="",
         metavar="FILE",


### PR DESCRIPTION
Summary:
Add noising option in PytorchTranslateTask. When a nested dict is passed in, we add noise for the dataset specified by the key. It's based on NoisingDataset and UnsupervisedMTNoising.

Since arguments like --word_dropout_prob have conflicts with task-specific args in denoising autoencoder, current names are kinda ad-hoc (suffixed with '_map'). Happy to modify later. Put up now to unblock experiments.

Differential Revision: D15078404

