### PR TITLE
Fix generate.py in pytorch_translate for OSS

### DIFF
--- a/pytorch_translate/generate.py
+++ b/pytorch_translate/generate.py
@@ -46,7 +46,7 @@ try:
         LevenshteinTransformerModel,
     )  # noqa
 except ImportError:
-    pass
+    from fairseq.models.nat import LevenshteinTransformerModel
 
 
 def generate_score(


### PR DESCRIPTION
Summary:
LevT with fb_ is for production. There is a separate version for OSS users.

Note: pytorch_translate OSS library would not be actively maintained. We are switching to Fairseq.

Differential Revision: D19260751

