### PR TITLE
Manifold migration for export code / export code cleanup

### DIFF
--- a/pytorch_translate/benchmark.py
+++ b/pytorch_translate/benchmark.py
@@ -10,6 +10,7 @@ from pytorch_translate import (
     options as pytorch_translate_options,
     utils as pytorch_translate_utils,
 )
+from pytorch_translate.constants import CHECKPOINT_PATHS_DELIMITER
 
 
 from pytorch_translate import rnn  # noqa; noqa
@@ -124,7 +125,7 @@ def benchmark(args):
     args.target_lang = "tgt"
 
     models, model_args, task = pytorch_translate_utils.load_diverse_ensemble_for_inference(
-        args.path.split(":")
+        args.path.split(CHECKPOINT_PATHS_DELIMITER)
     )
 
     append_eos_to_source = model_args[0].append_eos_to_source

--- a/pytorch_translate/constants.py
+++ b/pytorch_translate/constants.py
@@ -18,3 +18,4 @@ ARCHS_FOR_CHAR_SOURCE = {
     "char_aware_hybrid",
 }
 ARCHS_FOR_CHAR_TARGET = {"char_aware_hybrid"}
+CHECKPOINT_PATHS_DELIMITER = "|"

--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -24,6 +24,7 @@ from fairseq.models import ARCH_MODEL_REGISTRY
 from fairseq.models.model_utils import script_skip_tensor
 from fairseq.models.transformer import EncoderOut
 from pytorch_translate.beam_decode import BeamDecode
+from pytorch_translate.checkpoint import load_to_cpu
 from pytorch_translate.data import dictionary
 from pytorch_translate.research.knowledge_distillation import (
     dual_decoder_kd_model,
@@ -81,7 +82,7 @@ def load_models_from_checkpoints(
     dst_dict = dictionary.Dictionary.load(dst_dict_filename)
     models = []
     for filename in checkpoint_filenames:
-        checkpoint_data = torch.load(filename, map_location="cpu")
+        checkpoint_data = load_to_cpu(filename)
         if lexical_dict_paths is not None:
             assert (
                 checkpoint_data["args"].vocab_reduction_params is not None

--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -31,6 +31,7 @@ from pytorch_translate import (
     options as pytorch_translate_options,
     utils as pytorch_translate_utils,
 )
+from pytorch_translate.constants import CHECKPOINT_PATHS_DELIMITER
 from pytorch_translate.data import data as pytorch_translate_data
 from pytorch_translate.dual_learning.dual_learning_models import DualLearningModel
 from pytorch_translate.research.beam_search import competing_completed
@@ -166,7 +167,11 @@ def _generate_score(models, args, task, dataset, modify_target_dict):
 
     # Load ensemble
     if not args.quiet:
-        print("| loading model(s) from {}".format(", ".join(args.path.split(":"))))
+        print(
+            "| loading model(s) from {}".format(
+                ", ".join(args.path.split(CHECKPOINT_PATHS_DELIMITER))
+            )
+        )
 
     # Optimize ensemble for generation
     for model in models:
@@ -683,7 +688,7 @@ def generate(args):
     pytorch_translate_options.print_args(args)
 
     models, model_args, task = pytorch_translate_utils.load_diverse_ensemble_for_inference(
-        args.path.split(":")
+        args.path.split(CHECKPOINT_PATHS_DELIMITER)
     )
     args.source_lang = model_args[0].source_lang
     args.target_lang = model_args[0].target_lang

--- a/pytorch_translate/onnx_component_export.py
+++ b/pytorch_translate/onnx_component_export.py
@@ -5,6 +5,7 @@ import argparse
 import numpy as np
 import torch
 from pytorch_translate import rnn  # noqa
+from pytorch_translate.constants import CHECKPOINT_PATHS_DELIMITER
 from pytorch_translate.ensemble_export import (
     CharSourceEncoderEnsemble,
     DecoderBatchedStepEnsemble,
@@ -90,7 +91,7 @@ def main():
 
 def export(args):
     assert_required_args_are_set(args)
-    checkpoint_filenames = args.path.split(":")
+    checkpoint_filenames = args.path.split(CHECKPOINT_PATHS_DELIMITER)
 
     if args.char_source:
         encoder_class = CharSourceEncoderEnsemble

--- a/pytorch_translate/research/knowledge_distillation/collect_top_k_probs.py
+++ b/pytorch_translate/research/knowledge_distillation/collect_top_k_probs.py
@@ -11,6 +11,7 @@ from pytorch_translate import (
     options as pytorch_translate_options,
     utils as pytorch_translate_utils,
 )
+from pytorch_translate.constants import CHECKPOINT_PATHS_DELIMITER
 from pytorch_translate.tasks.pytorch_translate_multi_task import (  # noqa
     PyTorchTranslateMultiTask,
 )
@@ -109,7 +110,7 @@ def save_top_k(args):
         model_args,
         task,
     ) = pytorch_translate_utils.load_diverse_ensemble_for_inference(
-        args.path.split(":")
+        args.path.split(CHECKPOINT_PATHS_DELIMITER)
     )
     for model in models:
         model.eval()

--- a/pytorch_translate/research/tune_ensemble_weights/tune_model_weights.py
+++ b/pytorch_translate/research/tune_ensemble_weights/tune_model_weights.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from fairseq import options
 from pytorch_translate import generate
+from pytorch_translate.constants import CHECKPOINT_PATHS_DELIMITER
 
 
 def add_tune_args(parser):
@@ -43,7 +44,7 @@ def tune_model_weights():
     parser = add_tune_args(parser)
     args = options.parse_args_and_arch(parser)
     print(args.model_weights)
-    n_models = len(args.path.split(":"))
+    n_models = len(args.path.split(CHECKPOINT_PATHS_DELIMITER))
     print(n_models)
 
     weight_grid = np.linspace(

--- a/pytorch_translate/research/tune_ensemble_weights/tune_model_weights_with_ax.py
+++ b/pytorch_translate/research/tune_ensemble_weights/tune_model_weights_with_ax.py
@@ -4,6 +4,7 @@ import json
 from ax.service.managed_loop import optimize
 from fairseq import options
 from pytorch_translate import generate
+from pytorch_translate.constants import CHECKPOINT_PATHS_DELIMITER
 
 
 def add_tune_args(parser):
@@ -52,7 +53,7 @@ def tune_model_weights():
     parser = generate.get_parser_with_args()
     parser = add_tune_args(parser)
     args = options.parse_args_and_arch(parser)
-    n_models = len(args.path.split(":"))
+    n_models = len(args.path.split(CHECKPOINT_PATHS_DELIMITER))
     print(n_models)
     print(args.weight_lower_bound)
     print(args.weight_upper_bound)

--- a/pytorch_translate/torchscript_export.py
+++ b/pytorch_translate/torchscript_export.py
@@ -3,6 +3,7 @@
 import argparse
 
 from pytorch_translate import rnn  # noqa
+from pytorch_translate.constants import CHECKPOINT_PATHS_DELIMITER
 from pytorch_translate.ensemble_export import BeamSearch
 
 
@@ -62,7 +63,7 @@ def main():
         parser.print_help()
         return
 
-    checkpoint_filenames = args.path.split(":")
+    checkpoint_filenames = args.path.split(CHECKPOINT_PATHS_DELIMITER)
 
     beam_search = BeamSearch.build_from_checkpoints(
         checkpoint_filenames=checkpoint_filenames,


### PR DESCRIPTION
Summary:
1. Migrate export related code from Gluster to Manifold
2. Simplify the code a bit by removing branches for batched beam. We don't export models with batched beam anymore.
3. Following suggestions in T56261838, copy from/to gluster for now and remove the logic after downstream code (eval related T55948284 Chau) & upstream code (sweep related) finishes migration.
4. splitter ":" -> "|"

Differential Revision: D18185452

