### PR TITLE
Script MultiheadAttention (#1524)

### DIFF
--- a/pytorch_translate/average_attention.py
+++ b/pytorch_translate/average_attention.py
@@ -9,9 +9,11 @@
 import torch
 import torch.nn.functional as F
 from fairseq import utils
+from fairseq.incremental_decoding_utils import with_incremental_state
 from torch import nn
 
 
+@with_incremental_state
 class AttentionAbstract(nn.Module):
     """Abstract class for attention modules
     """


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/fairseq/pull/1524

Make fairseq MultiheadAttention scriptable. Looking for feedbacks.

1. Add types
2. Move incremental state management logic from util functions to initializers. TorchScript in general doesn't support global dict. As a result modules with multihead attention in it would assign itself fairseq_instance_id in the initializer.
3. There might be opportunities to make assertions and annotations cleaner.

Differential Revision: D18772594

