### PR TITLE
Fix argument redundancy in preprocess.binarize_text_file method

### DIFF
--- a/pytorch_translate/constants.py
+++ b/pytorch_translate/constants.py
@@ -11,4 +11,10 @@ DENOISING_AUTOENCODER_TASK = "pytorch_translate_denoising_autoencoder"
 MULTILINGUAL_TRANSLATION_TASK = "pytorch_translate_multilingual_task"
 LATENT_VARIABLE_TASK = "translation_vae"
 
-ARCHS_FOR_CHAR_SOURCE = {"char_source", "char_source_hybrid", "char_source_transformer"}
+ARCHS_FOR_CHAR_SOURCE = {
+    "char_source",
+    "char_source_hybrid",
+    "char_source_transformer",
+    "word_char_hybrid_decoder",
+}
+ARCHS_FOR_CHAR_TARGET = {"word_char_hybrid_decoder"}

--- a/pytorch_translate/options.py
+++ b/pytorch_translate/options.py
@@ -159,6 +159,12 @@ def add_preprocessing_args(parser):
         help="Same as --source-vocab-file except using characters.",
     )
     group.add_argument(
+        "--char-target-vocab-file",
+        default="",
+        metavar="FILE",
+        help="Same as --target-vocab-file except using characters.",
+    )
+    group.add_argument(
         "--embed-bytes",
         type=utils.bool_flag,
         nargs="?",
@@ -173,6 +179,13 @@ def add_preprocessing_args(parser):
         type=int,
         metavar="N",
         help="Same as --source-max-vocab-size except using characters.",
+    )
+    group.add_argument(
+        "--char-target-max-vocab-size",
+        default=-1,
+        type=int,
+        metavar="N",
+        help="Same as --target-max-vocab-size except using characters.",
     )
     group.add_argument(
         "--target-vocab-file",

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -39,13 +39,12 @@ def binarize_text_file(
     output_path: str,
     append_eos: bool,
     reverse_order: bool,
-    use_char_data: bool = False,
     embed_bytes: bool = False,
     char_dictionary: Optional[Dictionary] = None,
     already_numberized: bool = False,
 ) -> str:
     output_path = maybe_generate_temp_file_path(output_path)
-    if use_char_data:
+    if char_dictionary is not None:
         dataset = char_data.InMemoryNumpyWordCharDataset()
         dataset.parse(
             path=text_file,
@@ -219,7 +218,6 @@ def preprocess_monolingual_corpora(
     Preprocess source and target monolingual datasets
     Prerequisite: Vocabs are already built (see build_vocabs)
     """
-    use_char_source = char_source_dict is not None
     if getattr(args, "train_mono_source_text_file", None):
         args.train_mono_source_binary_path = binarize_text_file(
             text_file=args.train_mono_source_text_file,
@@ -227,7 +225,6 @@ def preprocess_monolingual_corpora(
             output_path=args.train_mono_source_binary_path,
             append_eos=args.append_eos_to_source,
             reverse_order=args.reverse_source,
-            use_char_data=use_char_source,
             char_dictionary=char_source_dict,
         )
 
@@ -332,7 +329,6 @@ def preprocess_bilingual_corpora(
     Preprocess source and target parallel datasets
     Prerequisite: Vocabs are already built (see build_vocabs)
     """
-    use_char_source = args.char_source_vocab_file != ""
     embed_bytes = getattr(args, "embed_bytes", False)
     if args.train_source_text_file:
         args.train_source_binary_path = binarize_text_file(
@@ -341,7 +337,6 @@ def preprocess_bilingual_corpora(
             output_path=args.train_source_binary_path,
             append_eos=args.append_eos_to_source,
             reverse_order=args.reverse_source,
-            use_char_data=use_char_source,
             embed_bytes=embed_bytes,
             char_dictionary=char_source_dict,
         )
@@ -352,7 +347,6 @@ def preprocess_bilingual_corpora(
             output_path=args.eval_source_binary_path,
             append_eos=args.append_eos_to_source,
             reverse_order=args.reverse_source,
-            use_char_data=use_char_source,
             embed_bytes=embed_bytes,
             char_dictionary=char_source_dict,
         )

--- a/pytorch_translate/test/test_data.py
+++ b/pytorch_translate/test/test_data.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 import numpy as np
+import torch
 from fairseq.data import LanguagePairDataset, NoisingDataset
 from fairseq.data.concat_dataset import ConcatDataset
 from fairseq.data.noising import UnsupervisedMTNoising
@@ -296,3 +297,37 @@ class TestInMemoryNumpyDataset(unittest.TestCase):
             assert len(sampled_chars_list) == len(orig_chars_list)
             for sampled_chars, orig_chars in zip(sampled_chars_list, orig_chars_list):
                 assert all(sampled_chars.numpy() == orig_chars.numpy())
+
+    def test_collate_char_dataset(self):
+        src_dataset = char_data.InMemoryNumpyWordCharDataset()
+        src_dataset.parse(
+            self.src_txt, self.d, self.char_dict, reverse_order=True, append_eos=True
+        )
+        tgt_dataset = char_data.InMemoryNumpyWordCharDataset()
+        tgt_dataset.parse(
+            self.trg_txt, self.d, self.char_dict, reverse_order=True, append_eos=True
+        )
+        char_dataset = char_data.LanguagePairCharDataset(
+            src=src_dataset,
+            src_sizes=src_dataset.sizes,
+            src_dict=self.d,
+            tgt=tgt_dataset,
+            tgt_sizes=tgt_dataset.sizes,
+            tgt_dict=self.d,
+        )
+        samples = [char_dataset[i] for i in range(len(char_dataset))]
+        collate_data = char_dataset.collater(samples)
+        ids = collate_data["id"]
+        ntokens = collate_data["ntokens"]
+        assert len(ids) == 4
+        assert ntokens == 32
+        assert collate_data["net_input"]["char_inds"].size() == torch.Size([4, 11, 4])
+        assert collate_data["net_input"]["prev_output_chars"].size() == torch.Size(
+            [4, 12, 4]
+        )
+        assert collate_data["target_char_inds"].size() == torch.Size([4, 11, 4])
+        for i in range(collate_data["net_input"]["prev_output_chars"].size()[0]):
+            assert (
+                collate_data["net_input"]["prev_output_chars"][i, 0, 0]
+                == self.d.eos_index
+            )

--- a/pytorch_translate/test/test_preprocess.py
+++ b/pytorch_translate/test/test_preprocess.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 from pytorch_translate import constants, preprocess
+from pytorch_translate.data.dictionary import Dictionary
 from pytorch_translate.test import utils as test_utils
 
 
@@ -40,9 +41,28 @@ class TestPreprocess(unittest.TestCase):
         args.target_vocab_file = test_utils.make_temp_file()
         args.target_max_vocab_size = None
         args.char_source_vocab_file = ""
+        args.char_target_vocab_file = ""
 
         args.task = "pytorch_translate"
         return args
+
+    def test_build_vocabs_char(self):
+        args = self.get_common_data_args_namespace()
+        args.arch = "word_char_hybrid_decoder"
+        args.char_source_max_vocab_size = 30
+        args.char_target_max_vocab_size = 30
+        args.char_source_vocab_file = test_utils.make_temp_file()
+        args.char_target_vocab_file = test_utils.make_temp_file()
+        dictionaries = preprocess.build_vocabs(args, Dictionary)
+        assert len(dictionaries["char_source_dict"]) > 0
+        assert len(dictionaries["char_target_dict"]) > 0
+
+    def test_build_vocabs_no_char(self):
+        args = self.get_common_data_args_namespace()
+        args.arch = "rnn"
+        dictionaries = preprocess.build_vocabs(args, Dictionary)
+        dictionaries["char_source_dict"] is None
+        dictionaries["char_target_dict"] is None
 
     def test_preprocess(self):
         """


### PR DESCRIPTION
Summary: There is use_char_data as boolean, and char_dicitonary as optional. I think removing the boolean is safe.

Differential Revision: D16693693

