### PR TITLE
frequency multiplied in bilingual bpe

### DIFF
--- a/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
+++ b/pytorch_translate/research/unsupervised_morphology/bilingual_bpe.py
@@ -138,7 +138,7 @@ class BilingualBPE(BPE):
 
     def bpe_alignment_prob(self, bpe_token: str, freq: int):
         if bpe_token in self.bpe_probs_from_alignment:
-            return self.bpe_probs_from_alignment[bpe_token]
+            return freq * self.bpe_probs_from_alignment[bpe_token]
         else:
             # In cases where the alignment model did not cover long character
             # sequences in training data.


### PR DESCRIPTION
Summary: Incorporating the frequency from the raw text in order to get clues both from parallel data and monolingual data.

Differential Revision: D15324904

