### PR TITLE
remove export support for transformer_aan arch

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -48,7 +48,6 @@ from pytorch_translate import (  # noqa; noqa
     rnn,
     semi_supervised,
     transformer,
-    transformer_aan,
 )
 
 logger = logging.getLogger(__name__)
@@ -106,10 +105,6 @@ def load_models_from_checkpoints(
             )
         elif architecture == "ptt_transformer":
             model = transformer.TransformerModel.build_model(
-                checkpoint_data["args"], task
-            )
-        elif architecture == "transformer_aan":
-            model = transformer_aan.TransformerAANModel.build_model(
                 checkpoint_data["args"], task
             )
         elif architecture == "hybrid_transformer_rnn":
@@ -719,22 +714,15 @@ class DecoderBatchedStepEnsemble(nn.Module):
                 )
 
                 futures.append(fut)
-            elif (
-                isinstance(model, transformer.TransformerModel)
-                or isinstance(
-                    model, char_source_transformer_model.CharSourceTransformerModel
-                )
-                or isinstance(model, transformer_aan.TransformerAANModel)
+            elif isinstance(model, transformer.TransformerModel) or isinstance(
+                model, char_source_transformer_model.CharSourceTransformerModel
             ):
                 encoder_output = inputs[i]
                 # store cached states, use evaluation mode
                 model.decoder._is_incremental_eval = True
                 model.eval()
 
-                states_per_layer = (
-                    3 if isinstance(model, transformer_aan.TransformerAANModel) else 4
-                )
-
+                states_per_layer = 4
                 state_inputs = []
                 for _ in model.decoder.layers:
                     # (prev_key, prev_value) for self- and encoder-attention
@@ -967,12 +955,8 @@ class DecoderBatchedStepEnsemble(nn.Module):
                         [None for _ in reduced_output_weights_per_model[i]]
                     )
 
-            elif (
-                isinstance(model, transformer.TransformerModel)
-                or isinstance(
-                    model, char_source_transformer_model.CharSourceTransformerModel
-                )
-                or isinstance(model, transformer_aan.TransformerAANModel)
+            elif isinstance(model, transformer.TransformerModel) or isinstance(
+                model, char_source_transformer_model.CharSourceTransformerModel
             ):
                 log_probs, attn_scores, attention_states = torch.jit._wait(fut)
 

--- a/pytorch_translate/test/test_onnx.py
+++ b/pytorch_translate/test/test_onnx.py
@@ -524,27 +524,6 @@ class TestONNX(unittest.TestCase):
         }
         self._test_batched_beam_decoder_step(test_args)
 
-    def test_batched_beam_decoder_aan_vocab_reduction(self):
-        test_args = test_utils.ModelParamsDict(arch="transformer_aan")
-        lexical_dictionaries = test_utils.create_lexical_dictionaries()
-        test_args.vocab_reduction_params = {
-            "lexical_dictionaries": lexical_dictionaries,
-            "num_top_words": 5,
-            "max_translation_candidates_per_word": 1,
-        }
-        self._test_batched_beam_decoder_step(test_args)
-
-    def test_batched_beam_decoder_aan_bottleneck_vocab_reduction(self):
-        test_args = test_utils.ModelParamsDict(arch="transformer_aan")
-        test_args.decoder_out_embed_dim = 5
-        lexical_dictionaries = test_utils.create_lexical_dictionaries()
-        test_args.vocab_reduction_params = {
-            "lexical_dictionaries": lexical_dictionaries,
-            "num_top_words": 5,
-            "max_translation_candidates_per_word": 1,
-        }
-        self._test_batched_beam_decoder_step(test_args)
-
     def _test_beam_component_equivalence(self, test_args):
         beam_size = 5
         samples, src_dict, tgt_dict = test_utils.prepare_inputs(test_args)

--- a/pytorch_translate/test/utils.py
+++ b/pytorch_translate/test/utils.py
@@ -33,19 +33,6 @@ class ModelParamsDict:
             self.decoder_layers = 2
             self.decoder_attention_heads = 2
             self.aan = False
-        elif arch == "transformer_aan":
-            self.arch = "transformer_aan"
-            self.encoder_embed_dim = 10
-            self.encoder_ffn_embed_dim = 16
-            self.encoder_layers = 2
-            self.encoder_attention_heads = 2
-            self.decoder_embed_dim = 10
-            self.decoder_ffn_embed_dim = 16
-            self.decoder_layers = 2
-            self.decoder_attention_heads = 2
-            self.decoder_attn_window_size = 0
-            self.no_decoder_aan_ffn = False
-            self.no_decoder_aan_gating = False
         elif arch == "hybrid_transformer_rnn":
             self.arch = "hybrid_transformer_rnn"
             self.encoder_embed_dim = 6


### PR DESCRIPTION
Summary: In favor of using the `ptt_transformer` architecture with the `aan` option.

Differential Revision: D18219417

