### PR TITLE
modify beam decode

### DIFF
--- a/pytorch_translate/test/test_beam_search_and_decode.py
+++ b/pytorch_translate/test/test_beam_search_and_decode.py
@@ -125,9 +125,7 @@ class TestBeamSearchAndDecode(unittest.TestCase):
                 top_seq_gen_hypothesis[hyp_index]["attention"].numpy()[
                     :, 0:MAX_SEQ_LEN
                 ],
-                torch.stack(beam_search_and_decode_hypothesis[3])
-                .transpose(0, 1)
-                .numpy()[:, 0:MAX_SEQ_LEN],
+                beam_search_and_decode_hypothesis[3].numpy()[:, 0:MAX_SEQ_LEN],
                 decimal=1,
             )
             # Not testing the hypothesis score as sequence generator is adding EOS

--- a/pytorch_translate/test/test_export_beam_decode.py
+++ b/pytorch_translate/test/test_export_beam_decode.py
@@ -68,13 +68,13 @@ class TestExportBeamDecode(unittest.TestCase):
             beam_indices = beam_decode._get_output_steps_to_beam_indices(
                 end_state, beam_prev_indices
             )
-            weights_from_output = torch.stack(output[state_idx][3]).numpy()
+            weights_from_output = output[state_idx][3].numpy()
             weights_from_input = []
             for pos, beam_index in enumerate(beam_indices):
                 if pos == 0:
                     continue
                 weights_from_input.append(token_weights[pos][beam_index])
-            weights_from_input = torch.stack(weights_from_input).numpy()
+            weights_from_input = torch.stack(weights_from_input, dim=1).numpy()
 
             np.testing.assert_array_equal(weights_from_output, weights_from_input)
 
@@ -201,9 +201,7 @@ class TestExportBeamDecode(unittest.TestCase):
                 top_seq_gen_hypothesis[hyp_index]["attention"].numpy()[
                     :, 0:MAX_SEQ_LEN
                 ],
-                torch.stack(top_beam_decode_hypothesis[3])
-                .transpose(0, 1)
-                .numpy()[:, 0:MAX_SEQ_LEN],
+                top_beam_decode_hypothesis[3].numpy()[:, 0:MAX_SEQ_LEN],
                 decimal=1,
             )
             ## Not testing the hypothesis score as sequence generator is adding EOS

--- a/pytorch_translate/test/test_onnx.py
+++ b/pytorch_translate/test/test_onnx.py
@@ -723,9 +723,7 @@ class TestBeamSearchAndDecodeExport(unittest.TestCase):
                 hypo[2], hypo_deserialized[2], decimal=1
             )
             np.testing.assert_array_almost_equal(
-                torch.stack(hypo[3]).transpose(0, 1).numpy(),
-                torch.stack(hypo_deserialized[3]).transpose(0, 1).numpy(),
-                decimal=1,
+                hypo[3].numpy(), hypo_deserialized[3].numpy(), decimal=1
             )
 
     def test_full_beam_search_decoder(self):


### PR DESCRIPTION
Summary:
Modify BeamDecode and BeamSearchAndDecode return values to match C++ API
1. Add one return value best_indices which represents the ending position of one hypothesis, the first index corresponds num_step, the second one corresponds beam_index.
2. Change attention_weigths return type from List[tensor] to tensor to match C++ side.
3. Modify related test cases accordingly.

Differential Revision: D16355719

