### PR TITLE
Adding masked_lm_dictionary to pytorch_translate

### DIFF
--- a/pytorch_translate/data/masked_lm_dictionary.py
+++ b/pytorch_translate/data/masked_lm_dictionary.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+
+
+from typing import Dict, List, Set
+
+from pytorch_translate import vocab_constants
+from pytorch_translate.data.dictionary import Dictionary
+
+
+class MaskedLMDictionary(Dictionary):
+    """
+    Dictionary for Masked Language Modelling tasks. This extends Dictionary by
+    adding the mask symbol.
+    """
+
+    def __init__(
+        self,
+        pad="<pad>",
+        eos="</s>",
+        unk="<unk>",
+        mask="<mask>",
+        max_special_tokens: int = vocab_constants.MAX_SPECIAL_TOKENS,
+    ):
+        self.symbols: List[str] = []
+        self.count: List[int] = []
+        self.indices: Dict[str, int] = {}
+        self.lexicon_indices: Set[int] = set()
+
+        self.pad_word = pad
+        self.pad_index = self.add_symbol(pad)
+        assert self.pad_index == vocab_constants.PAD_ID
+
+        # Adds a junk symbol for vocab_constants' GO_ID
+        self.add_symbol("<reserved>")
+
+        self.eos_word = eos
+        self.eos_index = self.add_symbol(eos)
+        assert self.eos_index == vocab_constants.EOS_ID
+
+        self.unk_word = unk
+        self.unk_index = self.add_symbol(unk)
+        assert self.unk_index == vocab_constants.UNK_ID
+
+        self.mask_word = mask
+        self.mask_index = self.add_symbol(mask)
+        assert self.mask_index == vocab_constants.MASK_ID
+
+        # Adds junk symbols to pad up to the number of special tokens.
+        num_reserved = max_special_tokens - len(self.symbols)
+        for i in range(num_reserved):
+            self.add_symbol(f"<reserved_{i}>")
+
+        self.nspecial = len(self.symbols)
+        assert self.nspecial == max_special_tokens
+
+    def mask(self):
+        """Helper to get index of mask symbol"""
+        return self.mask_index

--- a/pytorch_translate/models/__init__.py
+++ b/pytorch_translate/models/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import importlib
+import os
+
+
+# automatically import any Python files in the models/ directory
+for file in os.listdir(os.path.dirname(__file__)):
+    if file.endswith(".py") and not file.startswith("_"):
+        model_name = file[: file.find(".py")]
+        importlib.import_module("pytorch_translate.models." + model_name)

--- a/pytorch_translate/models/transformer_from_pretrained_xlm.py
+++ b/pytorch_translate/models/transformer_from_pretrained_xlm.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+
+from fairseq.models import register_model, register_model_architecture
+from fairseq.models.transformer import (
+    base_architecture as transformer_base_architecture,
+)
+from fairseq.models.transformer_from_pretrained_xlm import (
+    TransformerFromPretrainedXLMModel,
+)
+from pytorch_translate.data.masked_lm_dictionary import MaskedLMDictionary
+
+
+@register_model("pytorch_translate_transformer_from_pretrained_xlm")
+class PytorchTranslateTransformerFromPretrainedXLMModel(
+    TransformerFromPretrainedXLMModel
+):
+    @classmethod
+    def build_model(cls, args, task):
+        return super().build_model(args, task, cls_dictionary=MaskedLMDictionary)
+
+
+@register_model_architecture(
+    "pytorch_translate_transformer_from_pretrained_xlm",
+    "pytorch_translate_transformer_from_pretrained_xlm",
+)
+def base_architecture(args):
+    transformer_base_architecture(args)

--- a/pytorch_translate/tasks/cross_lingual_lm.py
+++ b/pytorch_translate/tasks/cross_lingual_lm.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+
+import os
+
+from fairseq import tokenizer
+from fairseq.tasks import register_task
+from fairseq.tasks.cross_lingual_lm import CrossLingualLMTask
+from pytorch_translate.data.masked_lm_dictionary import MaskedLMDictionary
+
+
+@register_task("pytorch_translate_cross_lingual_lm")
+class PytorchTranslateCrossLingualLMTask(CrossLingualLMTask):
+    """
+    Task for training cross-lingual language models.
+    For more details look at: https://arxiv.org/pdf/1901.07291.pdf
+    Args:
+        dictionary (MaskedLMDictionary): the dictionary for the input of the task
+    """
+
+    @staticmethod
+    def add_args(parser):
+        CrossLingualLMTask.add_args(parser)
+        """Add task-specific arguments to the parser."""
+        parser.add_argument(
+            "-s", "--source-lang", default=None, metavar="SRC", help="source language"
+        )
+        parser.add_argument(
+            "-t",
+            "--target-lang",
+            default=None,
+            metavar="TARGET",
+            help="target language",
+        )
+        parser.add_argument(
+            "--save-only", action="store_true", help="skip eval and only do save"
+        )
+
+    @classmethod
+    def load_dictionary(cls, filename):
+        return MaskedLMDictionary.load(filename)
+
+    @classmethod
+    def build_dictionary(
+        cls, filenames, workers=1, threshold=-1, nwords=-1, padding_factor=8
+    ):
+        d = MaskedLMDictionary()
+        for filename in filenames:
+            MaskedLMDictionary.add_file_to_dictionary(
+                filename, d, tokenizer.tokenize_line, workers
+            )
+        d.finalize(threshold=threshold, nwords=nwords, padding_factor=padding_factor)
+        return d
+
+    @classmethod
+    def setup_task(cls, args, **kwargs):
+        """Setup the task.
+        """
+        if getattr(args, "raw_text", False):
+            args.dataset_impl = "raw"
+        elif getattr(args, "lazy_load", False):
+            args.dataset_impl = "lazy"
+
+        dictionary = MaskedLMDictionary.load(
+            os.path.join(args.data, args.source_vocab_file)
+        )
+
+        print("| dictionary: {} types".format(len(dictionary)))
+
+        return cls(args, dictionary)

--- a/pytorch_translate/tasks/translation_from_pretrained_xlm.py
+++ b/pytorch_translate/tasks/translation_from_pretrained_xlm.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+
+from fairseq import options, tokenizer
+from fairseq.tasks import register_task
+from pytorch_translate.data.masked_lm_dictionary import MaskedLMDictionary
+from pytorch_translate.tasks.pytorch_translate_task import PytorchTranslateTask
+
+
+@register_task("pytorch_translate_translation_from_pretrained_xlm")
+class PytorchTranslateTranslationFromPretrainedXLMTask(PytorchTranslateTask):
+    """
+    Same as TranslationTask except use the MaskedLMDictionary class so that
+    we can load data that was binarized with the MaskedLMDictionary class.
+
+    This task should be used for the entire training pipeline when we want to
+    train an NMT model from a pretrained XLM checkpoint: binarizing NMT data,
+    training NMT with the pretrained XLM checkpoint, and subsequent evaluation
+    of that trained model.
+    """
+
+    @staticmethod
+    def add_args(parser):
+        PytorchTranslateTask.add_args(parser)
+        """Add task-specific arguments to the parser."""
+        parser.add_argument(
+            "--save-only", action="store_true", help="skip eval and only do save"
+        )
+
+    @classmethod
+    def load_dictionary(cls, filename):
+        """Load the masked LM dictionary from the filename
+
+        Args:
+            filename (str): the filename
+        """
+        return MaskedLMDictionary.load(filename)
+
+    @classmethod
+    def build_dictionary(
+        cls, filenames, workers=1, threshold=-1, nwords=-1, padding_factor=8
+    ):
+        """Build the dictionary
+
+        Args:
+            filenames (list): list of filenames
+            workers (int): number of concurrent workers
+            threshold (int): defines the minimum word count
+            nwords (int): defines the total number of words in the final dictionary,
+                including special symbols
+            padding_factor (int): can be used to pad the dictionary size to be a
+                multiple of 8, which is important on some hardware (e.g., Nvidia
+                Tensor Cores).
+        """
+        d = MaskedLMDictionary()
+        for filename in filenames:
+            MaskedLMDictionary.add_file_to_dictionary(
+                filename, d, tokenizer.tokenize_line, workers
+            )
+        d.finalize(threshold=threshold, nwords=nwords, padding_factor=padding_factor)
+        return d
+
+    @classmethod
+    def setup_task(cls, args, **kwargs):
+        args.left_pad_source = options.eval_bool(args.left_pad_source)
+
+        # Load dictionaries
+        source_dict = MaskedLMDictionary.load(args.source_vocab_file)
+        target_dict = MaskedLMDictionary.load(args.target_vocab_file)
+
+        source_lang = args.source_lang or "src"
+        target_lang = args.target_lang or "tgt"
+
+        print(f"| [{source_lang}] dictionary: {len(source_dict)} types")
+        print(f"| [{target_lang}] dictionary: {len(target_dict)} types")
+
+        use_char_source = (
+            (args.char_source_vocab_file != "")
+            or (getattr(args, "arch", "") == "char_source")
+            or (getattr(args, "arch", "") == "char_source_transformer")
+            or getattr(args, "arch", "") == "char_source_hybrid"
+        )
+        if use_char_source:
+            char_source_dict = MaskedLMDictionary.load(args.char_source_vocab_file)
+            # this attribute is used for CharSourceModel construction
+            args.char_source_dict_size = len(char_source_dict)
+        else:
+            char_source_dict = None
+
+        return cls(args, source_dict, target_dict, char_source_dict)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -162,10 +162,14 @@ class TestDataset(torch.utils.data.Dataset):
         return len(self.data)
 
 
-def dummy_dictionary(dummy_tokens=3, additional_token_list=None):
+def dummy_dictionary(
+    dummy_tokens=3,
+    additional_token_list=None,
+    dictionary_cls=pytorch_translate_dictionary.Dictionary,
+):
     """First adds the amount of dummy_tokens that you specify, then
     finally the additional_token_list, which is a list of string token values"""
-    d = pytorch_translate_dictionary.Dictionary()
+    d = dictionary_cls()
     for i in range(dummy_tokens):
         token = f"token_{i}"
         d.add_symbol(token)

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -273,6 +273,8 @@ def setup_training_model(args):
             weights_file=getattr(args, "train_weights_path", None),
             is_train=True,
         )
+    elif args.task == "pytorch_translate_cross_lingual_lm":
+        task.load_dataset(args.train_subset, combine=True, epoch=0)
     else:
         # Support both single and multi path loading for now
         task.load_dataset(
@@ -284,12 +286,15 @@ def setup_training_model(args):
 
     if args.task == "dual_learning_task":
         task.load_dataset(split=args.valid_subset, seed=args.seed)
+    elif args.task == "pytorch_translate_cross_lingual_lm":
+        task.load_dataset(args.valid_subset, combine=True, epoch=0)
     else:
         task.load_dataset(
             split=args.valid_subset,
             src_bin_path=args.eval_source_binary_path,
             tgt_bin_path=args.eval_target_binary_path,
         )
+
     return task, model, criterion
 
 

--- a/pytorch_translate/vocab_constants.py
+++ b/pytorch_translate/vocab_constants.py
@@ -13,3 +13,4 @@ PAD_ID = 0
 GO_ID = 1
 EOS_ID = 2
 UNK_ID = 3
+MASK_ID = 4


### PR DESCRIPTION
Summary:
forked masked_lm_dictionary from fairseq
changed import in pytorch_translate to use the new masked_lm_dictionary
registered cooresponding tasks

Differential Revision: D15410352

