### PR TITLE
Precomputation of character representation for the character-aware decoder (part 1)

### DIFF
--- a/pytorch_translate/char_aware_hybrid.py
+++ b/pytorch_translate/char_aware_hybrid.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
+import math
 from ast import literal_eval
+from typing import List
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pytorch_translate import char_encoder, hybrid_transformer_rnn
+from pytorch_translate import char_encoder, hybrid_transformer_rnn, vocab_constants
+from pytorch_translate.data.dictionary import TAGS
+from pytorch_translate.utils import maybe_cuda
 
 
 class CharAwareHybridRNNDecoder(hybrid_transformer_rnn.HybridRNNDecoder):
@@ -45,6 +49,30 @@ class CharAwareHybridRNNDecoder(hybrid_transformer_rnn.HybridRNNDecoder):
         )
         self.char_layer_norm = nn.LayerNorm(embed_tokens.embedding_dim)
 
+        # By default (before training ends), character representations are
+        # not precomputed. After precomputation, this value should be used in place of
+        # the two embeddings.
+        self._is_precomputed = False
+        self.combined_word_char_embed = nn.Embedding(
+            embed_tokens.num_embeddings, embed_tokens.embedding_dim
+        )
+
+    def _get_char_cnn_output(self, char_inds):
+        if char_inds.dim() == 2:
+            char_inds = char_inds.unsqueeze(1)
+        bsz, seqlen, maxchars = char_inds.size()
+
+        # char_cnn_encoder takes input (max_word_length, total_words)
+        char_inds_flat = char_inds.view(-1, maxchars).t()
+        # output (total_words, encoder_dim)
+        char_cnn_output = self.char_cnn_encoder(char_inds_flat)
+
+        char_cnn_output = char_cnn_output.view(bsz, seqlen, char_cnn_output.shape[-1])
+        # (seqlen, bsz, char_cnn_output_dim)
+        char_cnn_output = char_cnn_output.transpose(0, 1)
+        char_cnn_output = self.char_layer_norm(char_cnn_output)
+        return char_cnn_output
+
     def _embed_prev_outputs(
         self, prev_output_tokens, incremental_state=None, prev_output_chars=None
     ):
@@ -53,24 +81,30 @@ class CharAwareHybridRNNDecoder(hybrid_transformer_rnn.HybridRNNDecoder):
             if prev_output_chars is not None:
                 prev_output_chars = prev_output_chars[:, -1:, :].squeeze(1)
 
-        x = self.embed_tokens(prev_output_tokens)
-        x = F.dropout(x, p=self.dropout, training=self.training)
+        combined_embed = self._combined_word_char_embed(
+            prev_output_tokens=prev_output_tokens, prev_output_chars=prev_output_chars
+        )
+        return combined_embed, prev_output_tokens
 
-        bsz, maxchars = prev_output_chars.size()
-        # char_cnn_encoder takes input (max_word_length, total_words)
-        char_inds_flat = prev_output_chars.view(-1, maxchars).t()
-        # output (total_words, encoder_dim)
-        char_cnn_output = self.char_cnn_encoder(char_inds_flat)
-
-        char_cnn_output = char_cnn_output.view(bsz, 1, char_cnn_output.shape[-1])
-        # (seqlen, bsz, char_cnn_output_dim)
-        char_cnn_output = char_cnn_output.transpose(0, 1)
-        char_cnn_output = self.char_layer_norm(char_cnn_output)
-
-        # B x T x C -> T x B x C
-        x = x.transpose(0, 1)
-
-        return torch.add(x, char_cnn_output), prev_output_tokens
+    def _combined_word_char_embed(self, prev_output_tokens, prev_output_chars):
+        """
+        If the embeddings are precomputed for character compositions (this holds
+        in inference), use the cached embeddings, otherwise compute it.
+        """
+        if self._is_precomputed:
+            combined_embedding = (
+                self.combined_word_char_embed(prev_output_tokens)
+                .squeeze(1)
+                .unsqueeze(0)
+            )
+        else:
+            x = self.embed_tokens(prev_output_tokens)
+            x = F.dropout(x, p=self.dropout, training=self.training)
+            # B x T x C -> T x B x C
+            x = x.transpose(0, 1)
+            char_cnn_output = self._get_char_cnn_output(prev_output_chars)
+            combined_embedding = x + char_cnn_output
+        return combined_embedding
 
     def forward(
         self,
@@ -105,3 +139,90 @@ class CharAwareHybridRNNDecoder(hybrid_transformer_rnn.HybridRNNDecoder):
             possible_translation_tokens=possible_translation_tokens,
             timestep=timestep,
         )
+
+    def precompute_char_representations(
+        self, char_dict, embed_bytes=False, batch_size=5000
+    ):
+        """
+        Precomputes the embeddings from character CNNs. Then adds that to the
+        word embeddings.
+        Args:
+            batch_size: maximum number of words in one batch
+        """
+        character_list = self._char_list_from_dict(
+            char_dict=char_dict, embed_bytes=embed_bytes
+        )
+        all_idx = maybe_cuda(
+            torch.LongTensor([i for i in range(self.embed_tokens.num_embeddings)])
+        )
+        word_embeds = self.embed_tokens(all_idx)
+        num_minibatches = math.ceil(len(character_list) / batch_size)
+        for i in range(num_minibatches):
+            character_sublist = character_list[
+                i * batch_size : min((i + 1) * batch_size, len(character_list))
+            ]
+            max_word_len = max(len(chars) for chars in character_sublist)
+            char_inds = (
+                torch.Tensor(len(character_sublist), max_word_len)
+                .long()
+                .fill_(char_dict.pad_index)
+            )
+
+            for j, chars in enumerate(character_sublist):
+                char_inds[j, : len(chars)] = torch.LongTensor(chars)
+
+            char_cnn_output = self._get_char_cnn_output(maybe_cuda(char_inds))
+
+            # Filling in the precomputed embedding values.
+            index_offset = i * batch_size
+            for j in range(char_cnn_output.size()[1]):
+                cur_idx = j + index_offset
+                self.combined_word_char_embed.weight[cur_idx] = (
+                    char_cnn_output[0, j, :] + word_embeds[cur_idx]
+                )
+
+        self._is_precomputed = True
+        self.combined_word_char_embed.weight.detach()
+
+    def _char_list_from_dict(self, char_dict, embed_bytes=False) -> List[List[int]]:
+        """
+        From self.word_dict, extracts all character sequneces, and convert
+        them to their corresponding list of characters.
+        """
+        character_list = []
+        for word_index, word in enumerate(self.dictionary.symbols):
+            character_list.append(
+                self._char_list_for_word(
+                    word_index=word_index,
+                    word=word,
+                    char_dict=char_dict,
+                    embed_bytes=embed_bytes,
+                )
+            )
+        return character_list
+
+    def _char_list_for_word(
+        self, word_index: int, word: str, char_dict, embed_bytes=False
+    ) -> List[int]:
+        """
+        Extracts character
+        For special words except pad, we put eos, because we actually
+        do not need their character sequences.
+        """
+        if word_index == self.dictionary.pad_index:
+            char_inds = [char_dict.pad_index]
+        elif word_index < self.dictionary.nspecial:
+            char_inds = [char_dict.eos_index]
+        else:
+            if embed_bytes:
+                # The byte_id needs to be incremented by 1 to account for the
+                # padding id (0) in the embedding table
+                char_inds = (
+                    [vocab_constants.NUM_BYTE_INDICES + TAGS.index(word) + 1]
+                    if word in TAGS
+                    else [byte_id + 1 for byte_id in word.encode("utf8", "ignore")]
+                )
+            else:
+                chars = [word] if word in TAGS else list(word)
+                char_inds = [char_dict.index(c) for c in chars]
+        return char_inds

--- a/pytorch_translate/test/test_char_aware_hybrid.py
+++ b/pytorch_translate/test/test_char_aware_hybrid.py
@@ -7,6 +7,7 @@ from pytorch_translate import char_aware_hybrid, transformer
 from pytorch_translate.data.dictionary import Dictionary
 from pytorch_translate.tasks import pytorch_translate_task as tasks
 from pytorch_translate.test import utils as test_utils
+from pytorch_translate.utils import maybe_cuda
 
 
 class TestCharAwareHybrid(unittest.TestCase):
@@ -45,28 +46,32 @@ class TestCharAwareHybrid(unittest.TestCase):
             arch="hybrid_transformer_rnn"
         )
         self.task = tasks.DictionaryHolderTask(self.word_dict, self.word_dict)
-        word_model = self.task.build_model(test_word_decoder_args)
+        word_model = maybe_cuda(self.task.build_model(test_word_decoder_args))
         word_model.eval()  # Make sure we do not apply dropout.
 
         test_args = test_utils.ModelParamsDict(arch="char_aware_hybrid")
 
-        decoder_embed_tokens = transformer.build_embedding(
-            dictionary=self.word_dict, embed_dim=10
+        decoder_embed_tokens = maybe_cuda(
+            transformer.build_embedding(dictionary=self.word_dict, embed_dim=10)
         )
-        decoder = char_aware_hybrid.CharAwareHybridRNNDecoder(
-            args=test_args,
-            src_dict=self.word_dict,
-            dst_dict=self.word_dict,
-            embed_tokens=decoder_embed_tokens,
-            num_chars=len(self.char_dict),
+        decoder = maybe_cuda(
+            char_aware_hybrid.CharAwareHybridRNNDecoder(
+                args=test_args,
+                src_dict=self.word_dict,
+                dst_dict=self.word_dict,
+                embed_tokens=decoder_embed_tokens,
+                num_chars=len(self.char_dict),
+            )
         )
 
-        src_tokens = self.sample["net_input"]["src_tokens"]
-        src_lengths = self.sample["net_input"]["src_lengths"]
-        prev_output_chars = self.sample["net_input"]["prev_output_chars"][
-            :, -1:, :
-        ].squeeze(1)
-        prev_output_tokens = self.sample["net_input"]["prev_output_tokens"][:, 0:1]
+        src_tokens = maybe_cuda(self.sample["net_input"]["src_tokens"])
+        src_lengths = maybe_cuda(self.sample["net_input"]["src_lengths"])
+        prev_output_chars = maybe_cuda(
+            self.sample["net_input"]["prev_output_chars"][:, -1:, :].squeeze(1)
+        )
+        prev_output_tokens = maybe_cuda(
+            self.sample["net_input"]["prev_output_tokens"][:, 0:1]
+        )
 
         encoder_out = word_model.encoder(src_tokens, src_lengths)
 
@@ -146,6 +151,115 @@ class TestCharAwareHybrid(unittest.TestCase):
         assert output_logits[0].equal(output_logits_shuffled[2])
         assert output_logits[1].equal(output_logits_shuffled[0])
         assert output_logits[2].equal(output_logits_shuffled[1])
+
+    def test_precompute(self):
+        """
+        We test that if we shuffle the input sample, we will get the same
+        forward values, both in training mode (without dropout) and in
+        eval mode.
+        For the meanwhile, we use an auxiliary hybrid_transformer_rnn
+        in order to get the encoder output.
+        """
+        test_args = test_utils.ModelParamsDict(arch="char_aware_hybrid")
+
+        decoder_embed_tokens = maybe_cuda(
+            transformer.build_embedding(dictionary=self.word_dict, embed_dim=10)
+        )
+
+        decoder = maybe_cuda(
+            char_aware_hybrid.CharAwareHybridRNNDecoder(
+                args=test_args,
+                src_dict=self.word_dict,
+                dst_dict=self.word_dict,
+                embed_tokens=decoder_embed_tokens,
+                num_chars=len(self.char_dict),
+            )
+        )
+        # Making sure we do not apply dropout.
+        decoder.eval()
+        decoder.precompute_char_representations(
+            char_dict=self.char_dict, embed_bytes=False, batch_size=5
+        )
+
+        first_embedding = decoder.combined_word_char_embed.weight.clone()
+        first_embedding.detach()
+        decoder.precompute_char_representations(
+            char_dict=self.char_dict, embed_bytes=False, batch_size=11
+        )
+        second_embedding = decoder.combined_word_char_embed.weight.clone()
+        second_embedding.detach()
+
+        # Due to a known issue in the char_encoder model, this does not hold for
+        # torch.equal (T53048656)
+        assert torch.allclose(first_embedding, second_embedding, rtol=1e-04, atol=1e-04)
+
+        decoder.precompute_char_representations(
+            char_dict=self.char_dict, embed_bytes=False, batch_size=23
+        )
+        third_embedding = decoder.combined_word_char_embed.weight.clone()
+        third_embedding.detach()
+        # Due to a known issue in the char_encoder model, this does not hold for
+        # torch.equal (T53048656)
+        assert torch.allclose(second_embedding, third_embedding, rtol=1e-04, atol=1e-04)
+
+    def test_forward_training_precompute(self):
+        """
+        We test if precomputation gives the same result.
+        """
+        test_args = test_utils.ModelParamsDict(arch="char_aware_hybrid")
+
+        decoder_embed_tokens = transformer.build_embedding(
+            dictionary=self.word_dict, embed_dim=10
+        )
+        decoder = maybe_cuda(
+            char_aware_hybrid.CharAwareHybridRNNDecoder(
+                args=test_args,
+                src_dict=self.word_dict,
+                dst_dict=self.word_dict,
+                embed_tokens=decoder_embed_tokens,
+                num_chars=len(self.char_dict),
+            )
+        )
+        decoder.eval()
+        prev_output_word_strs = self.word_dict.symbols[-3:]
+        prev_out_word_indices = [
+            self.word_dict.indices[w] for w in prev_output_word_strs
+        ]
+        prev_output_tokens = maybe_cuda(
+            torch.LongTensor(prev_out_word_indices).unsqueeze(1)
+        )
+
+        prev_output_chars = maybe_cuda(
+            torch.LongTensor(
+                [
+                    decoder._char_list_for_word(
+                        word_index=word_index, word=word, char_dict=self.char_dict
+                    )
+                    for word_index, word in zip(
+                        prev_out_word_indices, prev_output_word_strs
+                    )
+                ]
+            )
+        )
+
+        embed_output = maybe_cuda(
+            decoder._embed_prev_outputs(
+                prev_output_tokens=prev_output_tokens,
+                prev_output_chars=prev_output_chars,
+            )[0]
+        )
+
+        decoder.precompute_char_representations(
+            char_dict=self.char_dict, embed_bytes=False, batch_size=30
+        )
+        embed_output_after_precompute = decoder._embed_prev_outputs(
+            prev_output_tokens=prev_output_tokens, prev_output_chars=prev_output_chars
+        )[0]
+        # Due to a known issue in padding, we know that the results are not exactly
+        # the same.
+        assert torch.allclose(
+            embed_output, embed_output_after_precompute, rtol=1e-04, atol=1e-04
+        )
 
     def _dummy_char_data_sample(
         self,


### PR DESCRIPTION
Summary: After training, the character representations will not change; thus we can precompute and store them in an embedding matrix. The next diff will use the embedding in the code.

Differential Revision: D16973132

