### PR TITLE
Clear intermediate checkpoints after training

### DIFF
--- a/pytorch_translate/checkpoint.py
+++ b/pytorch_translate/checkpoint.py
@@ -296,6 +296,14 @@ class CheckpointManager:
                 f"| Finished removing old checkpoint {checkpoint_to_remove}."
             )
 
+    def remove_all_checkpoints(self):
+        """
+        Removes all checkpoints besides
+         average_checkpoint.pt and last_checkpoint.pt
+        """
+        for checkpoint_to_remove in self._checkpoint_files:
+            self._remove_checkpoint(checkpoint_to_remove)
+
     def save(
         self,
         args,

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -641,6 +641,11 @@ def train(
 
     train_meter.stop()
     print(f"| done training in {train_meter.sum:.1f} seconds")
+
+    # the checkpoint manager may be None
+    if checkpoint_manager:
+        checkpoint_manager.remove_all_checkpoints()
+
     print(
         f"| Best BLEU score of {extra_state['tune_bleu']['best']} was from "
         f"epoch {extra_state['tune_bleu']['best_epoch']}"


### PR DESCRIPTION
Summary:
Clears all intermediate checkpoints after training, leaving only `checkpoint_last.pt`and `averaged_checkpoint_best.pt`. Each checkpoint file can be ~1GB.

In the future, if others have a use case for keeping the checkpoints after training completes, we may want to consider adding a boolean flag to control this behavior.

Differential Revision: D15768746

