### PR TITLE
FairseqModel -> FairseqEncoderDecoderModel

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -36,8 +36,9 @@ class SequenceGenerator(object):
     ):
         """Generates translations of a given source sentence.
         Args:
-            models: List of FairseqModel objects. Each one must implement
-                reorder_encoder_output() method to replicate encoder outputs.
+            models: List of FairseqEncoderDecoderModel objects. Each one must
+                implement reorder_encoder_output() method to replicate encoder
+                outputs.
             min/maxlen: The length of the generated output will be bounded by
                 minlen and maxlen (not including the end-of-sentence marker).
             stop_early: Stop generation immediately after we finalize beam_size

--- a/pytorch_translate/char_source_hybrid.py
+++ b/pytorch_translate/char_source_hybrid.py
@@ -186,7 +186,8 @@ class CharSourceHybridModel(hybrid_transformer_rnn.HybridTransformerRNNModel):
         self, src_tokens, src_lengths, char_inds, word_lengths, prev_output_tokens
     ):
         """
-        Overriding FairseqModel.forward() due to different encoder inputs.
+        Overriding FairseqEncoderDecoderModel.forward() due to different encoder
+        inputs.
         """
         encoder_out = self.encoder(src_tokens, src_lengths, char_inds, word_lengths)
         decoder_out = self.decoder(prev_output_tokens, encoder_out)

--- a/pytorch_translate/char_source_model.py
+++ b/pytorch_translate/char_source_model.py
@@ -133,7 +133,8 @@ class CharSourceModel(rnn.RNNModel):
         self, src_tokens, src_lengths, char_inds, word_lengths, prev_output_tokens
     ):
         """
-        Overriding FairseqModel.forward() due to different encoder inputs.
+        Overriding FairseqEncoderDecoderModel.forward() due to different encoder
+        inputs.
         """
         encoder_out = self.encoder(src_tokens, src_lengths, char_inds, word_lengths)
         decoder_out = self.decoder(prev_output_tokens, encoder_out)

--- a/pytorch_translate/char_source_transformer_model.py
+++ b/pytorch_translate/char_source_transformer_model.py
@@ -197,7 +197,8 @@ class CharSourceTransformerModel(transformer.TransformerModel):
         self, src_tokens, src_lengths, char_inds, word_lengths, prev_output_tokens
     ):
         """
-        Overriding FairseqModel.forward() due to different encoder inputs.
+        Overriding FairseqEncoderDecoderModel.forward() due to different encoder
+        inputs.
         """
         encoder_out = self.encoder(src_tokens, src_lengths, char_inds, word_lengths)
         decoder_out = self.decoder(prev_output_tokens, encoder_out)

--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 from fairseq import bleu, data, options, progress_bar, tasks, utils
 from fairseq.meters import StopwatchMeter, TimeMeter
-from fairseq.models import FairseqModel, FairseqMultiModel
+from fairseq.models import FairseqEncoderDecoderModel, FairseqMultiModel
 from pytorch_translate import hybrid_transformer_rnn  # noqa
 from pytorch_translate import rnn  # noqa
 from pytorch_translate import transformer  # noqa
@@ -35,7 +35,7 @@ def generate_score(
     args: argparse.Namespace,
     task: tasks.FairseqTask,
     dataset: data.FairseqDataset,
-    models: List[FairseqModel],
+    models: List[FairseqEncoderDecoderModel],
     lang_pair: Optional[str] = None,
 ):
     """
@@ -45,7 +45,7 @@ def generate_score(
         args: Command-line arguments.
         task: FairseqTask object.
         dataset: Dataset set object for a specific split for a specific model
-        models: List[FairseqModel], an ensemble of models
+        models: List[FairseqEncoderDecoderModel], an ensemble of models
         lang_pair: Optional model key in a multi model object. Specify None in
             single model set up
     """

--- a/pytorch_translate/hybrid_transformer_rnn.py
+++ b/pytorch_translate/hybrid_transformer_rnn.py
@@ -5,8 +5,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from fairseq import utils
 from fairseq.models import (
+    FairseqEncoderDecoderModel,
     FairseqIncrementalDecoder,
-    FairseqModel,
     register_model,
     register_model_architecture,
     transformer as fairseq_transformer,
@@ -20,7 +20,7 @@ from pytorch_translate.utils import torch_find
 
 
 @register_model("hybrid_transformer_rnn")
-class HybridTransformerRNNModel(FairseqModel):
+class HybridTransformerRNNModel(FairseqEncoderDecoderModel):
     def __init__(self, task, encoder, decoder):
         super().__init__(encoder, decoder)
         self.task = task

--- a/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_model.py
+++ b/pytorch_translate/research/knowledge_distillation/dual_decoder_kd_model.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
-from fairseq.models import FairseqModel, register_model, register_model_architecture
+from fairseq.models import (
+    FairseqEncoderDecoderModel,
+    register_model,
+    register_model_architecture,
+)
 from pytorch_translate import (
     hybrid_transformer_rnn,
     transformer as pytorch_translate_transformer,
@@ -9,7 +13,7 @@ from pytorch_translate.utils import torch_find
 
 
 @register_model("dual_decoder_kd")
-class DualDecoderKDModel(FairseqModel):
+class DualDecoderKDModel(FairseqEncoderDecoderModel):
     def __init__(self, task, encoder, teacher_decoder, student_decoder):
         super().__init__(encoder, student_decoder)
         self.teacher_decoder = teacher_decoder

--- a/pytorch_translate/research/knowledge_distillation/hybrid_dual_decoder_kd_model.py
+++ b/pytorch_translate/research/knowledge_distillation/hybrid_dual_decoder_kd_model.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
-from fairseq.models import FairseqModel, register_model, register_model_architecture
+from fairseq.models import (
+    FairseqEncoderDecoderModel,
+    register_model,
+    register_model_architecture,
+)
 from pytorch_translate import (
     hybrid_transformer_rnn,
     transformer as pytorch_translate_transformer,
@@ -9,7 +13,7 @@ from pytorch_translate.utils import torch_find
 
 
 @register_model("hybrid_dual_decoder_kd")
-class HybridDualDecoderKDModel(FairseqModel):
+class HybridDualDecoderKDModel(FairseqEncoderDecoderModel):
     def __init__(self, task, encoder, teacher_decoder, student_decoder):
         super().__init__(encoder, student_decoder)
         self.teacher_decoder = teacher_decoder

--- a/pytorch_translate/research/rescore/cloze_transformer_model.py
+++ b/pytorch_translate/research/rescore/cloze_transformer_model.py
@@ -1,35 +1,14 @@
 #!/usr/bin/env python3
 
-import math
-
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
-from fairseq import options, utils
-from fairseq.models import (
-    FairseqEncoder,
-    FairseqIncrementalDecoder,
-    FairseqModel,
-    register_model,
-    register_model_architecture,
-    transformer as fairseq_transformer,
-)
-from fairseq.modules import AdaptiveSoftmax, SinusoidalPositionalEmbedding
-from pytorch_translate import utils as pytorch_translate_utils, vocab_reduction
-from pytorch_translate.common_layers import (
-    TransformerEmbedding,
-    TransformerEncoderGivenEmbeddings,
-    TransformerTokenEmbedding,
-    VariableTracker,
-)
-from pytorch_translate.semi_supervised import SemiSupervisedModel
+from fairseq import utils
+from fairseq.models import register_model, register_model_architecture
 from pytorch_translate.transformer import (
     TransformerDecoder,
     TransformerModel,
     base_architecture,
     build_embedding,
 )
-from pytorch_translate.utils import torch_find
 
 
 @register_model("cloze_transformer")

--- a/pytorch_translate/rnn.py
+++ b/pytorch_translate/rnn.py
@@ -7,7 +7,7 @@ import torch.onnx.operators
 from fairseq import options, utils
 from fairseq.models import (
     FairseqEncoder,
-    FairseqModel,
+    FairseqEncoderDecoderModel,
     register_model,
     register_model_architecture,
 )
@@ -77,7 +77,7 @@ class DummyPyTextRNNPointerModel:
 
 
 @register_model("rnn")
-class RNNModel(FairseqModel):
+class RNNModel(FairseqEncoderDecoderModel):
     def __init__(self, task, encoder, decoder):
         super().__init__(encoder, decoder)
         self.task = task

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -8,8 +8,8 @@ import torch.nn.functional as F
 from fairseq import options, utils
 from fairseq.models import (
     FairseqEncoder,
+    FairseqEncoderDecoderModel,
     FairseqIncrementalDecoder,
-    FairseqModel,
     register_model,
     register_model_architecture,
     transformer as fairseq_transformer,
@@ -38,7 +38,7 @@ def build_embedding(dictionary, embed_dim, path=None, freeze=False):
 
 
 @register_model("ptt_transformer")
-class TransformerModel(FairseqModel):
+class TransformerModel(FairseqEncoderDecoderModel):
     def __init__(self, task, encoder, decoder):
         super().__init__(encoder, decoder)
         self.task = task

--- a/pytorch_translate/word_prediction/word_prediction_model.py
+++ b/pytorch_translate/word_prediction/word_prediction_model.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 
-from fairseq.models import FairseqModel, register_model, register_model_architecture
+from fairseq.models import (
+    FairseqEncoderDecoderModel,
+    register_model,
+    register_model_architecture,
+)
 from pytorch_translate import rnn
 from pytorch_translate.rnn import LSTMSequenceEncoder, RNNDecoder, RNNEncoder, RNNModel
 from pytorch_translate.utils import torch_find
 from pytorch_translate.word_prediction import word_predictor
 
 
-class WordPredictionModel(FairseqModel):
+class WordPredictionModel(FairseqEncoderDecoderModel):
     """
     An architecuture which jointly learns translation and target words
     prediction, as described in http://aclweb.org/anthology/D17-1013.


### PR DESCRIPTION
Summary: Using new class `FairseqEncoderDecoderModel` as the base class for seq2seq models as `FairseqModel` is deprecated for direct instantiation.

Differential Revision: D15487504

