### PR TITLE
AAN as ptt_transformer option

### DIFF
--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -32,6 +32,7 @@ class ModelParamsDict:
             self.decoder_ffn_embed_dim = 16
             self.decoder_layers = 2
             self.decoder_attention_heads = 2
+            self.aan = False
         elif arch == "transformer_aan":
             self.arch = "transformer_aan"
             self.encoder_embed_dim = 10


### PR DESCRIPTION
Summary: There's a latency architecture upon export for the `transformer_aan` architecture, so this diff adds the AAN approach as an option in the `ptt_transformer` architecture, which both resolves the efficiency issue and simplifies our codebase.

Differential Revision: D18155970

