### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/pytorch_translate/utils.py
+++ b/pytorch_translate/utils.py
@@ -196,7 +196,7 @@ def average_tensors(tensor_list, norm_fn=None, weights=None):
     stability, and iterates through `tensor_list` in a Python for-loop rather
     than stacking it to a PyTorch tensor.
 
-    Arguments:
+    Args:
         tensor_list (list): Python list of tensors of the same size and same type
         norm_fn (function): If set, apply norm_fn() to elements in `tensor_list`
             before averaging. If list of functions, apply n-th function to
@@ -232,7 +232,7 @@ def load_embedding(embedding, dictionary, pretrained_embed):
     can either be a nn.Embedding layer, in which case the embedding is set
     to the pretrained_embed argument, or a path to an embedding file.
 
-    Arguments:
+    Args:
         embedding (pytorch_translate.common_layers.Embedding):
             Embedding layer whose weights are to be set.
         dictionary (fairseq.data.dictionary.Dictionary): dictionary with the


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue when I was parsing/generating from the TensorFlow—and now PyTorch—codebases: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see pytorch/pytorch/pull/49736