### PR TITLE
custom LanguagePairUpsamplingDataset

### DIFF
--- a/pytorch_translate/data/language_pair_upsampling_dataset.py
+++ b/pytorch_translate/data/language_pair_upsampling_dataset.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import numpy as np
+from fairseq.data.concat_dataset import ConcatDataset
+
+
+class LanguagePairUpsamplingDataset(ConcatDataset):
+    def __init__(self, datasets, sample_ratios=1):
+        super(LanguagePairUpsamplingDataset, self).__init__(datasets, sample_ratios)
+        if isinstance(sample_ratios, float):
+            self.memoized_sizes = [self.size(idx) for idx in range(len(self))]
+        else:
+            self.memoized_sizes = np.concatenate(
+                [
+                    np.tile(ds.src_sizes, sr)
+                    for ds, sr in zip(self.datasets, self.sample_ratios)
+                ]
+            )
+
+    @property
+    def sizes(self):
+        return self.memoized_sizes

--- a/pytorch_translate/tasks/pytorch_translate_task.py
+++ b/pytorch_translate/tasks/pytorch_translate_task.py
@@ -18,6 +18,9 @@ from pytorch_translate.data import (
     utils as data_utils,
     weighted_data,
 )
+from pytorch_translate.data.language_pair_upsampling_dataset import (
+    LanguagePairUpsamplingDataset,
+)
 from pytorch_translate.research.multisource import multisource_data
 
 
@@ -267,9 +270,9 @@ class PytorchTranslateTask(FairseqTask):
         sample_ratios = []
         for key, val in datasets.items():
             ds_list.append(val)
-            sample_ratios.append(dataset_upsampling.get(key, 1.0))
+            sample_ratios.append(int(dataset_upsampling.get(key, 1)))
 
-        self.datasets[split] = ConcatDataset(
+        self.datasets[split] = LanguagePairUpsamplingDataset(
             datasets=datasets.values(), sample_ratios=sample_ratios
         )
 


### PR DESCRIPTION
Summary: Extends from fairseq ConcatDataset. As Myle pointed out in D15720559, ConcatDataset is not designed to wrap LanguagePairDataset so in our case there are some limitations. Create a custom dataset for doing it. If we observe serious performance issue for iterating over sizes we could switch back to only supporting integer as sampling_ratios

Differential Revision: D15730883

