### PR TITLE
classmethods for pad, eos, unk indices

### DIFF
--- a/pytorch_translate/rescoring/weights_search.py
+++ b/pytorch_translate/rescoring/weights_search.py
@@ -6,6 +6,7 @@ import pickle
 import numpy as np
 import torch
 from fairseq import bleu
+from pytorch_translate import vocab_constants
 from pytorch_translate.data.dictionary import Dictionary
 from pytorch_translate.generate import smoothed_sentence_bleu
 
@@ -37,8 +38,11 @@ class DummyTask:
 
 
 def evaluate_weights(scores_info, feature_weights, length_penalty):
-    pad, eos, unk = (0, 1, 2)
-    scorer = bleu.Scorer(pad, eos, unk)
+    scorer = bleu.Scorer(
+        vocab_constants.PAD_ID,
+        vocab_constants.EOS_ID,
+        vocab_constants.UNK_ID,
+    )
 
     for example in scores_info:
         weighted_scores = (example["scores"] * feature_weights).sum(axis=1)
@@ -66,8 +70,11 @@ def random_search(scores_info_export_path, num_trials, report_oracle_bleu=False)
     dummy_task = DummyTask()
 
     if report_oracle_bleu:
-        pad, eos, unk = (0, 1, 2)
-        oracle_scorer = bleu.Scorer(pad, eos, unk)
+        oracle_scorer = bleu.Scorer(
+            vocab_constants.PAD_ID,
+            vocab_constants.EOS_ID,
+            vocab_constants.UNK_ID,
+        )
 
         for example in scores_info:
             smoothed_bleu = []


### PR DESCRIPTION
Summary:
In case we want to reference these values without instantiating a dictionary (as in the updated weights_search.py) example.

Note that the index 1 is skipped (https://fburl.com/008dxkjt) for legacy reasons dating back to Lua Torch.

Differential Revision: D15464943

