### PR TITLE
Support idx/bin loading in pytorch_translate_task

### DIFF
--- a/pytorch_translate/data/char_data.py
+++ b/pytorch_translate/data/char_data.py
@@ -261,7 +261,7 @@ class LanguagePairSourceCharDataset(data.LanguagePairDataset):
     ):
         """
         src : InMemoryNumpyWordCharDataset
-        tgt : InMemoryNumpyDataset
+        tgt : InMemoryIndexedDataset
         weights: Optional[IndexedInMemoryDataset]
         """
         super().__init__(

--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -263,7 +263,7 @@ def _generate_score(models, args, task, dataset):
 
     # If applicable, save collected hypothesis tokens to binary output file
     if collect_output_hypos:
-        output_dataset = pytorch_translate_data.InMemoryNumpyDataset()
+        output_dataset = pytorch_translate_data.InMemoryIndexedDataset()
         output_dataset.load_from_sequences(output_hypos_token_arrays)
         output_dataset.save(args.output_hypos_binary_path)
     if args.output_source_binary_path:

--- a/pytorch_translate/preprocess.py
+++ b/pytorch_translate/preprocess.py
@@ -55,7 +55,7 @@ def binarize_text_file(
             append_eos=append_eos,
         )
     else:
-        dataset = pytorch_translate_data.InMemoryNumpyDataset()
+        dataset = pytorch_translate_data.InMemoryIndexedDataset()
         dataset.parse(
             path=text_file,
             dictionary=dictionary,
@@ -123,7 +123,7 @@ def binarize_text_file_multilingual(
             already_numberized=already_numberized,
         )
     else:
-        dataset = pytorch_translate_data.InMemoryNumpyDataset()
+        dataset = pytorch_translate_data.InMemoryIndexedDataset()
         dataset.parse_multilingual(
             corpus_configs,
             append_eos=append_eos,

--- a/pytorch_translate/tasks/knowledge_distillation_task.py
+++ b/pytorch_translate/tasks/knowledge_distillation_task.py
@@ -103,10 +103,10 @@ class PytorchKnowledgeDistillationTask(PytorchTranslateTask):
             print("Starting to load binarized data files.", flush=True)
         data_utils.validate_corpus_exists(corpus=corpus, split=split)
 
-        dst_dataset = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
+        dst_dataset = pytorch_translate_data.InMemoryIndexedDataset.create_from_file(
             corpus.target.data_file
         )
-        src_dataset = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
+        src_dataset = pytorch_translate_data.InMemoryIndexedDataset.create_from_file(
             corpus.source.data_file
         )
         if is_train:

--- a/pytorch_translate/tasks/multilingual_task.py
+++ b/pytorch_translate/tasks/multilingual_task.py
@@ -168,10 +168,10 @@ class PyTorchTranslateMultilingualTranslationTask(PyTorchTranslateMultiTask):
 
             data_utils.validate_corpus_exists(corpus=corpus, split=split)
 
-            tgt_dataset = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
+            tgt_dataset = pytorch_translate_data.InMemoryIndexedDataset.create_from_file(
                 corpus.target.data_file
             )
-            src_dataset = pytorch_translate_data.InMemoryNumpyDataset.create_from_file(
+            src_dataset = pytorch_translate_data.InMemoryIndexedDataset.create_from_file(
                 corpus.source.data_file
             )
             datasets[lang_pair] = weighted_data.WeightedLanguagePairDataset(

--- a/pytorch_translate/tasks/semi_supervised_task.py
+++ b/pytorch_translate/tasks/semi_supervised_task.py
@@ -173,16 +173,16 @@ class PytorchTranslateSemiSupervised(PyTorchTranslateMultiTask):
             print("Starting to load binarized data files.", flush=True)
         ptt_data_utils.validate_corpus_exists(corpus=corpus, split=split)
 
-        forward_tgt_dataset = ptt_data.InMemoryNumpyDataset.create_from_file(
+        forward_tgt_dataset = ptt_data.InMemoryIndexedDataset.create_from_file(
             corpus.target.data_file
         )
-        backward_tgt_dataset = ptt_data.InMemoryNumpyDataset.create_from_file(
+        backward_tgt_dataset = ptt_data.InMemoryIndexedDataset.create_from_file(
             corpus.source.data_file
         )
-        forward_src_dataset = ptt_data.InMemoryNumpyDataset.create_from_file(
+        forward_src_dataset = ptt_data.InMemoryIndexedDataset.create_from_file(
             corpus.source.data_file
         )
-        backward_src_dataset = ptt_data.InMemoryNumpyDataset.create_from_file(
+        backward_src_dataset = ptt_data.InMemoryIndexedDataset.create_from_file(
             corpus.target.data_file
         )
         forward_parallel_dataset = weighted_data.WeightedLanguagePairDataset(

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -578,6 +578,6 @@ def create_dummy_binarized_dataset(
             sequence.append(vocab_constants.EOS_ID)
         index_sequences.append(sequence)
 
-    dataset = pytorch_translate_data.InMemoryNumpyDataset()
+    dataset = pytorch_translate_data.InMemoryIndexedDataset()
     dataset.load_from_sequences(index_sequences)
     return dataset


### PR DESCRIPTION
Summary:
1. Rename InMemoryNumpyDataset to InMemoryIndexedDataset

2. Support loading idx/bin as fairseq does. In the initializer if the path is passed directly into the class, call the initializer of parent class.

3. When self.npz=True, use the current implementation which overrides parent methods. Otherwise use parent functions.

4. In pytorch_translate_task.load_datasets add the argument npz. Added unit test. We could extend this to other tasks if needed.

Differential Revision: D16867809

