### PR TITLE
fix GPU unit tests: missing params

### DIFF
--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -142,6 +142,8 @@ class ModelParamsDict:
         self.append_eos_to_source = False
         self.word_reward = 0.0
         self.length_penalty = 0.0
+        self.use_bmuf = False
+        self.no_save_optimizer_state = False
         # Rescoring params
         self.enable_rescoring = False
         self.l2r_model_path = None


### PR DESCRIPTION
Summary: Fairseq requires these params downstream.

Differential Revision: D16627606

