### PR TITLE
transformer_aan: export support

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -717,8 +717,6 @@ class SequenceGenerator(object):
                 if self.temperature != 1.0:
                     decoder_out[0].div_(self.temperature)
                 attn = decoder_out[1]
-                if isinstance(model.decoder, TransformerAANDecoder):
-                    attn = attn["attn"]
                 if len(decoder_out) == 3:
                     possible_translation_tokens = decoder_out[2]
                 else:

--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -49,6 +49,7 @@ from pytorch_translate import (  # noqa; noqa
     rnn,
     semi_supervised,
     transformer,
+    transformer_aan,
 )
 
 logger = logging.getLogger(__name__)
@@ -709,8 +710,12 @@ class DecoderBatchedStepEnsemble(nn.Module):
                 )
 
                 futures.append(fut)
-            elif isinstance(model, transformer.TransformerModel) or isinstance(
-                model, char_source_transformer_model.CharSourceTransformerModel
+            elif (
+                isinstance(model, transformer.TransformerModel)
+                or isinstance(
+                    model, char_source_transformer_model.CharSourceTransformerModel
+                )
+                or isinstance(model, transformer_aan.TransformerAANModel)
             ):
                 encoder_output = inputs[i]
                 # store cached states, use evaluation mode
@@ -894,8 +899,12 @@ class DecoderBatchedStepEnsemble(nn.Module):
                         [None for _ in reduced_output_weights_per_model[i]]
                     )
 
-            elif isinstance(model, transformer.TransformerModel) or isinstance(
-                model, char_source_transformer_model.CharSourceTransformerModel
+            elif (
+                isinstance(model, transformer.TransformerModel)
+                or isinstance(
+                    model, char_source_transformer_model.CharSourceTransformerModel
+                )
+                or isinstance(model, transformer_aan.TransformerAANModel)
             ):
                 log_probs, attn_scores, attention_states = torch.jit._wait(fut)
 

--- a/pytorch_translate/test/test_onnx.py
+++ b/pytorch_translate/test/test_onnx.py
@@ -524,6 +524,16 @@ class TestONNX(unittest.TestCase):
         }
         self._test_batched_beam_decoder_step(test_args)
 
+    def test_batched_beam_decoder_aan_vocab_reduction(self):
+        test_args = test_utils.ModelParamsDict(arch="transformer_aan")
+        lexical_dictionaries = test_utils.create_lexical_dictionaries()
+        test_args.vocab_reduction_params = {
+            "lexical_dictionaries": lexical_dictionaries,
+            "num_top_words": 5,
+            "max_translation_candidates_per_word": 1,
+        }
+        self._test_batched_beam_decoder_step(test_args)
+
     def _test_beam_component_equivalence(self, test_args):
         beam_size = 5
         samples, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -32,6 +32,19 @@ class ModelParamsDict:
             self.decoder_ffn_embed_dim = 16
             self.decoder_layers = 2
             self.decoder_attention_heads = 2
+        elif arch == "transformer_aan":
+            self.arch = "transformer_aan"
+            self.encoder_embed_dim = 10
+            self.encoder_ffn_embed_dim = 16
+            self.encoder_layers = 2
+            self.encoder_attention_heads = 2
+            self.decoder_embed_dim = 10
+            self.decoder_ffn_embed_dim = 16
+            self.decoder_layers = 2
+            self.decoder_attention_heads = 2
+            self.decoder_attn_window_size = 0
+            self.no_decoder_aan_ffn = False
+            self.no_decoder_aan_gating = False
         elif arch == "hybrid_transformer_rnn":
             self.arch = "hybrid_transformer_rnn"
             self.encoder_embed_dim = 6


### PR DESCRIPTION
Summary: Adds support for model export (batched beam and PyTorch native) as well as vocabulary reduction to the transformer AAN architecture.

Differential Revision: D16765306

