### PR TITLE
Make TransformerDecoupled model scriptable

### DIFF
--- a/pytorch_translate/attention/attention_utils.py
+++ b/pytorch_translate/attention/attention_utils.py
@@ -1,25 +1,32 @@
 #!/usr/bin/env python3
 
+from typing import Dict, Optional
+
 import numpy as np
 import torch
 import torch.nn.functional as F
+from torch import Tensor
 
 
-def create_src_lengths_mask(batch_size, src_lengths):
+def create_src_lengths_mask(
+    batch_size: int, src_lengths: Tensor, max_src_len: Optional[int] = None
+):
     """
     Generate boolean mask to prevent attention beyond the end of source
 
     Inputs:
       batch_size : int
       src_lengths : [batch_size] of sentence lengths
+      max_src_len: Optionally override max_src_len for the mask
 
     Outputs:
       [batch_size, max_src_len]
     """
-    max_srclen = src_lengths.max()
-    src_indices = torch.arange(0, max_srclen).unsqueeze(0).type_as(src_lengths)
-    src_indices = src_indices.expand(batch_size, max_srclen)
-    src_lengths = src_lengths.unsqueeze(dim=1).expand(batch_size, max_srclen)
+    if max_src_len is None:
+        max_src_len = int(src_lengths.max())
+    src_indices = torch.arange(0, max_src_len).unsqueeze(0).type_as(src_lengths)
+    src_indices = src_indices.expand(batch_size, max_src_len)
+    src_lengths = src_lengths.unsqueeze(dim=1).expand(batch_size, max_src_len)
     # returns [batch_size, max_seq_len]
     return (src_indices < src_lengths).int().detach()
 

--- a/pytorch_translate/ensemble_export.py
+++ b/pytorch_translate/ensemble_export.py
@@ -1834,6 +1834,8 @@ class IterativeRefinementGenerator(nn.Module):
                     encoder_out.encoder_embedding, ~terminated
                 ),
                 encoder_states=None,
+                src_tokens=None,
+                src_lengths=None,
             )
             sent_idxs = script_skip_tensor(sent_idxs, not_terminated)
 


### PR DESCRIPTION
Summary:
- Switches the model to the scripted sequence generator recently implemented in fairseq. Involved making the input/ouput format of this model to conform to that in Fairseq TransformerEncoder/Decoder
- Modify the `EncoderOut` format for fairseq transformer and added optional fields needed for copy ptr decoder
- Switches to using WordEmbedding directly instead of the non scriptable EmbeddingList for src/trg embedding layer
- Small assorted syntactic changes to make it jit scriptable
- Adds a torchscriptify method for this model. Will do latency analysis shortly
- Currently the Roberta decoupled model is not scriptable because the base TransformerSentenceEncoder it is based on is not scriptable. We can look at adding that later

Differential Revision: D20687247

