### PR TITLE
Try except block for import

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -35,8 +35,8 @@ from torch.onnx import ExportTypes, OperatorExportTypes
 
 
 try:
-    import latent_var_models  # noqa;
-except BaseException:
+    from pytorch_translate import latent_var_models  # noqa;
+except ImportError:
     pass
 
 
@@ -48,7 +48,6 @@ from pytorch_translate import (  # noqa; noqa
     rnn,
     semi_supervised,
     transformer,
-    latent_var_models,
 )
 
 logger = logging.getLogger(__name__)

--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -19,9 +19,6 @@ from fairseq.meters import AverageMeter, StopwatchMeter
 from fairseq.trainer import Trainer
 from pytorch_translate import char_source_hybrid  # noqa
 from pytorch_translate import hybrid_transformer_rnn  # noqa
-from pytorch_translate import latent_var_criterion  # noqa
-from pytorch_translate import latent_var_models  # noqa
-from pytorch_translate import latent_var_task  # noqa
 from pytorch_translate import sequence_criterions  # noqa
 from pytorch_translate import transformer  # noqa
 from pytorch_translate import transformer_aan  # noqa
@@ -52,6 +49,14 @@ from pytorch_translate.research.rescore import (  # noqa
 )
 from pytorch_translate.word_prediction import word_prediction_criterion  # noqa
 from pytorch_translate.word_prediction import word_prediction_model  # noqa
+
+
+try:
+    from pytorch_translate import latent_var_criterion  # noqa
+    from pytorch_translate import latent_var_models  # noqa
+    from pytorch_translate import latent_var_task  # noqa
+except ImportError:
+    pass
 
 
 from pytorch_translate import rnn  # noqa; noqa


### PR DESCRIPTION
Summary:
[fbonly]
Some modules exist in internal libraries. Try except block is a common way to handle import https://stackoverflow.com/questions/3131217/error-handling-when-importing-modules

Differential Revision: D16380587

