### PR TITLE
get attn out from dictionary

### DIFF
--- a/pytorch_translate/beam_decode.py
+++ b/pytorch_translate/beam_decode.py
@@ -758,6 +758,8 @@ class SequenceGenerator(object):
                 all_log_probs.append(log_probs)
 
             if attn is not None:
+                if isinstance(attn, dict):
+                    attn = attn["attn"]
                 attn = attn[:, -1, :].data
                 if avg_attn is None:
                     avg_attn = attn


### PR DESCRIPTION
Summary: beam decoding breaks as `attn` becomes a dictionary

Differential Revision: D18710264

