### PR TITLE
Fixing wrong dimension for previous characters in char_data

### DIFF
--- a/pytorch_translate/data/char_data.py
+++ b/pytorch_translate/data/char_data.py
@@ -454,7 +454,7 @@ class LanguagePairCharDataset(LanguagePairSourceCharDataset):
         )
         prev_tgt_char_inds = (
             samples[0]["target_chars_list"][0]
-            .new(len(samples), max_tgt_words + 1, max_tgt_word_length)
+            .new(len(samples), max_tgt_words, max_tgt_word_length)
             .long()
             .fill_(self.pad_idx)
         )
@@ -464,7 +464,9 @@ class LanguagePairCharDataset(LanguagePairSourceCharDataset):
             prev_tgt_char_inds[i, 0, :1] = eos_tensor
             for j, chars in enumerate(chars_list):
                 tgt_char_inds[i, j, : tgt_word_lengths[i, j]] = chars
-                prev_tgt_char_inds[i, j + 1, : tgt_word_lengths[i, j]] = chars
+                if j < prev_tgt_char_inds.size()[1] - 1:
+                    # We skip previous characters for the last word.
+                    prev_tgt_char_inds[i, j + 1, : tgt_word_lengths[i, j]] = chars
 
         prev_tgt_word_lengths = torch.cat(
             (torch.ones((len(samples), 1), dtype=torch.long), tgt_word_lengths), dim=1

--- a/pytorch_translate/test/test_data.py
+++ b/pytorch_translate/test/test_data.py
@@ -381,7 +381,7 @@ class TestInMemoryIndexedDataset(unittest.TestCase):
         assert ntokens == 32
         net_input = collate_data["net_input"]
         assert net_input["char_inds"].size() == torch.Size([4, 11, 4])
-        assert net_input["prev_output_chars"].size() == torch.Size([4, 12, 4])
+        assert net_input["prev_output_chars"].size() == torch.Size([4, 11, 4])
         assert collate_data["target_char_inds"].size() == torch.Size([4, 11, 4])
         assert net_input["prev_output_word_lengths"].size() == torch.Size([4, 12])
         for i in range(net_input["prev_output_chars"].size()[0]):


### PR DESCRIPTION
Summary: There was a mistake in dimensions for previous chars in char_data: included one unnecessary additional dimension for previous chars for the last generated words (which are not necessary at all). This causes integration tests break (next diff). Here I fixed that.

Differential Revision: D17290436

