### PR TITLE
Fix LevT training on master

### DIFF
--- a/pytorch_translate/tasks/translation_lev_task.py
+++ b/pytorch_translate/tasks/translation_lev_task.py
@@ -59,9 +59,11 @@ class PytorchTranslationLevenshteinTask(PytorchTranslateTask):
 
         return cls(args, source_dict, target_dict)
 
-    def train_step(self, sample, model, criterion, optimizer, ignore_grad=False):
+    def train_step(
+        self, sample, model, criterion, optimizer, update_num, ignore_grad=False
+    ):
         return self.trans_lev_task.train_step(
-            sample, model, criterion, optimizer, ignore_grad
+            sample, model, criterion, optimizer, update_num, ignore_grad
         )
 
     def valid_step(self, sample, model, criterion):


### PR DESCRIPTION
Summary:
update_num was added in a recent diff but change does not reflected in internal LevT task (in pytorch_translate).

TODO: Add integration test for NAT training using new testing framework following D20494349

Differential Revision: D20551660

