### PR TITLE
Reduce number of directions in test_multilingual_hybrid to speed it up

### DIFF
--- a/pytorch_translate/test/test_integration.py
+++ b/pytorch_translate/test/test_integration.py
@@ -567,7 +567,7 @@ class TestTranslation(unittest.TestCase):
                         "--decoder-out-embed-dim",
                         "8",
                         "--lang-pairs",
-                        "xh-en,zu-en,en-xh",
+                        "xh-en,zu-en",
                         "--multilingual-train-text-file",
                         (
                             "xh-en:"
@@ -591,18 +591,6 @@ class TestTranslation(unittest.TestCase):
                             "zu-en:"
                             f"{os.path.join(data_dir, 'tune.zuen.zu')},"
                             f"{os.path.join(data_dir, 'tune.zuen.en')}"
-                        ),
-                        "--multilingual-train-text-file",
-                        (
-                            "en-xh:"
-                            f"{os.path.join(data_dir, 'train.xhen.en')},"
-                            f"{os.path.join(data_dir, 'train.xhen.xh')}"
-                        ),
-                        "--multilingual-eval-text-file",
-                        (
-                            "en-xh:"
-                            f"{os.path.join(data_dir, 'tune.xhen.en')},"
-                            f"{os.path.join(data_dir, 'tune.xhen.xh')}"
                         ),
                         # set these to empty to satisfy argument validation
                         "--train-source-text-file",


### PR DESCRIPTION
Summary: Reducing the number of directions from 3 to 2 to avoid processing additional data which is slowing down the test

Differential Revision: D15587194

