### PR TITLE
Fixing the wrong condition in forward function of the char_aware_model

### DIFF
--- a/pytorch_translate/char_aware_hybrid.py
+++ b/pytorch_translate/char_aware_hybrid.py
@@ -222,17 +222,11 @@ class CharAwareHybridRNNDecoder(hybrid_transformer_rnn.HybridRNNDecoder):
         summed with their corresponding character representations. Thus the model
         will look like the same as a word-based decoder.
         """
-        if self.training:
-            x, prev_output_tokens = self._embed_prev_outputs(
-                prev_output_tokens=prev_output_tokens,
-                incremental_state=incremental_state,
-                prev_output_chars=prev_output_chars,
-            )
-        else:
-            x, prev_output_tokens = super()._embed_prev_outputs(
-                prev_output_tokens=prev_output_tokens,
-                incremental_state=incremental_state,
-            )
+        x, prev_output_tokens = self._embed_prev_outputs(
+            prev_output_tokens=prev_output_tokens,
+            incremental_state=incremental_state,
+            prev_output_chars=prev_output_chars,
+        )
         return self._forward_given_embeddings(
             embed_out=x,
             prev_output_tokens=prev_output_tokens,

--- a/pytorch_translate/checkpoint.py
+++ b/pytorch_translate/checkpoint.py
@@ -266,7 +266,7 @@ class CheckpointManager:
     ) -> Optional[str]:
         # Consider making a copy of each tensor here if we run into issues in
         # the future with callers later modifying the params passed in.
-        self._averaged_params = new_averaged_params
+        self.set_averaged_params(new_averaged_params=new_averaged_params)
 
         checkpoint_to_remove = None
         if (
@@ -282,6 +282,12 @@ class CheckpointManager:
         # even if the file gets copied to another name (ex: checkpoint_last.py).
         self._checkpoint_files.append(new_params_filename)
         return checkpoint_to_remove
+
+    def averaged_params(self) -> OrderedDict:
+        return self._averaged_params
+
+    def set_averaged_params(self, new_averaged_params: OrderedDict) -> None:
+        self._averaged_params = new_averaged_params
 
     def _remove_checkpoint(self, checkpoint_to_remove: Optional[str]):
         if checkpoint_to_remove:


### PR DESCRIPTION
Summary: The condition is wrong: it forces the model to ignore character information during inference. By removing it, this is going to get fixed.

Differential Revision: D17880973

