### PR TITLE
Fix PPL reporting

### DIFF
--- a/pytorch_translate/train.py
+++ b/pytorch_translate/train.py
@@ -129,9 +129,9 @@ def update_output(
         progress_output: Tuple[int, Dict] = (
             num_updates,
             {
-                "train_ppl": utils.item(train_ppl),
+                "train_ppl": train_ppl,
                 "tune_loss": utils.item(extra_state["tune_eval"]["loss"]),
-                "tune_ppl": utils.item(extra_state["tune_eval"]["perplexity"]),
+                "tune_ppl": extra_state["tune_eval"]["perplexity"],
                 "wps": utils.item(wps),
                 # translation_samples isn't currently used by the queue reader,
                 # so just pass None for now until we start needing it.


### PR DESCRIPTION
Summary: These numbers are reported as primitives instead of tensor, so utils.item works incorrectly https://fburl.com/c12q92mf. It truncates the number and only reports the first character.

Differential Revision: D21121803

