### PR TITLE
`build_generator` api changes for the scripted SequenceGenerator (#1922)

### DIFF
--- a/pytorch_translate/tasks/translation_lev_task.py
+++ b/pytorch_translate/tasks/translation_lev_task.py
@@ -38,8 +38,8 @@ class PytorchTranslationLevenshteinTask(PytorchTranslateTask):
     def inject_noise(self, target_tokens):
         return self.trans_lev_task.inject_noise(target_tokens)
 
-    def build_generator(self, args):
-        self.trans_lev_task.build_generator(args)
+    def build_generator(self, models, args):
+        self.trans_lev_task.build_generator(models, args)
 
     @classmethod
     def setup_task(cls, args, **kwargs):


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/fairseq/pull/1922

Pull Request resolved: https://github.com/fairinternal/fairseq-py/pull/1117

We are planning to deprecate the original SequenceGenerator and use the ScriptSequenceGenerator in the Fairseq. Due to the change of scripted Sequence Generator constructor, I change `build_generator` interface in Fairseq, pyspeech and pytorch translate.

Reviewed By: myleott

Differential Revision: D20683836

