### PR TITLE
Fix a bug in calculating denominator in ibm model

### DIFF
--- a/pytorch_translate/research/test/test_bpe.py
+++ b/pytorch_translate/research/test/test_bpe.py
@@ -156,10 +156,8 @@ class TestBPE(unittest.TestCase):
         """
         bpe_model = bilingual_bpe.BilingualBPE()
         tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
-        bpe_model._init_params(
-            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
-        )
-        assert len(bpe_model.bpe_probs_from_alignment) == 83
+        bpe_model._init_params(src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3)
+        assert len(bpe_model.bpe_probs_from_alignment) == 80
         assert bpe_model.eow_symbol in bpe_model.bpe_probs_from_alignment
 
         shutil.rmtree(tmp_dir)
@@ -177,9 +175,7 @@ class TestBPE(unittest.TestCase):
     def test_best_candidate_bilingual(self):
         bpe_model = bilingual_bpe.BilingualBPE()
         tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
-        bpe_model._init_params(
-            src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3, num_cpus=3
-        )
+        bpe_model._init_params(src_txt_path=f1, dst_txt_path=f2, num_ibm_iters=3)
 
         b1 = bpe_model.get_best_candidate()
         c1 = bpe_model.get_best_candidate()
@@ -192,7 +188,7 @@ class TestBPE(unittest.TestCase):
         bpe_model = bilingual_bpe.BilingualBPE()
         tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
         vocab_size = bpe_model.build_vocab(
-            src_txt_path=f1, dst_txt_path=f2, vocab_size=12, num_ibm_iters=3, num_cpus=3
+            src_txt_path=f1, dst_txt_path=f2, vocab_size=12, num_ibm_iters=3
         )
         assert vocab_size == len(bpe_model.vocab) == 12
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -2,6 +2,7 @@
 
 import shutil
 import unittest
+from collections import Counter
 from multiprocessing import Pool
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
@@ -16,11 +17,13 @@ class TestCharIBMModel1(unittest.TestCase):
         char_ibm_model = CharIBMModel1(max_subword_len=4)
 
         substrs = char_ibm_model.get_possible_subwords("123412345")
-        assert len(substrs) == 24
-        assert substrs[char_ibm_model.eow_symbol] == 1
-        assert substrs["5" + char_ibm_model.eow_symbol] == 1
-        assert substrs["123"] == 2
-        assert "12345" not in substrs
+        assert len(substrs) == 34
+        substr_counter = Counter(substrs)
+        assert len(substr_counter) == 24
+        assert substr_counter[char_ibm_model.eow_symbol] == 1
+        assert substr_counter["5" + char_ibm_model.eow_symbol] == 1
+        assert substr_counter["123"] == 2
+        assert "12345" not in substr_counter
 
     def test_get_subwords_counts_for_line(self):
         char_ibm_model = CharIBMModel1(max_subword_len=4)
@@ -38,7 +41,7 @@ class TestCharIBMModel1(unittest.TestCase):
         ibm_model = CharIBMModel1()
         ibm_model.initialize_translation_probs(f1, f2)
         assert ibm_model.translation_prob["5"]["d" + ibm_model.eow_symbol] > 0
-        assert len(ibm_model.translation_prob) == 83
+        assert len(ibm_model.translation_prob) == 80
         assert len(ibm_model.training_data) == 4
 
         ibm_model = Word2CharIBMModel1(max_subword_len=4)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -47,7 +47,7 @@ class TestCharIBMModel1(unittest.TestCase):
         assert "cdef" in ibm_model.translation_prob["123456789"]
         assert "cde" in ibm_model.translation_prob["123456789"]
         assert len(ibm_model.translation_prob["123456789"]) == 34
-        assert len(ibm_model.translation_prob) == 9
+        assert len(ibm_model.translation_prob) == 10
         assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_char_ibm_model.py
+++ b/pytorch_translate/research/test/test_char_ibm_model.py
@@ -20,37 +20,51 @@ class TestCharIBMModel1(unittest.TestCase):
         assert len(substrs) == 34
         substr_counter = Counter(substrs)
         assert len(substr_counter) == 24
-        assert substr_counter[char_ibm_model.eow_symbol] == 1
-        assert substr_counter["5" + char_ibm_model.eow_symbol] == 1
-        assert substr_counter["123"] == 2
-        assert "12345" not in substr_counter
+        assert substr_counter[char_ibm_model.str2int(char_ibm_model.eow_symbol)] == 1
+        assert (
+            substr_counter[char_ibm_model.str2int("5" + char_ibm_model.eow_symbol)] == 1
+        )
+        assert substr_counter[char_ibm_model.str2int("123")] == 2
+        assert "12345" not in char_ibm_model._str2int
 
     def test_get_subwords_counts_for_line(self):
         char_ibm_model = CharIBMModel1(max_subword_len=4)
 
         substrs = char_ibm_model.get_subword_counts_for_line("123412345 12345")
         assert len(substrs) == 24
-        assert substrs[char_ibm_model.eow_symbol] == 2
-        assert substrs["5" + char_ibm_model.eow_symbol] == 2
-        assert substrs["123"] == 3
-        assert "12345" not in substrs
+        assert substrs[char_ibm_model.str2int(char_ibm_model.eow_symbol)] == 2
+        assert substrs[char_ibm_model.str2int("5" + char_ibm_model.eow_symbol)] == 2
+        assert substrs[char_ibm_model.str2int("123")] == 3
+        assert "12341" not in char_ibm_model._str2int
 
     def test_morph_init(self):
         tmp_dir, f1, f2 = morph_utils.get_two_different_tmp_files()
 
         ibm_model = CharIBMModel1()
         ibm_model.initialize_translation_probs(f1, f2)
-        assert ibm_model.translation_prob["5"]["d" + ibm_model.eow_symbol] > 0
+        assert (
+            ibm_model.translation_prob[ibm_model.str2int("5")][
+                ibm_model.str2int("d" + ibm_model.eow_symbol)
+            ]
+            > 0
+        )
         assert len(ibm_model.translation_prob) == 80
-        assert len(ibm_model.training_data) == 4
 
         ibm_model = Word2CharIBMModel1(max_subword_len=4)
         ibm_model.initialize_translation_probs(f1, f2)
-        assert "abcdefghi" not in ibm_model.translation_prob["123456789"]
-        assert "cdef" in ibm_model.translation_prob["123456789"]
-        assert "cde" in ibm_model.translation_prob["123456789"]
-        assert len(ibm_model.translation_prob["123456789"]) == 34
+        assert (
+            ibm_model.str2int("abcdefghi")
+            not in ibm_model.translation_prob[ibm_model.str2int("123456789")]
+        )
+        assert (
+            ibm_model.str2int("cdef")
+            in ibm_model.translation_prob[ibm_model.str2int("123456789")]
+        )
+        assert (
+            ibm_model.str2int("cde")
+            in ibm_model.translation_prob[ibm_model.str2int("123456789")]
+        )
+        assert len(ibm_model.translation_prob[ibm_model.str2int("123456789")]) == 34
         assert len(ibm_model.translation_prob) == 10
-        assert len(ibm_model.training_data) == 4
 
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -11,15 +11,34 @@ from pytorch_translate.research.unsupervised_morphology.ibm_model1 import IBMMod
 
 
 class TestIBMModel1(unittest.TestCase):
+    def test_str2int(self):
+        ibm_model = IBMModel1()
+        # Calling multiple times to make sure we get the same value.
+        assert ibm_model.str2int("hello") == 1
+        assert ibm_model.str2int("bye") == 2
+        assert ibm_model.str2int("hello") == 1
+        assert ibm_model.str2int("bye") == 2
+        assert len(ibm_model._str2int) == 3
+        assert len(ibm_model._int2str) == 3
+        assert ibm_model._int2str == [ibm_model.null_str, "hello", "bye"]
+        assert ibm_model.int2str(2) == "bye"
+
     def test_morph_init(self):
         ibm_model = IBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         assert len(ibm_model.translation_prob) == 10
-        assert len(ibm_model.translation_prob[ibm_model.null_str]) == 9
-        assert len(ibm_model.translation_prob["345"]) == 6
-        assert ibm_model.translation_prob["122"]["123"] == 1.0 / 4
+        assert (
+            len(ibm_model.translation_prob[ibm_model.str2int(ibm_model.null_str)]) == 9
+        )
+        assert len(ibm_model.translation_prob[ibm_model.str2int("345")]) == 6
+        assert (
+            ibm_model.translation_prob[ibm_model.str2int("122")][
+                ibm_model.str2int("123")
+            ]
+            == 1.0 / 4
+        )
         shutil.rmtree(tmp_dir)
 
     def test_expectation_for_one_sentence(self):
@@ -30,11 +49,20 @@ class TestIBMModel1(unittest.TestCase):
         translation_counts = defaultdict(lambda: defaultdict(float))
 
         ibm_model.expectation_for_one_sentence(
-            Counter(["123", "124", "234", "345", ibm_model.null_str]),
-            Counter(["123", "124", "234", "345"]),
+            Counter(
+                ibm_model.str2int(w)
+                for w in ["123", "124", "234", "345", ibm_model.null_str]
+            ),
+            Counter(ibm_model.str2int(w) for w in ["123", "124", "234", "345"]),
             translation_counts,
         )
-        assert round(translation_counts["123"]["345"], 3) == 0.176
+        assert (
+            round(
+                translation_counts[ibm_model.str2int("123")][ibm_model.str2int("345")],
+                3,
+            )
+            == 0.176
+        )
         shutil.rmtree(tmp_dir)
 
     def test_ibm_train(self):
@@ -43,6 +71,16 @@ class TestIBMModel1(unittest.TestCase):
         tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
 
-        assert ibm_model.translation_prob["456789"]["345"] == 0
-        assert ibm_model.translation_prob["456789"]["456789"] == 0.5
+        assert (
+            ibm_model.translation_prob[ibm_model.str2int("456789")][
+                ibm_model.str2int("345")
+            ]
+            == 0
+        )
+        assert (
+            ibm_model.translation_prob[ibm_model.str2int("456789")][
+                ibm_model.str2int("456789")
+            ]
+            == 0.5
+        )
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -35,7 +35,7 @@ class TestIBMModel1(unittest.TestCase):
             Counter(["123", "124", "234", "345"]),
             translation_counts,
         )
-        assert translation_counts["123"]["345"] == 1.0 / 4
+        assert round(translation_counts["123"]["345"], 3) == 0.176
         shutil.rmtree(tmp_dir)
 
     def test_em_step(self):
@@ -49,11 +49,6 @@ class TestIBMModel1(unittest.TestCase):
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
-        assert (
-            ibm_model.translation_prob[ibm_model.null_str]["124"]
-            < ibm_model.translation_prob[ibm_model.null_str]["456789"]
-        )
-
         shutil.rmtree(tmp_dir)
 
     def test_ibm_train(self):
@@ -66,9 +61,4 @@ class TestIBMModel1(unittest.TestCase):
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5
-        assert (
-            ibm_model.translation_prob[ibm_model.null_str]["124"]
-            < ibm_model.translation_prob[ibm_model.null_str]["456789"]
-        )
-
         shutil.rmtree(tmp_dir)

--- a/pytorch_translate/research/test/test_ibm_model.py
+++ b/pytorch_translate/research/test/test_ibm_model.py
@@ -4,7 +4,6 @@ import shutil
 import tempfile
 import unittest
 from collections import Counter, defaultdict
-from multiprocessing import Pool
 from os import path
 
 from pytorch_translate.research.test import morphology_test_utils as morph_utils
@@ -23,14 +22,14 @@ class TestIBMModel1(unittest.TestCase):
         assert ibm_model.translation_prob["122"]["123"] == 1.0 / 4
         shutil.rmtree(tmp_dir)
 
-    def test_e_step(self):
+    def test_expectation_for_one_sentence(self):
         ibm_model = IBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
         ibm_model.initialize_translation_probs(f1, f2)
         translation_counts = defaultdict(lambda: defaultdict(float))
 
-        ibm_model.e_step(
+        ibm_model.expectation_for_one_sentence(
             Counter(["123", "124", "234", "345", ibm_model.null_str]),
             Counter(["123", "124", "234", "345"]),
             translation_counts,
@@ -38,26 +37,11 @@ class TestIBMModel1(unittest.TestCase):
         assert round(translation_counts["123"]["345"], 3) == 0.176
         shutil.rmtree(tmp_dir)
 
-    def test_em_step(self):
-        ibm_model = IBMModel1()
-
-        tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
-        ibm_model.initialize_translation_probs(f1, f2)
-
-        pool = Pool(3)
-        ibm_model.em_step(src_path=f1, dst_path=f2, num_cpus=3, pool=pool)
-
-        assert ibm_model.translation_prob["456789"]["345"] == 0
-        assert ibm_model.translation_prob["456789"]["456789"] == 0.5
-        shutil.rmtree(tmp_dir)
-
     def test_ibm_train(self):
         ibm_model = IBMModel1()
 
         tmp_dir, f1, f2 = morph_utils.get_two_same_tmp_files()
-        ibm_model.learn_ibm_parameters(
-            src_path=f1, dst_path=f2, num_iters=3, num_cpus=3
-        )
+        ibm_model.learn_ibm_parameters(src_path=f1, dst_path=f2, num_iters=3)
 
         assert ibm_model.translation_prob["456789"]["345"] == 0
         assert ibm_model.translation_prob["456789"]["456789"] == 0.5

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -52,6 +52,7 @@ def get_arg_parser():
         help="Number of training epochs for character IBM models.",
         default=3,
     )
+    parser.add_option("--model", type="str", dest="model_path", help="Model Path.")
     return parser
 
 
@@ -60,27 +61,16 @@ class BilingualBPE(BPE):
     An extension of the BPE model that is cross-lingual wrt parallel data.
     """
 
-    def __init__(self):
-        super().__init__()
-        self.dst2src_ibm_model = Word2CharIBMModel1()
-
-    def _init_params(self, src_txt_path: str, dst_txt_path: str, num_ibm_iters: int):
+    def _init_params(self, ibm_model_path: str, src_txt_path: str, dst_txt_path: str):
         """
         Args:
             src_txt_path: Text path for source language in parallel data.
             dst_txt_path: Text path for target language in parallel data.
             num_ibm_iters: Number of training epochs for the IBM model.
         """
-        logger.info("Initializing vocabulary.")
-
-        # Note the reverse side of the model. Target is word based, that is why
-        # we give it a reverse order.
-        self.dst2src_ibm_model.learn_ibm_parameters(
-            src_path=dst_txt_path, dst_path=src_txt_path, num_iters=num_ibm_iters
-        )
         logger.info("calculating alignment-based BPE type probs.")
         self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
-            dst_txt_path=dst_txt_path
+            ibm_model_path=ibm_model_path, dst_txt_path=dst_txt_path
         )
 
         # Need to call this at the end, because this funciton calls the
@@ -102,20 +92,25 @@ class BilingualBPE(BPE):
             vocab[word] /= denom
         return vocab
 
-    def _calc_bpe_prob_from_alignment(self, dst_txt_path: str) -> Dict[str, float]:
+    def _calc_bpe_prob_from_alignment(
+        self, ibm_model_path: str, dst_txt_path: str
+    ) -> Dict[str, float]:
         """
          p(subword=s) = sum_{t in target} p(s|t) p(t)
          where p(t) is target_word_prob[t] from _calc_word_probs
          and p(s|t) = self.dst2src_ibm_model.translation_prob[t][s]
         """
+
+        dst2src_ibm_model = Word2CharIBMModel1()
+        dst2src_ibm_model.load(file_path=ibm_model_path)
         target_word_probs = self._calc_word_probs(txt_path=dst_txt_path)
         bpe_alignment_prob = defaultdict(float)
-        for dst_word_id in list(self.dst2src_ibm_model.translation_prob.keys()):
-            dst_word = self.dst2src_ibm_model.int2str(dst_word_id)
+        for dst_word_id in list(dst2src_ibm_model.translation_prob.keys()):
+            dst_word = dst2src_ibm_model.int2str(dst_word_id)
             target_word_prob = target_word_probs[dst_word]
-            alignment_probs = self.dst2src_ibm_model.translation_prob[dst_word_id]
+            alignment_probs = dst2src_ibm_model.translation_prob[dst_word_id]
             for src_subword_id in list(alignment_probs.keys()):
-                src_subword = self.dst2src_ibm_model.int2str(src_subword_id)
+                src_subword = dst2src_ibm_model.int2str(src_subword_id)
                 bpe_alignment_prob[src_subword] += (
                     alignment_probs[src_subword] * target_word_prob
                 )
@@ -190,16 +185,16 @@ class BilingualBPE(BPE):
             del self.vocab[old_tokens[-1]]
 
     def build_vocab(
-        self, src_txt_path: str, dst_txt_path: str, vocab_size: int, num_ibm_iters: int
+        self, ibm_model_path: str, src_txt_path: str, dst_txt_path: str, vocab_size: int
     ):
         """
         Note that except initalization, other parts are the same as the
         original bpe build_vocab method.
         """
         self._init_params(
+            ibm_model_path=ibm_model_path,
             src_txt_path=src_txt_path,
             dst_txt_path=dst_txt_path,
-            num_ibm_iters=num_ibm_iters,
         )
         return self._build_vocab_loop(vocab_size=vocab_size)
 
@@ -207,13 +202,25 @@ class BilingualBPE(BPE):
 if __name__ == "__main__":
     arg_parser = get_arg_parser()
     options, args = arg_parser.parse_args()
+
+    # Note the reverse side of the model. Target is word based, that is why
+    # we give it a reverse order.
+    dst2src_ibm_model = Word2CharIBMModel1()
+    dst2src_ibm_model.learn_ibm_parameters(
+        src_path=options.dst_train_file,
+        dst_path=options.src_train_file,
+        num_iters=options.num_ibm_iters,
+    )
+    dst2src_ibm_model.save(file_path=options.model_path + ".ibm")
+
     bpe_model = BilingualBPE()
     bpe_model.build_vocab(
+        ibm_model_path=options.model_path + ".ibm",
         src_txt_path=options.src_train_file,
         dst_txt_path=options.dst_train_file,
         vocab_size=options.vocab_size,
-        num_ibm_iters=options.num_ibm_iters,
     )
     bpe_model.segment_txt(
         input_path=options.src_train_file, output_path=options.train_output_file
     )
+    bpe_model.save(file_path=options.model_path)

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -110,10 +110,12 @@ class BilingualBPE(BPE):
         """
         target_word_probs = self._calc_word_probs(txt_path=dst_txt_path)
         bpe_alignment_prob = defaultdict(float)
-        for dst_word in self.dst2src_ibm_model.translation_prob.keys():
+        for dst_word_id in list(self.dst2src_ibm_model.translation_prob.keys()):
+            dst_word = self.dst2src_ibm_model.int2str(dst_word_id)
             target_word_prob = target_word_probs[dst_word]
-            alignment_probs = self.dst2src_ibm_model.translation_prob[dst_word]
-            for src_subword in self.dst2src_ibm_model.translation_prob[dst_word]:
+            alignment_probs = self.dst2src_ibm_model.translation_prob[dst_word_id]
+            for src_subword_id in list(alignment_probs.keys()):
+                src_subword = self.dst2src_ibm_model.int2str(src_subword_id)
                 bpe_alignment_prob[src_subword] += (
                     alignment_probs[src_subword] * target_word_prob
                 )

--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -52,13 +52,6 @@ def get_arg_parser():
         help="Number of training epochs for character IBM models.",
         default=3,
     )
-    parser.add_option(
-        "--num-cpus",
-        type="int",
-        dest="num_cpus",
-        help="Number of cpus for multi-processing.",
-        default=3,
-    )
     return parser
 
 
@@ -71,25 +64,19 @@ class BilingualBPE(BPE):
         super().__init__()
         self.dst2src_ibm_model = Word2CharIBMModel1()
 
-    def _init_params(
-        self, src_txt_path: str, dst_txt_path: str, num_ibm_iters: int, num_cpus: int
-    ):
+    def _init_params(self, src_txt_path: str, dst_txt_path: str, num_ibm_iters: int):
         """
         Args:
             src_txt_path: Text path for source language in parallel data.
             dst_txt_path: Text path for target language in parallel data.
             num_ibm_iters: Number of training epochs for the IBM model.
-            num_cpus: Number of CPUs for training the IBM model with multi-processing.
         """
         logger.info("Initializing vocabulary.")
 
         # Note the reverse side of the model. Target is word based, that is why
         # we give it a reverse order.
         self.dst2src_ibm_model.learn_ibm_parameters(
-            src_path=dst_txt_path,
-            dst_path=src_txt_path,
-            num_iters=num_ibm_iters,
-            num_cpus=num_cpus,
+            src_path=dst_txt_path, dst_path=src_txt_path, num_iters=num_ibm_iters
         )
         logger.info("calculating alignment-based BPE type probs.")
         self.bpe_probs_from_alignment = self._calc_bpe_prob_from_alignment(
@@ -201,12 +188,7 @@ class BilingualBPE(BPE):
             del self.vocab[old_tokens[-1]]
 
     def build_vocab(
-        self,
-        src_txt_path: str,
-        dst_txt_path: str,
-        vocab_size: int,
-        num_ibm_iters: int,
-        num_cpus: int,
+        self, src_txt_path: str, dst_txt_path: str, vocab_size: int, num_ibm_iters: int
     ):
         """
         Note that except initalization, other parts are the same as the
@@ -216,7 +198,6 @@ class BilingualBPE(BPE):
             src_txt_path=src_txt_path,
             dst_txt_path=dst_txt_path,
             num_ibm_iters=num_ibm_iters,
-            num_cpus=num_cpus,
         )
         return self._build_vocab_loop(vocab_size=vocab_size)
 
@@ -230,7 +211,6 @@ if __name__ == "__main__":
         dst_txt_path=options.dst_train_file,
         vocab_size=options.vocab_size,
         num_ibm_iters=options.num_ibm_iters,
-        num_cpus=options.num_cpus,
     )
     bpe_model.segment_txt(
         input_path=options.src_train_file, output_path=options.train_output_file

--- a/pytorch_translate/research/unsupervised_morphology/bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bpe.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+import pickle
 from collections import Counter, defaultdict
 from optparse import OptionParser
 from typing import Dict, List, Optional, Set, Tuple
@@ -228,6 +229,15 @@ class BPE(object):
                         output_bpe_tokens += segmentation_cache[word]
                     writer.write(" ".join(output_bpe_tokens))
                     writer.write("\n")
+
+    def save(self, file_path: str) -> None:
+        with open(file_path, "wb") as f:
+            pickle.dump((self.vocab, self.max_bpe_len), f)
+        logger.info(f"Saved the BPE model in {file_path}")
+
+    def load(self, file_path: str) -> None:
+        with open(file_path, "rb") as f:
+            self.vocab, self.max_bpe_len = pickle.load(f)
 
 
 if __name__ == "__main__":

--- a/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/char_ibm_model1.py
@@ -100,7 +100,7 @@ class Word2CharIBMModel1(CharIBMModel1):
         self.training_data = []
         with open(src_path) as src_file, open(dst_path) as dst_file:
             for src_line, dst_line in zip(src_file, dst_file):
-                src_words_counts = Counter(src_line.strip().split())
+                src_words_counts = Counter(src_line.strip().split() + [self.null_str])
                 dst_sub_words = self.get_subword_counts_for_line(dst_line)
 
                 for src_word in src_words_counts.keys():
@@ -119,7 +119,7 @@ class Word2CharIBMModel1(CharIBMModel1):
 if __name__ == "__main__":
     arg_parser = get_arg_parser()
     options, args = arg_parser.parse_args()
-    ibm_model = CharIBMModel1()
+    ibm_model = Word2CharIBMModel1()
     ibm_model.learn_ibm_parameters(
         src_path=options.src_file,
         dst_path=options.dst_file,

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -114,8 +114,7 @@ class IBMModel1(object):
     ) -> None:
         """
         Args:
-            translation_expectations: holder of expectations until now. This method
-                should update this
+            translation_expectations: holder of expectations until now.
             src_words and dst_words are Counter objects.
         """
         denom = defaultdict(float)
@@ -124,7 +123,7 @@ class IBMModel1(object):
             for dst_word in dst_words:
                 s_count, d_count = src_words[src_word], dst_words[dst_word]
                 prob = self.translation_prob[src_word][dst_word] * s_count * d_count
-                denom[src_word] += prob
+                denom[dst_word] += prob
                 translation_fractional_counts[src_word][dst_word] += prob
 
         for src_word in translation_fractional_counts.keys():
@@ -132,7 +131,7 @@ class IBMModel1(object):
                 translation_expectations[src_word] = defaultdict(float)
             for dst_word in translation_fractional_counts[src_word].keys():
                 delta = (
-                    translation_fractional_counts[src_word][dst_word] / denom[src_word]
+                    translation_fractional_counts[src_word][dst_word] / denom[dst_word]
                 )
                 translation_expectations[src_word][dst_word] += delta
 

--- a/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
+++ b/pytorch_translate/research/unsupervised_morphology/ibm_model1.py
@@ -114,9 +114,11 @@ class IBMModel1(object):
         for src_word in src_words:
             for dst_word in dst_words:
                 s_count, d_count = src_words[src_word], dst_words[dst_word]
-                prob = self.translation_prob[src_word][dst_word] * s_count * d_count
-                denom[dst_word] += prob
-                translation_fractional_counts[src_word][dst_word] += prob
+                prob = self.translation_prob[src_word][dst_word]
+                denom[dst_word] += prob * s_count
+                translation_fractional_counts[src_word][dst_word] += (
+                    prob * s_count * d_count
+                )
 
         for src_word in translation_fractional_counts.keys():
             if src_word not in translation_expectations:


### PR DESCRIPTION
Summary: The previous version took into account the target word counts inside the denominator. That is wrong and gives wrong expectation values in general.

Differential Revision: D15280663

