### PR TITLE
change the type of hypos consistent over all functions

### DIFF
--- a/pytorch_translate/rescoring/model_scorers.py
+++ b/pytorch_translate/rescoring/model_scorers.py
@@ -173,7 +173,7 @@ class SimpleModelScorer(object):
     def score(self, src_tokens, hypos):
         """ Rescores hypotheses based on a given model and input tokens.
             src_tokens: a tensor with size bsz x max_src_len
-            hypos: a nested list, hypos[i] = [h_0, ..., h_{beam_size}]
+            hypos: a list with length of bsz * beam_size
         """
         if self.model is None:
             return
@@ -182,8 +182,6 @@ class SimpleModelScorer(object):
         # tensors copy src_tokens's type (cpu or gpu)
         if torch.cuda.is_available():
             src_tokens = src_tokens.cuda()
-
-        hypos = [hypo for _ in hypos for hypo in _]
 
         encoder_inputs, tgt_tokens = self.prepare_inputs(src_tokens, hypos)
         hypos_scores, _, _ = self.score_tokens(encoder_inputs, tgt_tokens)

--- a/pytorch_translate/rescoring/test/test_model_scorers.py
+++ b/pytorch_translate/rescoring/test/test_model_scorers.py
@@ -183,17 +183,13 @@ class TestModelScorers(unittest.TestCase):
 
         src_tokens = torch.tensor([[6, 7, 8]], dtype=torch.long)
         hypos_with_padding = [
-            [
-                {"tokens": torch.tensor([12, 13, 14, 15, 16, eos], dtype=torch.long)},
-                {"tokens": torch.tensor([22, 23, 24, 25, eos], dtype=torch.long)},
-                {"tokens": torch.tensor([32, 33, eos], dtype=torch.long)},
-            ]
+            {"tokens": torch.tensor([12, 13, 14, 15, 16, eos], dtype=torch.long)},
+            {"tokens": torch.tensor([22, 23, 24, 25, eos], dtype=torch.long)},
+            {"tokens": torch.tensor([32, 33, eos], dtype=torch.long)},
         ]
         hypos_without_padding = [
-            [
-                {"tokens": torch.tensor([22, 23, 24, 25, eos], dtype=torch.long)},
-                {"tokens": torch.tensor([32, 33, eos], dtype=torch.long)},
-            ]
+            {"tokens": torch.tensor([22, 23, 24, 25, eos], dtype=torch.long)},
+            {"tokens": torch.tensor([32, 33, eos], dtype=torch.long)},
         ]
 
         with patch(
@@ -220,17 +216,15 @@ class TestModelScorers(unittest.TestCase):
 
         src_tokens = torch.tensor([[6, 7, 8]], dtype=torch.long)
         hypos = [
-            [
-                {"tokens": torch.tensor([12, 13, 14, 15, eos], dtype=torch.long)},
-                {"tokens": torch.tensor([22, 23, 24, eos], dtype=torch.long)},
-                {"tokens": torch.tensor([32, 33, eos], dtype=torch.long)},
-            ]
+            {"tokens": torch.tensor([12, 13, 14, 15, eos], dtype=torch.long)},
+            {"tokens": torch.tensor([22, 23, 24, eos], dtype=torch.long)},
+            {"tokens": torch.tensor([32, 33, eos], dtype=torch.long)},
         ]
 
         reverse_src_tokens_0 = torch.tensor([[12, 13, 14, 15]], dtype=torch.long)
         reverse_src_tokens_1 = torch.tensor([[22, 23, 24]], dtype=torch.long)
         reverse_src_tokens_2 = torch.tensor([[32, 33]], dtype=torch.long)
-        reverse_hypos = [[{"tokens": torch.tensor([6, 7, 8, eos], dtype=torch.long)}]]
+        reverse_hypos = [{"tokens": torch.tensor([6, 7, 8, eos], dtype=torch.long)}]
 
         with patch(
             "pytorch_translate.utils.load_diverse_ensemble_for_inference",

--- a/pytorch_translate/rescoring/test/test_rescorer.py
+++ b/pytorch_translate/rescoring/test/test_rescorer.py
@@ -33,15 +33,12 @@ class TestRescorer(unittest.TestCase):
                 [[80, 0, 0, 0, 0], [0, 0, 0, 80, 0]], dtype=torch.float
             )
             src_tokens = torch.tensor([[1, 2, 3, 4, 5]])
-            hypos = [
-                [{"tokens": torch.tensor([1, 2])}, {"tokens": torch.tensor([1, 2])}]
-            ]
+            hypos = [{"tokens": torch.tensor([1, 2])}, {"tokens": torch.tensor([1, 2])}]
 
             src_len = len(src_tokens)
 
             tgt_len = torch.tensor(
-                [len(hypo["tokens"]) for hypo_ in hypos for hypo in hypo_],
-                dtype=torch.float,
+                [len(hypo["tokens"]) for hypo in hypos], dtype=torch.float
             )
             weights = [
                 test_args.l2r_model_weight,
@@ -73,7 +70,7 @@ class TestRescorer(unittest.TestCase):
         task = tasks.PytorchTranslateTask(test_args, src_dict, tgt_dict)
         model = task.build_model(test_args)
         src_tokens = torch.tensor([[1, 2, 3, 4, 5]])
-        hypos = [[{"tokens": torch.tensor([1, 2])}, {"tokens": torch.tensor([1, 2])}]]
+        hypos = [{"tokens": torch.tensor([1, 2])}, {"tokens": torch.tensor([1, 2])}]
         rescorer = Rescorer(
             test_args, task, {"l2r_model": {"model": model, "task": task}}
         )
@@ -103,23 +100,17 @@ class TestRescorer(unittest.TestCase):
             rescorer = Rescorer(test_args)
             src_tokens = torch.tensor([[1, 3, 3, 4, 2], [1, 3, 2, 0, 0]])
             hypos = [
-                [
-                    {"tokens": torch.tensor([1, 5, 2])},
-                    {"tokens": torch.tensor([6, 3, 5, 2])},
-                ],
-                [
-                    {"tokens": torch.tensor([1, 2])},
-                    {"tokens": torch.tensor([1, 5, 6, 2])},
-                ],
+                {"tokens": torch.tensor([1, 5, 2])},
+                {"tokens": torch.tensor([6, 3, 5, 2])},
+                {"tokens": torch.tensor([1, 2])},
+                {"tokens": torch.tensor([1, 5, 6, 2])},
             ]
             scores = rescorer.score(src_tokens, hypos)
 
             src_tokens = torch.tensor([[1, 3, 3, 4, 2]])
             hypos = [
-                [
-                    {"tokens": torch.tensor([1, 5, 2])},
-                    {"tokens": torch.tensor([6, 3, 5, 2])},
-                ]
+                {"tokens": torch.tensor([1, 5, 2])},
+                {"tokens": torch.tensor([6, 3, 5, 2])},
             ]
             scores_single = rescorer.score(src_tokens, hypos)
 


### PR DESCRIPTION
Summary: Change the type of hypos to be a list. This is better for 1) consistent over all functions, don't have to change the type when calling different functions 2) variable hypos has the same meaning, don't have to create multiple names

Differential Revision: D15670964

