### PR TITLE
Separate weight combination from rescorer

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -155,6 +155,7 @@ def _generate_score(models, args, task, dataset):
     # and zero probs scores
     translated_sentences = [""] * len(dataset)
     translated_scores = [0.0] * len(dataset)
+    hypos_list = []
 
     collect_output_hypos = getattr(args, "output_hypos_binary_path", False)
     if collect_output_hypos:
@@ -211,8 +212,10 @@ def _generate_score(models, args, task, dataset):
             if oracle_scorer is not None:
                 oracle_scorer.add(trans_info.target_tokens, trans_info.best_hypo_tokens)
 
-            translated_sentences[trans_info.sample_id] = trans_info.hypo_str
-            translated_scores[trans_info.sample_id] = trans_info.hypo_score
+            if getattr(args, "translation_output_file", False):
+                translated_sentences[trans_info.sample_id] = trans_info.hypo_str
+            if getattr(args, "hypotheses_export_path", False):
+                hypos_list.append(trans_info.hypos)
             if collect_output_hypos:
                 output_hypos_token_arrays[
                     trans_info.sample_id
@@ -259,12 +262,23 @@ def _generate_score(models, args, task, dataset):
         pickle.dump(translation_info_list, f)
         f.close()
 
-    # If applicable, save the translations to the output file
+    # If applicable, save the translations and hypos to the output file
     # For eg. external evaluation
     if getattr(args, "translation_output_file", False):
         with open(args.translation_output_file, "w") as out_file:
             for hypo_str in translated_sentences:
                 print(hypo_str, file=out_file)
+
+    if getattr(args, "hypotheses_export_path", False):
+        with open(args.hypotheses_export_path, "w") as out_file:
+            for hypos in hypos_list:
+                for hypo in hypos:
+                    print(
+                        task.tgt_dict.string(
+                            hypo["tokens"], bpe_symbol=args.remove_bpe
+                        ),
+                        file=out_file,
+                    )
 
     if getattr(args, "translation_probs_file", False):
         with open(args.translation_probs_file, "w") as out_file:

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -706,6 +706,12 @@ def expand_generation_args(group, train=False):
         default=0.0,
         help=("The diversity rate of sibling_rank for generating diverse beams"),
     )
+    group.add_argument(
+        "--hypotheses-export-path",
+        default=None,
+        type=str,
+        help=("Optional path to save all generated hypotheses to external file"),
+    )
 
     # These arguments are only used during training
     if train:

--- a/pytorch_translate/rescoring/test/test_rescorer.py
+++ b/pytorch_translate/rescoring/test/test_rescorer.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 import torch
-from pytorch_translate.rescoring.rescorer import Rescorer
+from pytorch_translate.rescoring.rescorer import combine_weighted_scores
 from pytorch_translate.tasks import pytorch_translate_task as tasks
 from pytorch_translate.test import utils as test_utils
 
@@ -14,13 +14,12 @@ class TestRescorer(unittest.TestCase):
         test_args = test_utils.ModelParamsDict()
         test_args.enable_rescoring = True
         test_args.length_penalty = 1
-        test_args.original_model_weight = 1
         test_args.l2r_model_path = ""
-        test_args.l2r_model_weight = 1
-        test_args.r2l_model_weight = 0
-        test_args.reverse_model_weight = 0.5
-        test_args.lm_model_weight = 0.75
-        test_args.length_penalty = 1
+        test_args.l2r_model_weight = 1.0
+        test_args.r2l_model_weight = 0.0
+        test_args.reverse_model_weight = 0.0
+        test_args.lm_model_weight = 1.01
+        test_args.length_penalty = 1.0
 
         _, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)
         task = tasks.PytorchTranslateTask(test_args, src_dict, tgt_dict)
@@ -29,13 +28,25 @@ class TestRescorer(unittest.TestCase):
             "pytorch_translate.utils.load_diverse_ensemble_for_inference",
             return_value=([model], test_args, task),
         ):
-            rescorer = Rescorer(test_args)
 
-            scores = torch.tensor([[10, 20, 30, 40]], dtype=torch.float)
+            scores = torch.tensor([[80, 0, 0, 0], [0, 0, 0, 80]], dtype=torch.float)
             src_tokens = torch.tensor([1, 2, 3, 4, 5])
-            hypos = [{"tokens": torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])}]
-            rescorer.combine_weighted_scores(scores, src_tokens, hypos)
+            hypos = [{"tokens": torch.tensor([1, 2])}, {"tokens": torch.tensor([1, 2])}]
 
-            # 10=1. , 20*0=0. , 30*(0.5/5)=3. , 40*(0.75/5)=6.
-            expected = torch.tensor([[10.0, 0.0, 3.0, 6.0]], dtype=torch.float)
-            assert torch.equal(scores, expected)
+            src_len = len(src_tokens)
+            tgt_len = torch.tensor(
+                [len(hypo["tokens"]) for hypo in hypos], dtype=torch.float
+            )
+            weights = [
+                test_args.l2r_model_weight,
+                test_args.r2l_model_weight,
+                test_args.reverse_model_weight,
+                test_args.lm_model_weight,
+            ]
+            combined_scores = combine_weighted_scores(
+                scores, weights, src_len, tgt_len, 1
+            )
+
+            # 80/(2^1), 0, 0, 80*1.01/(2^1)
+            expected = torch.tensor([40.0, 40.4], dtype=torch.float)
+            assert torch.equal(combined_scores, expected)


### PR DESCRIPTION
Summary:
*Separate weight combination from scorer. This will help with weight sweeping later.
*Add length penalty
*Score with forward model (previously we were just reading scores from hypo['score'] in input data

Differential Revision: D15173215

