### PR TITLE
Respect args.reverse_source argument for pytorch_translate models

### DIFF
--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -211,8 +211,7 @@ class ReverseModelScorer(SimpleModelScorer):
                 (
                     torch.tensor([eos]).type_as(src_tokens_mapped),
                     reversed(src_tokens_mapped)
-                    if self.task.args.reverse_source
-                    != self.forward_task.args.reverse_source
+                    if self.forward_task.args.reverse_source
                     else src_tokens_mapped,
                 ),
                 dim=0,
@@ -235,9 +234,11 @@ class ReverseModelScorer(SimpleModelScorer):
             tgt_tokens_mapped = self.task.src_dict.encode_line(
                 tgt_string, add_if_not_exist=False
             )
-            if not self.args.append_eos_to_source:
-                tgt_tokens_mapped = tgt_tokens_mapped[:-1]
-            src_tokens[i, : len(tgt_tokens_mapped)] = tgt_tokens_mapped
+            src_tokens[i, : len(tgt_tokens_mapped)] = (
+                reversed(tgt_tokens_mapped)
+                if self.task.args.reverse_source
+                else tgt_tokens_mapped
+            )
 
         src_length = src_tokens.shape[1]
         encoder_inputs = (src_tokens, [src_length])

--- a/pytorch_translate/rescoring/rescorer.py
+++ b/pytorch_translate/rescoring/rescorer.py
@@ -245,6 +245,7 @@ def find_top_tokens(args, trans_info, rescorer):
         args.r2l_model_weight,
         args.reverse_model_weight,
         args.lm_model_weight,
+        args.cloze_transformer_weight,
     ]
     src_len = len(src_tokens)
     tgt_len = torch.tensor([len(hypo["tokens"]) for hypo in hypos], dtype=torch.float)


### PR DESCRIPTION
Summary: For reverse scoring of pytorch_translate models, we need to respect args.reverse_source.

Differential Revision: D15203747

