### PR TITLE
Convert matmuls to quantizable nn.Linear modules (#1065)

### DIFF
--- a/pytorch_translate/hybrid_transformer_rnn.py
+++ b/pytorch_translate/hybrid_transformer_rnn.py
@@ -471,8 +471,8 @@ class HybridRNNDecoder(FairseqIncrementalDecoder):
 
         # (key, value) for encoder-decoder attention computed from encoder
         # output and remain the same throughout decoding
-        key = self.attention.in_proj_k(encoder_x)
-        value = self.attention.in_proj_v(encoder_x)
+        key = self.attention.k_proj(encoder_x)
+        value = self.attention.v_proj(encoder_x)
 
         # (key, value) kept in shape (bsz, num_heads, seq_len, head_dim)
         # to avoid repeated transpose operations

--- a/pytorch_translate/test/test_attention.py
+++ b/pytorch_translate/test/test_attention.py
@@ -131,20 +131,14 @@ class MultiheadAttentionTest(unittest.TestCase):
         X_fc_b = None
         X_fc_w = None
         for name, param in module.named_parameters():
-            if X_name + "weight" in name:
+            if X_name + ".weight" in name or X_name + "_weight" in name:
                 if X_fc_w is not None:
                     raise Exception(f"Duplicate FC name {name} found")
-                X_fc_w = param[start:end, :].detach().numpy()
-            elif X_name + "bias" in name:
-                if X_fc_b is not None:
-                    raise Exception(f"Duplicate FC name {name} found")
-                X_fc_b = param[start:end].detach().numpy()
-            elif "_proj_weight" in X_name and X_name in name:
                 X_fc_w = param.detach().numpy()
-            elif "_proj_weight" in X_name and "in_proj_bias" in name:
+            elif X_name + ".bias" in name or X_name + "_bias" in name:
                 if X_fc_b is not None:
                     raise Exception(f"Duplicate FC name {name} found")
-                X_fc_b = param[start:end].detach().numpy()
+                X_fc_b = param.detach().numpy()
         return np.matmul(X, np.transpose(X_fc_w)) + X_fc_b
 
     def _multihead_attn_test_helper(self, use_src_lengths):
@@ -190,17 +184,11 @@ class MultiheadAttentionTest(unittest.TestCase):
                     self.assertEqual(result.ndim, 3)
                     result = np.squeeze(result, axis=0)
 
-                Q_fc = self._fc(Q, "q_proj_weight", multihead_attn_module, end=d_model)
+                Q_fc = self._fc(Q, "q_proj", multihead_attn_module, end=d_model)
                 K_fc = self._fc(
-                    K,
-                    "k_proj_weight",
-                    multihead_attn_module,
-                    start=d_model,
-                    end=2 * d_model,
+                    K, "k_proj", multihead_attn_module, start=d_model, end=2 * d_model
                 )
-                V_fc = self._fc(
-                    V, "v_proj_weight", multihead_attn_module, start=2 * d_model
-                )
+                V_fc = self._fc(V, "v_proj", multihead_attn_module, start=2 * d_model)
 
                 Q_split = self._split_heads_ref(
                     Q_fc, [batch_sz, 1, d_model], nheads, d_head
@@ -221,7 +209,7 @@ class MultiheadAttentionTest(unittest.TestCase):
                 )
 
                 reference = self._fc(
-                    combined_attn_heads, "out_proj.", multihead_attn_module
+                    combined_attn_heads, "out_proj", multihead_attn_module
                 )
                 reference = np.squeeze(reference, axis=1)
                 self.assertEqual(tuple(result.shape), (batch_sz, d_model))

--- a/pytorch_translate/transformer.py
+++ b/pytorch_translate/transformer.py
@@ -551,21 +551,17 @@ class TransformerDecoder(FairseqIncrementalDecoder):
             for k in state_dict.keys():
                 if self.share_input_output_embed is True:
                     if k.endswith(prefix + "embed_tokens.weight"):
-                        keys_to_remove.append(k)
-
-                        items_to_add[prefix + "output_projection"] = nn.Linear(
-                            state_dict[k].shape[0], state_dict[k].shape[1]
-                        )
-                        items_to_add[prefix + "output_projection.weight"] = state_dict[k]
+                        items_to_add[prefix + "output_projection.weight"] = state_dict[
+                            k
+                        ]
                         bias = nn.Parameter(torch.Tensor(state_dict[k].shape[0]))
                         nn.init.constant_(bias, 0.0)
                         items_to_add[prefix + "output_projection.bias"] = bias
                 else:
                     if k.endswith(prefix + "embed_out"):
-                        items_to_add[prefix + "output_projection"] = nn.Linear(
-                            state_dict[k].shape[0], state_dict[k].shape[1]
-                        )
-                        items_to_add[prefix + "output_projection.weight"] = state_dict[k]
+                        items_to_add[prefix + "output_projection.weight"] = state_dict[
+                            k
+                        ]
                         bias = nn.Parameter(torch.Tensor(state_dict[k].shape[0]))
                         nn.init.constant_(bias, 0.0)
                         items_to_add[prefix + "output_projection.bias"] = bias
@@ -609,8 +605,8 @@ class TransformerDecoder(FairseqIncrementalDecoder):
 
             # (key, value) for encoder-decoder attention computed from encoder
             # output and remain the same throughout decoding
-            key = layer.encoder_attn.in_proj_k(encoder_x)
-            value = layer.encoder_attn.in_proj_v(encoder_x)
+            key = layer.encoder_attn.k_proj(encoder_x)
+            value = layer.encoder_attn.v_proj(encoder_x)
 
             # (key, value) kept in shape (bsz, num_heads, seq_len, head_dim)
             # to avoid repeated transpose operations

--- a/pytorch_translate/transformer_aan.py
+++ b/pytorch_translate/transformer_aan.py
@@ -558,8 +558,8 @@ class TransformerAANDecoder(FairseqIncrementalDecoder):
 
             # (key, value) for encoder-decoder attention computed from encoder
             # output and remain the same throughout decoding
-            key = layer.encoder_attn.in_proj_k(encoder_x)
-            value = layer.encoder_attn.in_proj_v(encoder_x)
+            key = layer.encoder_attn.k_proj(encoder_x)
+            value = layer.encoder_attn.v_proj(encoder_x)
 
             # (key, value) kept in shape (bsz, num_heads, seq_len, head_dim)
             # to avoid repeated transpose operations


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/pytext/pull/1065

Pull Request resolved: https://github.com/fairinternal/fairseq-py/pull/889

We are converting matmuls to quantizable nn.Linear modules in this diff. First let's test profile after the diff to see how low level operations are changing.

Reviewed By: jmp84, edunov, lly-zero-one, jhcross

Differential Revision: D17964796

