### PR TITLE
NAT bug fix

### DIFF
--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -1838,7 +1838,6 @@ class IterativeRefinementGenerator(nn.Module):
             sent_idxs = script_skip_tensor(sent_idxs, not_terminated)
 
             prev_output_tokens = prev_decoder_out.output_tokens.clone()
-            sent_idxs = sent_idxs[not_terminated]
 
         return (
             finalized_tokens_list,


### PR DESCRIPTION
Summary:
Remove a duplicate operation. Line 1838 is doing the same thing.

Earlier max_iter > 1 inference is broken internally. This fixes it, though we don't observe much performance gain for max_iter > 1. And the performance max_iter=1 doesn't change.

Reviewed By: kahne

Differential Revision: D19145640

