### PR TITLE
backward-compatibility before args.char_target_vocab_file

### DIFF
--- a/pytorch_translate/tasks/pytorch_translate_task.py
+++ b/pytorch_translate/tasks/pytorch_translate_task.py
@@ -148,7 +148,7 @@ class PytorchTranslateTask(FairseqTask):
         else:
             char_source_dict = None
 
-        use_char_target = (args.char_target_vocab_file != "") or (
+        use_char_target = (getattr(args, "char_target_vocab_file", "") != "") or (
             getattr(args, "arch", "") in constants.ARCHS_FOR_CHAR_TARGET
         )
         if use_char_target:


### PR DESCRIPTION
Summary:
Addressing https://github.com/pytorch/translate/issues/593

Broken by  D17271763

Differential Revision: D17438344

