### PR TITLE
Stop copying tensors to CPU for torch.unique() in vocab reduction

### DIFF
--- a/pytorch_translate/vocab_reduction.py
+++ b/pytorch_translate/vocab_reduction.py
@@ -236,26 +236,26 @@ class VocabReduction(nn.Module):
             "(to ensure its position in possible_translation_tokens is also 0), "
             f"instead of {self.dst_dict.pad()}."
         )
-        vocab_list = [src_tokens.new_tensor([self.dst_dict.pad()]).cpu()]
+        vocab_list = [src_tokens.new_tensor([self.dst_dict.pad()])]
 
         if decoder_input_tokens is not None:
             flat_decoder_input_tokens = decoder_input_tokens.view(-1)
-            # The tensors should be on CPU since unique is currently CPU-only.
-            vocab_list.append(flat_decoder_input_tokens.cpu())
+            vocab_list.append(flat_decoder_input_tokens)
 
         if self.translation_candidates is not None:
             reduced_vocab = self.translation_candidates.index_select(
                 dim=0, index=src_tokens.view(-1)
             ).view(-1)
-            vocab_list.append(reduced_vocab.cpu())
+            vocab_list.append(reduced_vocab)
         if (
             self.vocab_reduction_params is not None
             and self.vocab_reduction_params["num_top_words"] > 0
         ):
             top_words = torch.arange(
-                self.vocab_reduction_params["num_top_words"]
+                self.vocab_reduction_params["num_top_words"],
+                device=vocab_list[0].device,
             ).long()
-            vocab_list.append(top_words.cpu())
+            vocab_list.append(top_words)
 
         # Get bag of words predicted by word predictor
         if self.predictor is not None:
@@ -267,7 +267,7 @@ class VocabReduction(nn.Module):
             )
             # flatten indices for entire batch [1, batch * k]
             topk_indices = topk_indices.view(-1)
-            vocab_list.append(topk_indices.detach().cpu())
+            vocab_list.append(topk_indices.detach())
 
         all_translation_tokens = torch.cat(vocab_list, dim=0)
         possible_translation_tokens = torch.unique(


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/8899 had added CUDA support for `torch.unique()`

https://github.com/pytorch/pytorch/pull/16145 has some timing stats that could be relevant

 ---

Experiment results: https://fb.quip.com/olQOA853j0mb
Words per second (`gpu-unique_wps_avg_vs_base`): 1.046x
Total train time (`gpu-unique_total_train_time_vs_base`; excl ar_AR-fr_XX): 0.987x

Even though train time reduction is pretty minimal (probably overshadowed by random variance, scheduling delay, etc), WPS does seem to be ~5% faster - so might as well land this.

Training time for ar_AR-fr_XX increased significantly - but that's b/c it trained for many more updates (`gpu-unique_num_updates_avg_vs_base`) - and also ended up w/ +1.43 BLEU. I think this is probably just an anomaly?

Differential Revision: D15073468

