### PR TITLE
--output-source-binary-path option

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -262,6 +262,8 @@ def _generate_score(models, args, task, dataset):
         output_dataset = pytorch_translate_data.InMemoryNumpyDataset()
         output_dataset.load_from_sequences(output_hypos_token_arrays)
         output_dataset.save(args.output_hypos_binary_path)
+    if args.output_source_binary_path:
+        dataset.src.save(args.output_source_binary_path)
     if args.translation_info_export_path is not None:
         f = open(args.translation_info_export_path, "wb")
         pickle.dump(translation_info_list, f)

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -683,6 +683,16 @@ def expand_generation_args(group, train=False):
         ),
     )
     group.add_argument(
+        "--output-source-binary-path",
+        default=None,
+        type=str,
+        help=(
+            "Optional filename to save binarized source after evaluation "
+            "(primary use case being that this source dataset will be after "
+            "any filtering due to --max-examples-=to-evaluate)"
+        ),
+    )
+    group.add_argument(
         "--translation-info-export-path",
         default=None,
         type=str,


### PR DESCRIPTION
Summary: The `--max-examples-to-evaluate` option allows random filtering of a loaded dataset, which can then be used as sequence-level knowledge distillation targets by saving the output hypotheses (oracle outputs from beam if using `--nbest`) with the `--output-hypos-binary-path` flag. To use these sequences for training, however, we also need to save the filtered source, which this change enables (using the `--output-source-binary-path` option.

Differential Revision: D15323145

