### PR TITLE
Bug fix after D19679308

### DIFF
--- a/pytorch_translate/evals.py
+++ b/pytorch_translate/evals.py
@@ -338,7 +338,7 @@ def save_and_eval(
         )
     stop_training = pytorch_translate_utils.all_gather_from_master(
         args=args, data=[master_stop_training]
-    )
+    )[0]
 
     # TODO: fix after masked lm work completes
     if "save_only" not in args or not args.save_only:


### PR DESCRIPTION
Summary:
An important local fix got lost before D19679308 so on master training stops after first iteration.

When gathering "stop_training" from master in distributed training we need to unpack the result wrapped in a list.

Differential Revision: D19887095

