### PR TITLE
Fix type incompatibility for ParallelDataset

### DIFF
--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -302,9 +302,21 @@ def get_source_tokens_tensor(src_tokens):
         return src_tokens
 
 
+# TODO: Remove when gluster is deprecated (T48002528)
+def maybe_remove_gluster_path_prefix(path: str) -> str:
+    if "gluster:///" in path:
+        return path[10:]
+    else:
+        return path
+
+
 def maybe_parse_collection_argument(path: str) -> Union[str, Dict]:
     try:
         path_dict = ast.literal_eval(path)
-    except Exception:
-        return path
+        path_dict = {
+            key: maybe_remove_gluster_path_prefix(value)
+            for key, value in path_dict.items()
+        }
+    except (ValueError, SyntaxError):
+        return maybe_remove_gluster_path_prefix(path)
     return path_dict


### PR DESCRIPTION
Summary: Minimal change to fix type incompatibility for multilingual runs at AutoML sweeping. Not sure why type Union[Dict[str, GlusterPath], GlusterPath] didn't work. And we need either to unify gluster path representation across codebase (with/without gluster:/// prefix), or keep this workaround until we deprecate gluster.

Differential Revision: D16539163

