### PR TITLE
minibatch split for KD

### DIFF
--- a/pytorch_translate/research/test/test_teacher_score_dataset.py
+++ b/pytorch_translate/research/test/test_teacher_score_dataset.py
@@ -38,43 +38,47 @@ class TestTeacherScoreDataSet(unittest.TestCase):
         top_k_teacher_scores = {}
         top_k_teacher_indices = {}
         b1 = TeacherDataset.collate(
-            dataset1,
-            teacher_models,
-            3,
-            src_dict.pad(),
-            src_dict.eos(),
-            top_k_teacher_scores,
-            top_k_teacher_indices,
+            dataset=dataset1,
+            teacher_models=teacher_models,
+            top_k_teacher_tokens=3,
+            pad_idx=src_dict.pad(),
+            eos_idx=src_dict.eos(),
+            top_k_teacher_scores=top_k_teacher_scores,
+            top_k_teacher_indices=top_k_teacher_indices,
+            mem_split_size=3,
         )
         TeacherDataset.collate(
-            dataset2,
-            teacher_models,
-            3,
-            src_dict.pad(),
-            src_dict.eos(),
-            top_k_teacher_scores,
-            top_k_teacher_indices,
+            dataset=dataset2,
+            teacher_models=teacher_models,
+            top_k_teacher_tokens=3,
+            pad_idx=src_dict.pad(),
+            eos_idx=src_dict.eos(),
+            top_k_teacher_scores=top_k_teacher_scores,
+            top_k_teacher_indices=top_k_teacher_indices,
+            mem_split_size=3,
         )
         before_scores = [top_k_teacher_scores[i].cpu().numpy() for i in range(4)]
         before_indices = [top_k_teacher_indices[i].cpu().numpy() for i in range(4)]
 
         TeacherDataset.collate(
-            dataset3,
-            teacher_models,
-            3,
-            src_dict.pad(),
-            src_dict.eos(),
-            top_k_teacher_scores,
-            top_k_teacher_indices,
+            dataset=dataset3,
+            teacher_models=teacher_models,
+            top_k_teacher_tokens=3,
+            pad_idx=src_dict.pad(),
+            eos_idx=src_dict.eos(),
+            top_k_teacher_scores=top_k_teacher_scores,
+            top_k_teacher_indices=top_k_teacher_indices,
+            mem_split_size=3,
         )
         TeacherDataset.collate(
-            dataset4,
-            teacher_models,
-            3,
-            src_dict.pad(),
-            src_dict.eos(),
-            top_k_teacher_scores,
-            top_k_teacher_indices,
+            dataset=dataset4,
+            teacher_models=teacher_models,
+            top_k_teacher_tokens=3,
+            pad_idx=src_dict.pad(),
+            eos_idx=src_dict.eos(),
+            top_k_teacher_scores=top_k_teacher_scores,
+            top_k_teacher_indices=top_k_teacher_indices,
+            mem_split_size=3,
         )
         after_scores = [top_k_teacher_scores[i].cpu().numpy() for i in range(4)]
         after_indices = [top_k_teacher_indices[i].cpu().numpy() for i in range(4)]
@@ -84,13 +88,14 @@ class TestTeacherScoreDataSet(unittest.TestCase):
             np.array_equal(after_indices[i], before_indices[i])
 
         b5 = TeacherDataset.collate(
-            dataset1,
-            teacher_models,
-            3,
-            src_dict.pad(),
-            src_dict.eos(),
-            top_k_teacher_scores,
-            top_k_teacher_indices,
+            dataset=dataset1,
+            teacher_models=teacher_models,
+            top_k_teacher_tokens=3,
+            pad_idx=src_dict.pad(),
+            eos_idx=src_dict.eos(),
+            top_k_teacher_scores=top_k_teacher_scores,
+            top_k_teacher_indices=top_k_teacher_indices,
+            mem_split_size=3,
         )
 
         assert len(teacher_models) == 0

--- a/pytorch_translate/tasks/knowledge_distillation_task.py
+++ b/pytorch_translate/tasks/knowledge_distillation_task.py
@@ -28,6 +28,7 @@ class PytorchKnowledgeDistillationTask(PytorchTranslateTask):
         )
         self.top_k_probs_binary_file = args.top_k_probs_binary_file
         self.top_k_teacher_tokens = args.top_k_teacher_tokens
+        self.teacher_mem_split_size = args.teacher_mem_split_size
 
         if self.top_k_probs_binary_file is None:
             # Load model ensemble from checkpoints
@@ -82,6 +83,15 @@ class PytorchKnowledgeDistillationTask(PytorchTranslateTask):
                 "enumerating all.",
             ),
         )
+        parser.add_argument(
+            "--teacher-mem-split-size",
+            type=int,
+            default=20,
+            help=(
+                "Splits minitbatch to several smaller minibatches for memory-efficient",
+                "teacher scoring in knowledge distillation.",
+            ),
+        )
 
     def load_dataset(
         self, split, src_bin_path, tgt_bin_path, weights_file=None, is_train=False
@@ -122,6 +132,7 @@ class PytorchKnowledgeDistillationTask(PytorchTranslateTask):
                 top_k_teacher_tokens=self.top_k_teacher_tokens,
                 top_k_teacher_scores=self.top_k_teacher_scores,
                 top_k_teacher_indices=self.top_k_teacher_indices,
+                mem_split_size=self.teacher_mem_split_size,
                 left_pad_source=False,
             )
         else:


### PR DESCRIPTION
Summary: In knowledge distillation, we have to split a minibatch to smaller ones in order to prevent from out-of-memory error (due to having many teacher models computing on a same minibatch in every step). This diff facilitates this by having the split size as an option (previously it was hard-coded)

Differential Revision: D15966766

