### PR TITLE
transformer_aan: export fixes

### DIFF
--- a/pytorch_translate/average_attention.py
+++ b/pytorch_translate/average_attention.py
@@ -140,6 +140,9 @@ class AverageAttention(AttentionAbstract):
             saved_state = self._get_input_buffer(incremental_state)
             if "prev_sum" in saved_state:
                 prev_sum = saved_state["prev_sum"]
+                if len(prev_sum) == 2:
+                    # for tracing, prev_sum does not have sequence axis
+                    prev_sum = prev_sum.unsqueeze(0)
                 pos = saved_state["prev_pos"] + 1
                 curr_sum = prev_sum + value
                 attn = curr_sum / pos

--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -109,6 +109,10 @@ def load_models_from_checkpoints(
             model = transformer.TransformerModel.build_model(
                 checkpoint_data["args"], task
             )
+        elif architecture == "transformer_aan":
+            model = transformer_aan.TransformerAANModel.build_model(
+                checkpoint_data["args"], task
+            )
         elif architecture == "hybrid_transformer_rnn":
             model = hybrid_transformer_rnn.HybridTransformerRNNModel.build_model(
                 checkpoint_data["args"], task
@@ -722,11 +726,17 @@ class DecoderBatchedStepEnsemble(nn.Module):
                 model.decoder._is_incremental_eval = True
                 model.eval()
 
+                states_per_layer = (
+                    3 if isinstance(model, transformer_aan.TransformerAANModel) else 4
+                )
+
                 state_inputs = []
                 for _ in model.decoder.layers:
                     # (prev_key, prev_value) for self- and encoder-attention
-                    state_inputs.extend(inputs[next_state_input : next_state_input + 4])
-                    next_state_input += 4
+                    state_inputs.extend(
+                        inputs[next_state_input : next_state_input + states_per_layer]
+                    )
+                    next_state_input += states_per_layer
 
                 encoder_out = (encoder_output, None, None)
 


### PR DESCRIPTION
Summary:
Changes to the `transformer_aan` architecture to enable correctly exported inference networks.

- For the average attention module, only one state is necessary, `prev_sum`
- For correct tracing, states need to be set/fetched with `_set_input_buffer()` and `_get_input_buffer()` module methods instead of `utils.set_incremental_state()`and `utils.set_incremental_state()`
- Need a `get_targets()` for correct inference with vocab reduction
- Added a case for checkpoint loading for this architecture

Differential Revision: D16896729

