### PR TITLE
test transformer with aan=True param

### DIFF
--- a/pytorch_translate/test/test_export.py
+++ b/pytorch_translate/test/test_export.py
@@ -194,7 +194,8 @@ class TestPyTorchExport(unittest.TestCase):
         self._test_full_beam_decoder(test_args, quantize=True)
 
     def test_full_beam_decoder_aan(self):
-        test_args = test_utils.ModelParamsDict(arch="transformer_aan")
+        test_args = test_utils.ModelParamsDict(arch="transformer")
+        test_args.aan = True
         lexical_dictionaries = test_utils.create_lexical_dictionaries()
         test_args.vocab_reduction_params = {
             "lexical_dictionaries": lexical_dictionaries,
@@ -204,7 +205,8 @@ class TestPyTorchExport(unittest.TestCase):
         self._test_full_beam_decoder(test_args, quantize=True)
 
     def test_full_beam_decoder_aan_bottlenceck(self):
-        test_args = test_utils.ModelParamsDict(arch="transformer_aan")
+        test_args = test_utils.ModelParamsDict(arch="transformer")
+        test_args.aan = True
         test_args.decoder_out_embed_dim = 5
         lexical_dictionaries = test_utils.create_lexical_dictionaries()
         test_args.vocab_reduction_params = {


### PR DESCRIPTION
Summary: Current situation is that these tests just fall back to the default RNN config, clearly not intended.

Differential Revision: D20125225

